### PR TITLE
Adds transient variables to allow arbitrary factory parameters

### DIFF
--- a/lib/factory_girl/attribute.rb
+++ b/lib/factory_girl/attribute.rb
@@ -28,6 +28,15 @@ module FactoryGirl
     def association?
       false
     end
+
+    def ignore
+      @ignored = true
+      self
+    end
+    
+    def ignored?
+      @ignored
+    end
   end
 
 end

--- a/lib/factory_girl/proxy/attributes_for.rb
+++ b/lib/factory_girl/proxy/attributes_for.rb
@@ -5,11 +5,11 @@ module FactoryGirl
         @hash = {}
       end
 
-      def get(attribute)
+      def get_attr(attribute)
         @hash[attribute]
       end
 
-      def set(attribute, value)
+      def set_attr(attribute, value)
         @hash[attribute] = value
       end
 

--- a/lib/factory_girl/proxy/build.rb
+++ b/lib/factory_girl/proxy/build.rb
@@ -5,11 +5,11 @@ module FactoryGirl
         @instance = klass.new
       end
 
-      def get(attribute)
+      def get_attr(attribute)
         @instance.send(attribute)
       end
 
-      def set(attribute, value)
+      def set_attr(attribute, value)
         @instance.send(:"#{attribute}=", value)
       end
 

--- a/spec/acceptance/attributes_for_spec.rb
+++ b/spec/acceptance/attributes_for_spec.rb
@@ -23,11 +23,12 @@ describe "a generated attributes hash" do
         body { "default body" }
         summary { title }
         user
+        uploaded_image(nil).ignore
       end
     end
   end
 
-  subject { attributes_for(:post, :title => 'overridden title') }
+  subject { attributes_for(:post, :title => 'overridden title', :uploaded_image => "foo") }
 
   it "assigns an overridden value" do
     subject[:title].should == "overridden title"
@@ -43,6 +44,10 @@ describe "a generated attributes hash" do
 
   it "doesn't assign associations" do
     subject[:user_id].should be_nil
+  end
+
+  it "doesn't assign ignored attributes" do
+    subject[:uploaded_image].should be_nil
   end
 end
 

--- a/spec/acceptance/callbacks_spec.rb
+++ b/spec/acceptance/callbacks_spec.rb
@@ -15,6 +15,11 @@ describe "callbacks" do
       factory :user_with_inherited_callbacks, :parent => :user_with_callbacks do
         after_stub { |user| user.last_name = 'Double-Stubby' }
       end
+
+      factory :user_with_proxied_callbacks, :parent => :user_with_callbacks do |u|
+        u.proxified?(false).ignore
+        after_create { |user, proxy| user.last_name << ', Proxified' if proxy.proxified? }
+      end
     end
   end
 
@@ -38,5 +43,11 @@ describe "callbacks" do
     user = FactoryGirl.build_stubbed(:user_with_inherited_callbacks)
     user.first_name.should == 'Stubby'
     user.last_name.should == 'Double-Stubby'
+  end
+
+  it "provides the proxy to callbacks that want it" do
+    user = FactoryGirl.create(:user_with_proxied_callbacks, :proxified? => true)
+    user.first_name.should == 'Buildy'
+    user.last_name.should == 'Createy, Proxified'
   end
 end

--- a/spec/factory_girl/attribute_spec.rb
+++ b/spec/factory_girl/attribute_spec.rb
@@ -31,4 +31,9 @@ describe FactoryGirl::Attribute do
   it "should convert names to symbols" do
     FactoryGirl::Attribute.new('name').name.should == :name
   end
+
+  it "should be ignorable" do
+    @attr.ignore
+    @attr.should be_ignored
+  end
 end

--- a/spec/factory_girl/factory_spec.rb
+++ b/spec/factory_girl/factory_spec.rb
@@ -49,9 +49,11 @@ describe FactoryGirl::Factory do
       @proxy     = "proxy"
 
       stub(@attribute).name { :name }
+      stub(@attribute).ignored? { false }
       stub(@attribute).add_to
       stub(@proxy).set
       stub(@proxy).result { 'result' }
+      stub(@proxy).ignored_attributes = anything
       stub(FactoryGirl::Attribute::Static).new { @attribute }
       stub(FactoryGirl::Proxy::Build).new { @proxy }
 
@@ -68,6 +70,12 @@ describe FactoryGirl::Factory do
       @factory.run(FactoryGirl::Proxy::Build, {})
     end
 
+    it "should add the ignored attributes to the proxy by name when running" do
+      stub(@attribute).ignored? { true }
+      mock(@proxy).ignored_attributes = { :name => nil }
+      @factory.run(FactoryGirl::Proxy::Build, {})
+    end
+
     it "should return the result from the proxy when running" do
       mock(@proxy).result(nil) { 'result' }
       @factory.run(FactoryGirl::Proxy::Build, {}).should == 'result'
@@ -78,6 +86,7 @@ describe FactoryGirl::Factory do
     proxy = 'proxy'
     stub(FactoryGirl::Proxy::Build).new { proxy }
     stub(proxy).result {}
+    stub(proxy).ignored_attributes = anything
     block = lambda {}
     factory = FactoryGirl::Factory.new(:object)
     factory.to_create(&block)


### PR DESCRIPTION
Pull request originally made from https://github.com/thoughtbot/factory_girl/issues/103 and now with a few of my own changes.

Allows factory attributes to be marked as "ignored", meaning that they won't be passed on to the constructed instance but can be used to control other aspects of its creation.

Ignored attributes can still have defaults, are inherited as normal, and are accessible in lazy attribute blocks. They are also accessible in the after_\* callbacks, through a second argument to the block (i.e. the proxy object).

Please let me know if there is anything I can do to make the pull easier.
