### PR TITLE
Fixes documentation for association on create.

### DIFF
--- a/lib/factory_girl/proxy.rb
+++ b/lib/factory_girl/proxy.rb
@@ -59,7 +59,7 @@ module FactoryGirl
     #   FactoryGirl.build(:post)
     #
     #   # Builds and saves a User, builds a Post, assigns the User to the
-    #   # author association, and saves the User.
+    #   # author association, and saves the Post.
     #   FactoryGirl.create(:post)
     #
     def association(name, overrides = {})


### PR DESCRIPTION
This:

```
#   # Builds and saves a User, builds a Post, assigns the User to the
#   # author association, and saves the User.
#   FactoryGirl.create(:post)
```

Should read:

```
#   # Builds and saves a User, builds a Post, assigns the User to the
#   # author association, and saves the Post.
#   FactoryGirl.create(:post)
```

Since the second save is occurring on the object that the association was assigned to.
