### PR TITLE
Use #first in step definitions

### DIFF
--- a/lib/factory_girl/step_definitions.rb
+++ b/lib/factory_girl/step_definitions.rb
@@ -39,7 +39,7 @@ module FactoryGirlStepHelpers
         return unless association
 
         if attributes_hash = nested_attribute_hash
-          factory.build_class.find(:first, :conditions => attributes_hash.attributes(FindAttributes)) or
+          factory.build_class.first(:conditions => attributes_hash.attributes(FindAttributes)) or
           FactoryGirl.create(association.factory, attributes_hash.attributes)
         end
       end


### PR DESCRIPTION
# find(:first) will be deprecated in Rails 3.1.  #first works on Rails 2
