### PR TITLE
Load factories from /factories at the Rails root, just like the default definition_file_paths.

### DIFF
--- a/lib/factory_girl/rails2.rb
+++ b/lib/factory_girl/rails2.rb
@@ -1,5 +1,6 @@
 Rails.configuration.after_initialize do
   FactoryGirl.definition_file_paths = [
+    File.join(Rails.root, 'factories'),
     File.join(Rails.root, 'test', 'factories'),
     File.join(Rails.root, 'spec', 'factories')
   ]


### PR DESCRIPTION
Load factories from /factories at the Rails root, just like the default definition_file_paths.
