### PR TITLE
convert method name to string when determining when to undef unproxied methods

### DIFF
--- a/lib/factory_girl/definition_proxy.rb
+++ b/lib/factory_girl/definition_proxy.rb
@@ -3,7 +3,7 @@ module FactoryGirl
     UNPROXIED_METHODS = %w(__send__ __id__ nil? send object_id extend instance_eval initialize block_given? raise)
 
     (instance_methods + private_instance_methods).each do |method|
-      undef_method(method) unless UNPROXIED_METHODS.include?(method)
+      undef_method(method) unless UNPROXIED_METHODS.include?(method.to_s)
     end
 
     attr_reader :child_factories


### PR DESCRIPTION
Ruby 1.9 returns an array of symbols for instance_methods, private_instance_methods, etc. This pull request converts to a string before checking if it's in the array.
