### PR TITLE
Supplying a Class to a factory that overrides to_s no longer results in ...

### DIFF
--- a/lib/factory_girl/factory.rb
+++ b/lib/factory_girl/factory.rb
@@ -26,7 +26,11 @@ module FactoryGirl
     end
 
     def build_class #:nodoc:
-      class_name.to_s.camelize.constantize
+      if class_name.is_a? Class
+        class_name
+      else
+        class_name.to_s.camelize.constantize
+      end
     end
 
     def default_strategy #:nodoc:

--- a/spec/factory_girl/factory_spec.rb
+++ b/spec/factory_girl/factory_spec.rb
@@ -116,6 +116,25 @@ describe FactoryGirl::Factory, "when defined with a custom class" do
   its(:build_class) { should == Float }
 end
 
+describe FactoryGirl::Factory, "when given a class that overrides #to_s" do
+  let(:overriding_class) { Overriding::Class }
+
+  before do
+    define_class("Overriding")
+    define_class("Overriding::Class") do
+      def self.to_s
+        "Overriding"
+      end
+    end
+  end
+
+  subject { FactoryGirl::Factory.new(:overriding_class, :class => Overriding::Class) }
+
+  it "sets build_class correctly" do
+    subject.build_class.should == overriding_class
+  end
+end
+
 describe FactoryGirl::Factory, "when defined with a class instead of a name" do
   let(:factory_class) { ArgumentError }
   let(:name)          { :argument_error }


### PR DESCRIPTION
...getting the wrong Class constructed

This patch allows factories to be constructed like this:

FactoryGirl::Factory.new(:name, :class => SomeConst)

even when SomeConst.to_s returns something other than "SomeConst"

Patch includes test.
