### PR TITLE
Use correct module in docs.

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -87,7 +87,7 @@ If repeating "FactoryGirl" is too verbose for you, you can mix the syntax method
 
     # rspec
     RSpec.configure do |config|
-      config.include Factory::Syntax::Methods
+      config.include FactoryGirl::Syntax::Methods
     end
 
     # Test::Unit


### PR DESCRIPTION
It works as-is (I assume due to the `const_get` override in `deprecated.rb`), but this seems to be the better way.
