### PR TITLE
Fix the travis-ci build status image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# factory_girl [![Build Status](http://travis-ci.org/thoughtbot/factory_girl.png)](http://travis-ci.org/thoughtbot/factory_girl)
+# factory_girl [![Build Status](https://secure.travis-ci.org/thoughtbot/factory_girl.png)](http://travis-ci.org/thoughtbot/factory_girl)
 
 factory_girl is a fixtures replacement with a straightforward definition syntax, support for multiple build strategies (saved instances, unsaved instances, attribute hashes, and stubbed objects), and support for multiple factories for the same class (user, admin_user, and so on), including factory inheritance.
 


### PR DESCRIPTION
Fix the travis-ci build status image to use https, which prevents Github from caching the failed status image.

Stops making people think your build has failed :)
