### PR TITLE
Fix association id when stubbing

### DIFF
--- a/lib/factory_girl/proxy/stub.rb
+++ b/lib/factory_girl/proxy/stub.rb
@@ -11,6 +11,10 @@ module FactoryGirl
             id.nil?
           end
 
+          def persisted?
+            !new_record?
+          end
+
           def save(*args)
             raise "stubbed models are not allowed to access the database"
           end

--- a/spec/acceptance/stub_spec.rb
+++ b/spec/acceptance/stub_spec.rb
@@ -59,6 +59,10 @@ describe "a generated stub instance" do
     should_not be_new_record
   end
 
+  it "is persisted" do
+    should be_persisted
+  end
+
   it "disables connection" do
     lambda { subject.connection }.should raise_error(RuntimeError)
   end


### PR DESCRIPTION
Updating to AR 3.0.3 broke this. This includes a failing test and a (maybe not so clean) fix.
