### PR TITLE
Prevents RSpec from throwing a deprecation warning when mixing in syntax

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -83,7 +83,7 @@ If repeating "FactoryGirl" is too verbose for you, you can mix the syntax method
     # rspec
     RSpec.configure do |config|
       config.include Factory::Syntax::Methods
-    end
+    end unless RSpec.world.example_groups.any?
 
     # Test::Unit
     class Test::Unit::TestCase


### PR DESCRIPTION
Calling RSpec.configure after an example group has been defined throws a deprecation warning. Since it's difficult to predict file load order, it's easier to test for example group definitions and ignore if any exist.
