### PR TITLE
Support for xml-serialization

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     factory_girl (3.3.0)
       activesupport (>= 3.0.0)
+      nokogiri
 
 GEM
   remote: http://rubygems.org/
@@ -49,6 +50,7 @@ GEM
     mocha (0.10.5)
       metaclass (~> 0.0.1)
     multi_json (1.3.4)
+    nokogiri (1.5.0)
     rake (0.9.2.2)
     rspec (2.9.0)
       rspec-core (~> 2.9.0)

--- a/factory_girl.gemspec
+++ b/factory_girl.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/thoughtbot/factory_girl"
 
   s.add_dependency("activesupport", ">= 3.0.0")
+  s.add_dependency("nokogiri")
 
   s.add_development_dependency("rspec",    "~> 2.0")
   s.add_development_dependency("cucumber", "~> 1.1")

--- a/lib/factory_girl.rb
+++ b/lib/factory_girl.rb
@@ -12,6 +12,7 @@ require 'factory_girl/strategy/create'
 require 'factory_girl/strategy/attributes_for'
 require 'factory_girl/strategy/stub'
 require 'factory_girl/strategy/null'
+require 'factory_girl/strategy/xml'
 require 'factory_girl/disallows_duplicates_registry'
 require 'factory_girl/registry'
 require 'factory_girl/null_factory'
@@ -101,6 +102,7 @@ module FactoryGirl
     register_strategy(:attributes_for, FactoryGirl::Strategy::AttributesFor)
     register_strategy(:build_stubbed,  FactoryGirl::Strategy::Stub)
     register_strategy(:null,           FactoryGirl::Strategy::Null)
+    register_strategy(:xml,            FactoryGirl::Strategy::Xml)
   end
 
   def self.register_default_callbacks

--- a/lib/factory_girl/attribute_assigner.rb
+++ b/lib/factory_girl/attribute_assigner.rb
@@ -28,6 +28,10 @@ module FactoryGirl
       end
     end
 
+    def association_and_attribute_names
+      association_names + hash.keys
+    end
+
     private
 
     def build_class_instance

--- a/lib/factory_girl/evaluation.rb
+++ b/lib/factory_girl/evaluation.rb
@@ -9,7 +9,7 @@ module FactoryGirl
       @to_create = to_create
     end
 
-    delegate :object, :hash, to: :@attribute_assigner
+    delegate :object, :hash, :association_and_attribute_names, to: :@attribute_assigner
 
     def create(result_instance)
       @to_create[result_instance]

--- a/lib/factory_girl/strategy/xml.rb
+++ b/lib/factory_girl/strategy/xml.rb
@@ -1,0 +1,182 @@
+require 'nokogiri'
+
+module FactoryGirl
+  module Strategy
+    class Create
+      def association(runner)
+        runner.run
+      end
+
+      def result(evaluation)
+        evaluation.object.tap do |instance|
+          evaluation.notify(:after_build, instance)
+          evaluation.notify(:before_create, instance)
+          evaluation.create(instance)
+          evaluation.notify(:after_create, instance)
+        end
+      end
+    end
+  end
+end
+
+
+module FactoryGirl
+  module Strategy
+    class Xml
+
+      def association(runner)
+        runner.run(Strategy::Xml)
+      end
+
+      def result(evaluation)
+        evaluation.object.tap do |instance|
+          instance.extend XmlSerializeable
+          instance.factory_xml_config.attributes.concat(evaluation.association_and_attribute_names)
+          evaluation.notify(:after_build, instance)
+        end
+      end
+
+      # proxy configuration
+      def xml_config(&block)
+        block.call(@instance.factory_xml_config)
+      end
+
+private
+
+      class XmlConfig
+        attr_accessor :attributes
+        attr_reader :decoration_name
+
+        def initialize
+          @decorate_with_array  = false
+          @attributes = []
+        end
+
+        def decorate_with_array(options = {})
+          @decorate_with_array = true
+          @decoration_name = options.delete(:name)
+          @decorate_with_array = false if options.delete(:disable) == true
+        end
+
+        def decorate_with_array?
+          @decorate_with_array
+        end
+      end
+    end
+
+public
+    module XmlSerializeable
+
+      def decoration_name
+        factory_xml_config.decoration_name || instance_tag.pluralize
+      end
+
+      def instance_tag
+        return @instance_tag if @instance_tag
+        @instance_tag = self.tag_name if self.respond_to?(:tag_name)
+        @instance_tag ||= self.class.name.split('::').last.downcase
+      end
+
+      def factory_xml_config
+        @factory_xml_config ||=  FactoryGirl::Strategy::Xml::XmlConfig.new
+      end
+
+      def xml_config(&block)
+        block.call(self.factory_xml_config)
+      end
+
+      def to_xml
+        serializer = XmlSerializer.new(self).to_xml
+      end
+
+    end
+
+private
+    class XmlSerializer
+
+      def initialize(instance)
+        @instance = instance
+      end
+
+      # initialializes serialization of the instance
+      def to_xml
+        builder = Nokogiri::XML::Builder.new(:encoding => 'UTF-8') do |xml|
+          xml.root do
+            serialize_object(xml, @instance)
+          end
+        end
+
+        top_tag = @instance.factory_xml_config.decorate_with_array? ? @instance.decoration_name : @instance.instance_tag
+        builder.doc.xpath("//#{top_tag}").to_xml
+      end
+
+private
+      # the instance of the strategy is converted to xml
+      def serialize_object(xml, object)
+
+        # special case: instance itself is an array. kind of a hack
+        if object.kind_of?(Enumerable)
+          serialize_attribute(xml, object, nil)
+          return
+        end
+
+        # convert all attributes to XML
+        content = lambda do |parent|
+          a_list = object.factory_xml_config.attributes
+          a_list.each do |attribute|
+            serialize_attribute(parent, object, attribute)
+          end
+        end
+
+        # pack everything inside an array ?
+        if object.factory_xml_config.decorate_with_array?
+          decorate_with(xml, content, :decoration_name => object.decoration_name, :tag_name => object.instance_tag)
+        else
+          xml.send(object.instance_tag, &content)
+        end
+      end
+
+      # serialize the attribute. Complex objects like factories (associations) or array will be serialized recursively
+      def serialize_attribute(xml, object, attribute)
+        if attribute.nil?
+
+          # special case: instance itself is an array. kind of a hack
+          value = object
+          if object.respond_to?(:tag_name)
+            attribute = object.tag_name
+          else
+            attribute = "array"
+          end
+        else
+          value = object.send(:"#{attribute}")
+        end
+
+        if value.kind_of?(Enumerable)
+          # arrays
+          xml.send(attribute, :type => "array") do |array_xml|
+            value.each do |array_element|
+              serialize_object(array_xml, array_element)
+            end
+          end
+        elsif value.kind_of?(XmlSerializeable)
+          # factories
+          serialize_object(xml, value)
+        else
+          # value objects
+          tag_name = value.respond_to?(:tag_name) ? value.tag_name : attribute
+          xml.send("#{tag_name}_", value)
+        end
+      end
+
+      # creates an array-tag around the given block
+      def decorate_with(builder, content_block, params)
+        decoration_name = params.delete(:decoration_name)
+        tag_name = params.delete(:tag_name)
+
+        builder.send(decoration_name, :type => "array") do |around|
+          around.send(tag_name, &content_block)
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/xml_spec.rb
+++ b/spec/acceptance/xml_spec.rb
@@ -1,0 +1,173 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe FactoryGirl::Strategy::Xml do
+  before do
+    class Person
+      attr_accessor :name, :gender, :weight
+      attr_accessor :address
+      attr_accessor :home_address
+      attr_accessor :children
+    end
+
+    class Address
+      attr_accessor :street, :city
+    end
+
+    class Child
+      attr_accessor :name
+    end
+
+    class Post
+      attr_accessor :name
+    end
+
+    class PostCollection < Array
+      def tag_name
+        "posts"
+      end
+    end
+  end
+
+  after(:each) do
+    FactoryGirl.factories.clear
+  end
+
+  it "creates a new xml document representing the person class" do
+    FactoryGirl.define do
+      factory :person do
+        name "Kurt"
+      end
+    end
+
+    person = FactoryGirl.xml(:person)
+    person.should_not be_nil
+  end
+
+  it "creates a new xml document representing the person class. Its attribute-values are stored as text" do
+    FactoryGirl.define do
+      factory :person do
+        name    "Tom"
+        weight  80
+      end
+    end
+
+    person = FactoryGirl.xml(:person).to_xml
+    parsed = Nokogiri::XML.parse(person)
+    parsed.xpath("//person/name").text.should ==  "Tom"
+    parsed.xpath("//person/weight").text.should ==  "80"
+  end
+
+  it "serializes associated models as child nodes" do
+    FactoryGirl.define do
+      factory :person do
+        name "Mary"
+        address
+      end
+
+      factory :address do
+        street  "Mainstreet"
+        city    "Bern"
+      end
+    end
+
+
+    person = FactoryGirl.xml(:person).to_xml
+    parsed = Nokogiri::XML.parse(person)
+    parsed.xpath("//person/address/city").text.should ==  "Bern"
+  end
+
+  it "serializes an associated array as an array of child nodes" do
+    FactoryGirl.define do
+      factory :person do
+        name "Tom"
+        children { [FactoryGirl.xml(:child), FactoryGirl.xml(:child)]}
+      end
+      factory :child do
+        name "Lucy"
+      end
+    end
+
+    person = FactoryGirl.xml(:person).to_xml
+    parsed = Nokogiri::XML.parse(person)
+    parsed.xpath("//person/children[@type='array']").first.elements.size.should == 2
+  end
+
+  it "serializes the model inside an array, if the option is set" do
+    FactoryGirl.define do
+      factory :person do
+        name "Martin"
+
+        after(:build) do |p|
+          p.xml_config do |c|
+            c.decorate_with_array
+          end
+        end
+      end
+    end
+    person = FactoryGirl.xml(:person).to_xml
+    parsed = Nokogiri::XML.parse(person)
+    parsed.xpath("//people/person/name").text.should ==  "Martin"
+  end
+
+  it "serializes the model inside an array, if the option is set. An optional name may be supplied" do
+    FactoryGirl.define do
+      factory :person do
+        name "Martin"
+
+        after(:build) do |p|
+          p.xml_config do |c|
+            c.decorate_with_array :name => :men
+          end
+        end
+      end
+    end
+    person = FactoryGirl.xml(:person).to_xml
+    parsed = Nokogiri::XML.parse(person)
+    parsed.xpath("//men/person/name").text.should ==  "Martin"
+  end
+
+  it "can serialize an enuberable directly as array" do
+    FactoryGirl.define do
+      factory :post do
+        name    "Post"
+      end
+
+      factory :post_collection do
+      end
+    end
+
+    container = FactoryGirl.xml(:post_collection)
+    3.times {container << FactoryGirl.xml(:post)}
+    parsed = Nokogiri::XML.parse(container.to_xml)
+    parsed.xpath("//posts/post").size.should == 3
+  end
+
+  context "embedded in an array" do
+
+    let (:posts) {FactoryGirl.xml(:post_collection)}
+
+    it "suppresses the decoration serialisation, even if definied before" do
+      FactoryGirl.define do
+        factory :post do
+          name    "Post"
+          after(:build) do |p|
+            p.xml_config do |c|
+              c.decorate_with_array :name => :my_posts
+            end
+          end
+        end
+
+        factory :post_collection do
+        end
+      end
+
+      post =  FactoryGirl.xml(:post)
+      post.factory_xml_config.decorate_with_array(:disable=>true)
+      posts << post
+
+      parsed = Nokogiri::XML.parse(posts.to_xml)
+      parsed.xpath("//posts/post/name").text.should ==  "Post"
+    end
+  end
+end


### PR DESCRIPTION
Hi

In some projects we have REST-Services which we consume with ActiveResource.
In order to test those request, we mock them with a FactoryGirl extension.
We built a new strategy which outputs objects enriched with the ability to serialize to XML.

A sample would look like this:  

``` ruby
FactoryGirl.define do
  factory :person do
    name "Mary"
    address
  end

  factory :address do
    street  "Mainstreet"
    city    "Bern"
  end
end


xml = FactoryGirl.xml(:person).to_xml
```

The content of xml looks like this:

``` xml
<person>
  <name>Mary</name>
  <address>
    <street>Mainstreet</street>
    <city>Bern</city>
  </address>
</person>
```

The code isn't perfectly structured yet, but since we don't if you accept such an extension we didn't invest too much time in
beautifying the code :-)

There is support for more features, like serialization of arrays. Have a look at the acceptance tests.

Daniel
