### PR TITLE
use create_list in step definitions

### DIFF
--- a/lib/factory_girl/step_definitions.rb
+++ b/lib/factory_girl/step_definitions.rb
@@ -109,7 +109,7 @@ FactoryGirl.factories.each do |factory|
     end
 
     Given /^(\d+) #{human_name.pluralize} exist$/i do |count|
-      count.to_i.times { FactoryGirl.create(factory.name) }
+      FactoryGirl.create_list(factory.name, count.to_i)
     end
 
     if factory.build_class.respond_to?(:columns)
@@ -120,7 +120,7 @@ FactoryGirl.factories.each do |factory|
         end
 
         Given /^(\d+) #{human_name.pluralize} exist with an? #{human_column_name} of "([^"]*)"$/i do |count, value|
-          count.to_i.times { FactoryGirl.create(factory.name, column.name => value) }
+          FactoryGirl.create_list(factory.name, count.to_i, column.name => value)
         end
       end
     end


### PR DESCRIPTION
It's time to use awesome `create_list` instead of `count.to_i.times` in step definitions. 
