### PR TITLE
Adds new machinst make & make! syntax

### DIFF
--- a/lib/factory_girl/syntax/make.rb
+++ b/lib/factory_girl/syntax/make.rb
@@ -6,16 +6,16 @@ module FactoryGirl
     #
     # Usage:
     #
-    #   require 'factory_girl/syntax/make'
+    # require 'factory_girl/syntax/make'
     #
-    #   FactoryGirl.define do
-    #     factory :user do
-    #       name 'Billy Bob'
-    #       email 'billy@bob.example.com'
-    #     end
-    #   end
+    # FactoryGirl.define do
+    # factory :user do
+    # name 'Billy Bob'
+    # email 'billy@bob.example.com'
+    # end
+    # end
     #
-    #   User.make(:name => 'Johnny')
+    # User.make(:name => 'Johnny')
     #
     # This syntax was derived from Pete Yandell's machinist.
     module Make
@@ -27,10 +27,28 @@ module FactoryGirl
 
         module ClassMethods #:nodoc:
 
-          def make(overrides = {})
-            FactoryGirl.find(name.underscore).run(Proxy::Create, overrides)
+          def make(key_or_overrides = nil, overrides = {})
+            key, overrides = make_options_from_args(key_or_overrides, overrides)
+            FactoryGirl.find(key).run(Proxy::Build, overrides)
           end
 
+          def make!(key_or_overrides = nil, overrides = {})
+            key, overrides = make_options_from_args(key_or_overrides, overrides)
+            FactoryGirl.find(key).run(Proxy::Create, overrides)
+          end
+
+          def make_options_from_args(key_or_overrides = nil, overrides = {})
+            if key_or_overrides.nil?
+              key = name.underscore
+            elsif key_or_overrides.is_a?(Symbol)
+              key = key_or_overrides
+            else
+              key = name.underscore
+              overrides = key_or_overrides
+            end
+
+            [key, overrides]
+          end
         end
 
       end

--- a/spec/acceptance/syntax/make_spec.rb
+++ b/spec/acceptance/syntax/make_spec.rb
@@ -12,12 +12,35 @@ describe "a factory using make syntax" do
         first_name 'Bill'
         last_name  'Nye'
       end
+
+      factory :hail_to_the_king_baby, :parent => :user do
+        first_name 'Duke'
+        last_name  'Nukem'
+      end
     end
   end
 
-  describe "after making an instance" do
+  describe "after make" do
     before do
       @instance = User.make(:last_name => 'Rye')
+    end
+
+    it "should use attributes from the factory" do
+      @instance.first_name.should == 'Bill'
+    end
+
+    it "should use attributes passed to make" do
+      @instance.last_name.should == 'Rye'
+    end
+
+    it "should save the record" do
+      @instance.should be_new_record
+    end
+  end
+
+  describe "after make!" do
+    before do
+      @instance = User.make!(:last_name => 'Rye')
     end
 
     it "should use attributes from the factory" do
@@ -32,4 +55,25 @@ describe "a factory using make syntax" do
       @instance.should_not be_new_record
     end
   end
+
+
+  describe "after make with factory key" do
+    before do
+      @instance = User.make(:hail_to_the_king_baby, :last_name => 'Rye')
+    end
+
+    it "should use attributes from the factory" do
+      @instance.first_name.should == 'Duke'
+    end
+
+    it "should use attributes passed to make" do
+      @instance.last_name.should == 'Rye'
+    end
+
+    it "should save the record" do
+      @instance.should be_new_record
+    end
+  end
+
+
 end


### PR DESCRIPTION
Adds new machinst make & make! syntax, not backwards compatible (make creates unsaved instances now)

https://github.com/thoughtbot/factory_girl/issues#issue/133
## Unsaved instances:

`User.make(:first_name => 'Bob')`

`User.make(:user_with_address, :first_name => 'Bob')`
## Saved instances:

`User.make!(:first_name => 'Bob')`

`User.make!(:user_with_address, :first_name => 'Bob')`
- SHA: 931e2cd22e617139e424396d3df0f607448268c4

Machanist 2: https://github.com/notahat/machinist/wiki/machinist-2
