### PR TITLE
Feature: more customizable sequences aka Arrays, Ranges and Stuff 

### DIFF
--- a/lib/factory_girl/sequence.rb
+++ b/lib/factory_girl/sequence.rb
@@ -8,13 +8,14 @@ module FactoryGirl
     def initialize(name, value = 1, &proc) #:nodoc:
       @name  = name
       @proc  = proc
-      @value = value
+      @value = [Array, Range].any? {|klass| value.is_a? klass } ? value.to_enum : value
     end
 
     def next
-      @proc ? @proc.call(@value) : @value
+      value = @value.is_a?(Enumerator) ? @value.next : @value
+      @proc ? @proc.call(value) : value
     ensure
-      @value = @value.next
+      @value = @value.next unless @value.is_a?(Enumerator)
     end
 
     def names

--- a/spec/factory_girl/sequence_spec.rb
+++ b/spec/factory_girl/sequence_spec.rb
@@ -16,12 +16,34 @@ describe FactoryGirl::Sequence do
   end
 
   describe "a custom sequence" do
-    subject    { FactoryGirl::Sequence.new(:name, "A") {|n| "=#{n}" } }
-    its(:next) { should == "=A" }
+    context "a character sequence" do
+      subject    { FactoryGirl::Sequence.new(:name, "A") {|n| "=#{n}" } }
+      its(:next) { should == "=A" }
 
-    describe "when incrementing" do
-      before     { subject.next }
-      its(:next) { should == "=B" }
+      describe "when incrementing" do
+        before     { subject.next }
+        its(:next) { should == "=B" }
+      end
+    end
+
+    context "an array" do
+      subject    { FactoryGirl::Sequence.new(:name, ["foo","bar","baz"]) {|n| "=#{n}" } }
+      its(:next) { should == "=foo" }
+
+      describe "when incrementing" do
+        before     { subject.next }
+        its(:next) { should == "=bar" }
+      end
+    end
+
+    context "an enumerator" do
+      subject    { FactoryGirl::Sequence.new(:name, (0..30).step(10)) {|n| "=#{n}" } }
+      its(:next) { should == "=0" }
+
+      describe "when incrementing" do
+        before     { subject.next }
+        its(:next) { should == "=10" }
+      end
     end
   end
 
@@ -36,12 +58,34 @@ describe FactoryGirl::Sequence do
   end
 
   describe "a custom sequence without a block" do
-    subject    { FactoryGirl::Sequence.new(:name, "A") }
-    its(:next) { should == "A" }
+    context "a character sequence" do
+      subject    { FactoryGirl::Sequence.new(:name, "A") }
+      its(:next) { should == "A" }
 
-    describe "when incrementing" do
-      before     { subject.next }
-      its(:next) { should == "B" }
+      describe "when incrementing" do
+        before     { subject.next }
+        its(:next) { should == "B" }
+      end
+    end
+
+    context "an array" do
+      subject    { FactoryGirl::Sequence.new(:name, ["foo","bar","baz"]) }
+      its(:next) { should == "foo" }
+
+      describe "when incrementing" do
+        before     { subject.next }
+        its(:next) { should == "bar" }
+      end
+    end
+
+    context "an enumerator" do
+      subject    { FactoryGirl::Sequence.new(:name, (0..30).step(10)) }
+      its(:next) { should == 0 }
+
+      describe "when incrementing" do
+        before     { subject.next }
+        its(:next) { should == 10 }
+      end
     end
   end
 end


### PR DESCRIPTION
Hi, I needed this feature for a gem I am developing, so I was guessing why not trying to code it :-)
This feature allows to pass an Array, a Range or just an Enumerator (every kind of it) an treat it as a sequence.
I purposely did not try to monkey-patch any sort of class, or instance. Moreover, I preferred to avoid any error handling for the `StopIteration` error class, in that I suppose users looking for a custom enumerator are intentionally expecting an end. Otherwise they would build another kind of Enumerator, such as this: `(0..10).cycle`.

Thanks in advance to consider my pull request, and my best regards.

Riccardo
