### PR TITLE
Added a before_create callback

### DIFF
--- a/lib/factory_girl.rb
+++ b/lib/factory_girl.rb
@@ -69,6 +69,6 @@ module FactoryGirl
   end
 
   def self.callback_names
-    [:after_build, :after_create, :after_stub].freeze
+    [:after_build, :before_create, :after_create, :after_stub].freeze
   end
 end

--- a/lib/factory_girl/strategy/create.rb
+++ b/lib/factory_girl/strategy/create.rb
@@ -8,6 +8,7 @@ module FactoryGirl
       def result(attribute_assigner, to_create)
         attribute_assigner.object.tap do |result_instance|
           run_callbacks(:after_build, result_instance)
+          run_callbacks(:before_create, result_instance)
           to_create[result_instance]
           run_callbacks(:after_create, result_instance)
         end

--- a/spec/acceptance/callbacks_spec.rb
+++ b/spec/acceptance/callbacks_spec.rb
@@ -2,13 +2,20 @@ require 'spec_helper'
 
 describe "callbacks" do
   before do
-    define_model("User", :first_name => :string, :last_name => :string)
+    define_model("User", :first_name => :string, :middle_name => :string, :last_name => :string)
 
     FactoryGirl.define do
       factory :user_with_callbacks, :class => :user do
-        after_stub   { |user| user.first_name = 'Stubby' }
-        after_build  { |user| user.first_name = 'Buildy' }
-        after_create { |user| user.last_name  = 'Createy' }
+        after_stub    { |user|
+                        user.first_name = 'Stubby'
+                        user.middle_name = 'Stubby'
+                      }
+        after_build   { |user|
+                        user.first_name = 'Buildy'
+                        user.middle_name = 'Buildy'
+                      }
+        before_create { |user| user.middle_name = 'Createy' }
+        after_create  { |user| user.last_name  = 'Createy' }
       end
 
       factory :user_with_inherited_callbacks, :parent => :user_with_callbacks do
@@ -28,9 +35,10 @@ describe "callbacks" do
     user.first_name.should == 'Buildy'
   end
 
-  it "runs both the after_build and after_create callbacks when creating" do
+  it "runs both the after_build, before_create and after_create callbacks when creating" do
     user = FactoryGirl.create(:user_with_callbacks)
     user.first_name.should == 'Buildy'
+    user.middle_name.should == 'Createy'
     user.last_name.should == 'Createy'
   end
 

--- a/spec/factory_girl/strategy/create_spec.rb
+++ b/spec/factory_girl/strategy/create_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe FactoryGirl::Strategy::Create do
   it_should_behave_like "strategy with association support", FactoryGirl::Strategy::Create
-  it_should_behave_like "strategy with callbacks", :after_build, :after_create
+  it_should_behave_like "strategy with callbacks", :after_build, :before_create, :after_create
 
   it "runs a custom create block" do
     block_run = false


### PR DESCRIPTION
I'm working on a project where I need models built with Factory.create to have a property set differently than Factory.build (and needed it saved as well), and since after_build gets called before after_create the only way I could change the property back was by calling after_create with an additional call to the model's save method. There's a very long inheritance chain involved, so all those extra DB hits added up.

I needed a quick fix so I didn't modify any of the acceptance tests, but I wrote a few specs.

I know it's nothing huge, but maybe someone else in my situation will find it useful :)
