### PR TITLE
Simpler association syntax

### DIFF
--- a/lib/factory_girl/definition_proxy.rb
+++ b/lib/factory_girl/definition_proxy.rb
@@ -79,6 +79,8 @@ module FactoryGirl
     def method_missing(name, *args, &block)
       if args.empty? && block.nil?
         @factory.define_attribute(Attribute::Implicit.new(name))
+      elsif args.first.is_a?(Hash) && args.first.has_key?(:factory)
+        association(name, *args)
       else
         add_attribute(name, *args, &block)
       end

--- a/spec/factory_girl/definition_proxy_spec.rb
+++ b/spec/factory_girl/definition_proxy_spec.rb
@@ -135,6 +135,18 @@ describe FactoryGirl::DefinitionProxy do
     factory.attributes.should include(attr)
   end
 
+  it "adds an association when passed an undefined method with a hash including :factory key" do
+    name = :author
+    factory_name = :user
+    overrides = { :first_name => 'Ben' }
+    args = { :factory => factory_name }.merge(overrides)
+    attr = 'attribute'
+    stub(attr).name { name }
+    mock(FactoryGirl::Attribute::Association).new(name, factory_name, overrides) { attr }
+    subject.send(name, args)
+    factory.attributes.should include(attr)
+  end
+
   it "delegates to_create" do
     result = 'expected'
     mock(factory).to_create { result }


### PR DESCRIPTION
Hey,

I've simplified syntax for defining associations, so it's no longer necessary to explicitly use #association method. One can now do:

```
factory :post do
  author :factory => :user, :first_name => "Ben"
end
```

I'm not 100% sure if the test is correct, but I tried to make it similar to the other ones :)
