### PR TITLE
Sequence with block

### DIFF
--- a/lib/factory_girl/sequence.rb
+++ b/lib/factory_girl/sequence.rb
@@ -14,7 +14,7 @@ module FactoryGirl
 
     # Returns the next value for this sequence
     def next
-      @proc.call(@value)
+      @proc ? @proc.call(@value) : @value
     ensure
       @value = @value.next
     end

--- a/spec/acceptance/sequence_spec.rb
+++ b/spec/acceptance/sequence_spec.rb
@@ -16,5 +16,17 @@ describe "sequences" do
     another_value.should =~ /^somebody\d+@example\.com$/
     first_value.should_not == another_value
   end
-end
+  
+  it "generates sequential numbers if no block is given" do
+    FactoryGirl.define do
+      sequence :order
+    end
 
+    first_value = Factory.next(:order)
+    another_value = Factory.next(:order)
+
+    first_value.should == 1
+    another_value.should == 2
+    first_value.should_not == another_value
+  end
+end

--- a/spec/factory_girl/sequence_spec.rb
+++ b/spec/factory_girl/sequence_spec.rb
@@ -40,4 +40,44 @@ describe FactoryGirl::Sequence do
       end
     end
   end
+
+  describe "a basic sequence without a block" do
+    before do
+      @sequence = FactoryGirl::Sequence.new
+    end
+    
+    it "should start with a value of 1" do
+      @sequence.next.should == 1
+    end
+    
+    describe "after being called" do
+      before do
+        @sequence.next
+      end
+
+      it "should use the next value" do
+        @sequence.next.should == 2
+      end
+    end
+  end
+
+  describe "a custom sequence without a block" do
+    before do
+      @sequence = FactoryGirl::Sequence.new("A")
+    end
+
+    it "should start with a value of A" do
+      @sequence.next.should == "A"
+    end
+
+    describe "after being called" do
+      before do
+        @sequence.next
+      end
+
+      it "should use the next value" do
+        @sequence.next.should == "B"
+      end
+    end
+  end
 end


### PR DESCRIPTION
When not passed a block, a sequence should just generate numbers.

I was trying to generate integers for an 'order' attribute on my model, and thought that by leaving out the block, factory_girl would just generate the number for me.

Here's a patch that would do that.

Nate
