### PR TITLE
Factory overrides are applied before other attributes. Fixes #140.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "rake"
 gem "rspec", "~> 2.0"
 gem "rcov"
 gem "activerecord", :require => false
+gem "activesupport", :require => false
 gem "rr"
 gem "sqlite3-ruby", :require => false
 gem "appraisal", "~> 0.3.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord
+  activesupport
   appraisal (~> 0.3.5)
   bluecloth
   cucumber (~> 1.0.0)

--- a/lib/factory_girl/attribute.rb
+++ b/lib/factory_girl/attribute.rb
@@ -34,6 +34,10 @@ module FactoryGirl
       1
     end
 
+    def aliases_for?(attr)
+      FactoryGirl.aliases_for(attr).include?(name)
+    end
+
     def <=>(another)
       return nil unless another.is_a? Attribute
       self.priority <=> another.priority

--- a/lib/factory_girl/factory.rb
+++ b/lib/factory_girl/factory.rb
@@ -76,13 +76,15 @@ module FactoryGirl
     def run(proxy_class, overrides) #:nodoc:
       proxy = proxy_class.new(build_class)
       overrides = symbolize_keys(overrides)
-      overrides.each {|attr, val| proxy.set(attr, val) }
-      passed_keys = overrides.keys.collect {|k| FactoryGirl.aliases_for(k) }.flatten
       @attributes.each do |attribute|
-        unless passed_keys.include?(attribute.name)
+        factory_overrides = overrides.select { |attr, val| attribute.aliases_for?(attr) }
+        if factory_overrides.empty?
           attribute.add_to(proxy)
+        else
+          factory_overrides.each { |attr, val| proxy.set(attr, val) }
         end
       end
+      overrides.each { |attr, val| proxy.set(attr, val) }
       proxy.result(@to_create_block)
     end
 

--- a/spec/acceptance/overrides_spec.rb
+++ b/spec/acceptance/overrides_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'acceptance/acceptance_helper'
+require 'active_support/ordered_hash'
+
+describe "attribute overrides" do
+  include FactoryGirl::Syntax::Methods
+
+  before do
+    define_model('User', :admin    => :boolean)
+    define_model('Post', :title    => :string,
+                         :body     => :string,
+                         :secure   => :boolean,
+                         :user_id  => :integer) do
+      belongs_to :user
+      def secure=(value)
+        return unless value && user && user.admin?
+        self[:secure] = value
+      end
+    end
+
+    FactoryGirl.define do
+      factory :user
+      factory :post do
+        user
+        title { "default title" }
+        body  { "default body" }
+      end
+      factory :admin_post, :parent => :post
+    end
+
+    @admin = FactoryGirl.create :user, :admin => true
+  end
+
+  it "assign an overrides before others" do
+    secure_post = FactoryGirl.create :post, ActiveSupport::OrderedHash[:secure, true, :user, @admin]
+    secure_post.secure.should == true
+  end
+
+
+end


### PR DESCRIPTION
This should address issue #140 and allow factory overrides to be applied before other misc attributes. This way the base valid object per the factory spec is built first before any other attributes are applied.

In the acceptance/overrides_spec.rb, I have created a contrived test that uses ActiveSupport's OrderedHash so the test will fail on both 1.8 and upward. This patch ensures that users of FactoryGirl do not have to think back to how their factory attributes are defined and leverage an ordered hash when building objects. They can always count on the factory attributes/overrides being applied first to build a minimally valid object.
