### PR TITLE
allow passing traits to vintage Factory syntax

### DIFF
--- a/lib/factory_girl/syntax/methods.rb
+++ b/lib/factory_girl/syntax/methods.rb
@@ -18,6 +18,7 @@ module FactoryGirl
       # A set of attributes that can be used to build an instance of the class
       # this factory generates.
       def attributes_for(name, *traits_and_overrides, &block)
+        traits_and_overrides.flatten!
         FactoryRunner.new(name, Strategy::AttributesFor, traits_and_overrides).run(&block)
       end
 
@@ -37,6 +38,7 @@ module FactoryGirl
       # An instance of the class this factory generates, with generated attributes
       # assigned.
       def build(name, *traits_and_overrides, &block)
+        traits_and_overrides.flatten!
         FactoryRunner.new(name, Strategy::Build, traits_and_overrides).run(&block)
       end
 
@@ -60,6 +62,7 @@ module FactoryGirl
       # A saved instance of the class this factory generates, with generated
       # attributes assigned.
       def create(name, *traits_and_overrides, &block)
+        traits_and_overrides.flatten!
         FactoryRunner.new(name, Strategy::Create, traits_and_overrides).run(&block)
       end
 
@@ -79,6 +82,7 @@ module FactoryGirl
       # Returns: +Object+
       # An object with generated attributes stubbed out.
       def build_stubbed(name, *traits_and_overrides, &block)
+        traits_and_overrides.flatten!
         FactoryRunner.new(name, Strategy::Stub, traits_and_overrides).run(&block)
       end
 
@@ -98,6 +102,7 @@ module FactoryGirl
       # An array of instances of the class this factory generates, with generated attributes
       # assigned.
       def build_list(name, amount, *traits_and_overrides)
+        traits_and_overrides.flatten!
         amount.times.map { build(name, *traits_and_overrides) }
       end
 
@@ -117,6 +122,7 @@ module FactoryGirl
       # An array of instances of the class this factory generates, with generated attributes
       # assigned.
       def create_list(name, amount, *traits_and_overrides)
+        traits_and_overrides.flatten!
         amount.times.map { create(name, *traits_and_overrides) }
       end
 

--- a/lib/factory_girl/syntax/vintage.rb
+++ b/lib/factory_girl/syntax/vintage.rb
@@ -46,8 +46,9 @@ module FactoryGirl
         #
         # Returns: +Object+
         # The result of the default strategy.
-        def self.default_strategy(name, overrides = {})
-          FactoryGirl.send(FactoryGirl.factory_by_name(name).default_strategy, name, overrides)
+        def self.default_strategy(name, *traits_and_overrides)
+          traits_and_overrides.flatten!
+          FactoryGirl.send(FactoryGirl.factory_by_name(name).default_strategy, name, traits_and_overrides)
         end
 
         # Defines a new sequence that can be used to generate unique values in a specific format.
@@ -110,23 +111,23 @@ module FactoryGirl
         end
 
         # Alias for FactoryGirl.attributes_for
-        def self.attributes_for(name, overrides = {})
-          FactoryGirl.attributes_for(name, overrides)
+        def self.attributes_for(name, *traits_and_overrides)
+          FactoryGirl.attributes_for(name, traits_and_overrides.flatten)
         end
 
         # Alias for FactoryGirl.build
-        def self.build(name, overrides = {})
-          FactoryGirl.build(name, overrides)
+        def self.build(name, *traits_and_overrides)
+          FactoryGirl.build(name, traits_and_overrides.flatten)
         end
 
         # Alias for FactoryGirl.create
-        def self.create(name, overrides = {})
-          FactoryGirl.create(name, overrides)
+        def self.create(name, *traits_and_overrides)
+          FactoryGirl.create(name, traits_and_overrides.flatten)
         end
 
         # Alias for FactoryGirl.build_stubbed.
-        def self.stub(name, overrides = {})
-          FactoryGirl.build_stubbed(name, overrides)
+        def self.stub(name, *traits_and_overrides)
+          FactoryGirl.build_stubbed(name, traits_and_overrides.flatten)
         end
       end
 
@@ -139,8 +140,8 @@ module FactoryGirl
       #
       # Example:
       #   Factory(:user, :name => 'Joe')
-      def Factory(name, attrs = {})
-        Factory.default_strategy(name, attrs)
+      def Factory(name, *traits_and_overrides)
+        Factory.default_strategy(name, traits_and_overrides)
       end
     end
   end


### PR DESCRIPTION
this pull request allows users to do something like 

```
Factory(:factory_name, :trait1, :attr_name => :attr_val)
```

in the same way they would be able to write 

```
FactoryGirl.create(:factory_name, :trait1, :attr_name => :attr_val)
```

It adds this functionality to all of the relevant class-level `Factory` methods: `default_strategy`, `attributes_for`, `build`, `create`, and `stub`.

I'm happy to add specs for this, but I couldn't find any specs for the existing functionality for the vintage syntax, so I wasn't sure where to put additional specs. If someone points out to me where the relevant acceptance tests are, I can add to them.
