### PR TITLE
Use correct parameters in specs for FactoryGirl::Attribute::Dynamic class

### DIFF
--- a/spec/factory_girl/attribute/dynamic_spec.rb
+++ b/spec/factory_girl/attribute/dynamic_spec.rb
@@ -51,6 +51,6 @@ describe FactoryGirl::Attribute::Dynamic do
 end
 
 describe FactoryGirl::Attribute::Dynamic, "with a string name" do
-  subject    { FactoryGirl::Attribute::Dynamic.new("name", nil, false) }
+  subject    { FactoryGirl::Attribute::Dynamic.new("name", false, lambda { } ) }
   its(:name) { should == :name }
 end

--- a/spec/factory_girl/factory_spec.rb
+++ b/spec/factory_girl/factory_spec.rb
@@ -71,9 +71,9 @@ describe FactoryGirl::Factory do
     end
 
     it "does not call a lazy attribute block for an overridden attribute" do
-      declaration = FactoryGirl::Declaration::Dynamic.new(@name, lambda { flunk })
+      declaration = FactoryGirl::Declaration::Dynamic.new(@name, false, lambda { flunk })
       @factory.declare_attribute(declaration)
-      result = @factory.run(FactoryGirl::Proxy::AttributesFor, @hash)
+      @factory.run(FactoryGirl::Proxy::AttributesFor, @hash)
     end
 
     it "overrides a symbol parameter with a string parameter" do


### PR DESCRIPTION
Hi,

I think I've found a incorrect pass of parameter to the FactoryGirl::Attribute::Dynamic class, maybe these pull request solve it.

Other thing is the use of flunk it's not defined in ruby 1.9.3 maybe you could replace with other option I don't find any but maybe someone do
