### PR TITLE
Ensure static attributes are consistently prioritized

### DIFF
--- a/lib/factory_girl/attribute_list.rb
+++ b/lib/factory_girl/attribute_list.rb
@@ -47,9 +47,13 @@ module FactoryGirl
       end
 
       @attributes.unshift *new_attributes
-      @attributes = @attributes.partition {|attr| attr.priority.zero? }.flatten
+      prioritize_static_attributes
     end
 
+    def prioritize_static_attributes
+      @attributes = @attributes.partition {|attr| attr.priority.zero? }.flatten
+    end
+    
     private
 
     def valid_callback_names

--- a/lib/factory_girl/factory.rb
+++ b/lib/factory_girl/factory.rb
@@ -77,6 +77,10 @@ module FactoryGirl
     def attributes
       @attribute_list.to_a
     end
+    
+    def sort_attributes
+      @attribute_list.prioritize_static_attributes
+    end
 
     def run(proxy_class, overrides) #:nodoc:
       proxy = proxy_class.new(build_class)

--- a/lib/factory_girl/syntax/default.rb
+++ b/lib/factory_girl/syntax/default.rb
@@ -24,6 +24,9 @@ module FactoryGirl
           if parent = options.delete(:parent)
             factory.inherit_from(FactoryGirl.factory_by_name(parent))
           end
+          
+          factory.sort_attributes
+          
           FactoryGirl.register_factory(factory)
 
           proxy.child_factories.each do |(child_name, child_options, child_block)|

--- a/spec/acceptance/attributes_ordered_spec.rb
+++ b/spec/acceptance/attributes_ordered_spec.rb
@@ -20,14 +20,34 @@ describe "a generated attributes hash where order matters" do
           static 1
         end
       end
+      
+      factory :without_parent, :class=>ParentModel do
+        evaluates_first   { static }
+        evaluates_second  { evaluates_first }
+        evaluates_third   { evaluates_second }
+        static 1
+      end
     end
   end
 
-  subject { FactoryGirl.build(:child_model) }
+  context "factory with a parent" do
+    subject { FactoryGirl.build(:child_model) }
 
-  it "assigns attributes in the order they're defined with preference to static attributes" do
-    subject[:evaluates_first].should  == 1
-    subject[:evaluates_second].should == 1
-    subject[:evaluates_third].should  == 1
+    it "assigns attributes in the order they're defined with preference to static attributes" do
+      subject[:evaluates_first].should  == 1
+      subject[:evaluates_second].should == 1
+      subject[:evaluates_third].should  == 1
+    end
   end
+
+  context "factory without a parent" do
+    subject { FactoryGirl.build(:without_parent) }
+
+    it "assigns attributes in the order they're defined with preference to static attributes without a parent class" do
+      subject[:evaluates_first].should  == 1
+      subject[:evaluates_second].should == 1
+      subject[:evaluates_third].should  == 1
+    end
+  end
+  
 end


### PR DESCRIPTION
This change makes sure static attributes are prioritized for factories that have no parent, and no traits
