### PR TITLE
Make sure parent callbacks are run before child

### DIFF
--- a/lib/factory_girl/attribute_list.rb
+++ b/lib/factory_girl/attribute_list.rb
@@ -17,7 +17,11 @@ module FactoryGirl
 
       add_attribute attribute
     end
-
+    
+    def prepend_callback(callback)
+      @callbacks.unshift(callback)
+    end
+    
     def add_callback(callback)
       @callbacks << callback
     end
@@ -31,7 +35,7 @@ module FactoryGirl
     end
 
     def apply_attributes(attributes_to_apply)
-      attributes_to_apply.callbacks.each { |callback| add_callback(callback) }
+      attributes_to_apply.callbacks.reverse_each { |callback| prepend_callback(callback) }
       new_attributes = []
 
       attributes_to_apply.each do |attribute|

--- a/spec/acceptance/callbacks_spec.rb
+++ b/spec/acceptance/callbacks_spec.rb
@@ -13,6 +13,7 @@ describe "callbacks" do
 
       factory :user_with_inherited_callbacks, :parent => :user_with_callbacks do
         after_stub { |user| user.last_name = 'Double-Stubby' }
+        after_build {|user| user.first_name = 'Child-Buildy' }
       end
     end
   end
@@ -37,5 +38,10 @@ describe "callbacks" do
     user = FactoryGirl.build_stubbed(:user_with_inherited_callbacks)
     user.first_name.should == 'Stubby'
     user.last_name.should == 'Double-Stubby'
+  end
+  
+  it "runs child callback after parent callback" do
+    user = FactoryGirl.build(:user_with_inherited_callbacks)
+    user.first_name.should == 'Child-Buildy'
   end
 end


### PR DESCRIPTION
Parent callbacks used to be run before child callbacks as I would expect.  The recent changes to callbacks however changed this behavior.  This patch restores the previous behavior
