### PR TITLE
Ensure the proper result is returned when block is passed

### DIFF
--- a/lib/factory_girl/factory.rb
+++ b/lib/factory_girl/factory.rb
@@ -45,7 +45,7 @@ module FactoryGirl
         :overrides   => overrides.dup
       }
 
-      block[Runner.new(runner_options).run]
+      Runner.new(runner_options).run.tap(&block)
     end
 
     def human_names

--- a/spec/acceptance/attributes_for_spec.rb
+++ b/spec/acceptance/attributes_for_spec.rb
@@ -60,6 +60,14 @@ describe "calling `attributes_for` with a block" do
       attributes[:name].should eq('thoughtbot')
     end
   end
+
+  it "returns the hash of attributes" do
+    expected = nil
+    attributes_for(:company) do |attributes|
+      expected = attributes
+      "hello!"
+    end.should == expected
+  end
 end
 
 describe "`attributes_for` for a class whose constructor has required params" do

--- a/spec/acceptance/build_spec.rb
+++ b/spec/acceptance/build_spec.rb
@@ -78,4 +78,12 @@ describe "calling `build` with a block" do
       company.name.should eq('thoughtbot')
     end
   end
+
+  it "returns the built instance" do
+    expected = nil
+    build(:company) do |company|
+      expected = company
+      "hello!"
+    end.should == expected
+  end
 end

--- a/spec/acceptance/build_stubbed_spec.rb
+++ b/spec/acceptance/build_stubbed_spec.rb
@@ -92,4 +92,12 @@ describe "calling `build_stubbed` with a block" do
       expect { company.save }.to raise_error(RuntimeError)
     end
   end
+
+  it "returns the stub instance" do
+    expected = nil
+    build_stubbed(:company) do |company|
+      expected = company
+      "hello!"
+    end.should == expected
+  end
 end

--- a/spec/acceptance/create_spec.rb
+++ b/spec/acceptance/create_spec.rb
@@ -106,4 +106,12 @@ describe "calling `create` with a block" do
       company.name.should eq('thoughtbot')
     end
   end
+
+  it "returns the created instance" do
+    expected = nil
+    create(:company) do |company|
+      expected = company
+      "hello!"
+    end.should == expected
+  end
 end


### PR DESCRIPTION
According to this [blog post](http://robots.thoughtbot.com/post/11437609921/factory-girl-2-2-your-new-best-friend), the following example 

``` ruby
let(:old_published_post) do
  create(:post, created_at: 2.years.ago) do |post|
    post.publish!
  end
end
```

should be equivalent to

```
let(:old_published_post) do
  create(:post, created_at: 2.years.ago).tap do |post|
    post.publish!
  end
end
```

Unfortunately, the current version doesn't care about the returned value.

In the following example, `FactoryGirl.create(:order)` returns 0 because the last expression evaluates to 0.
`:order` is set to 0 causing an unexpected behavior (or at least the behavior is different compared to `#tap` that always returns `self`).

``` ruby
let(:order) {
  FactoryGirl.create(:order) do |order|
    order.save!
    order.total_cents = 0
  end
}

order
# => 0
```

This patch fixes the issue. It uses `#tap` internally, thus it's not compatible with Ruby < 1.8.7.
I'm not aware of current FactoryGirl minimum Ruby requirements. If you need to ensure compatibility with 1.8.6 let me know, I'll update the patch.
