### PR TITLE
Update rubygems on travis-ci.org before running dependency installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
+before_install:
+  - gem update --system
 script: "bundle exec rake spec:unit spec:acceptance features"
 gemfile:
   - gemfiles/2.1.gemfile


### PR DESCRIPTION
REE will fail to install Rails 3.2 gems w/o rubygems update.
