### PR TITLE
Optionally don't duplicate assignment in initialize_with

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -771,6 +771,15 @@ FactoryGirl.define do
 end
 ```
 
+When using `initialize_with`, attributes accessed from the `initialize_with`
+block are assigned a second time to the instance. Duplicate assignment can be
+disabled by configuring FactoryGirl as such:
+
+    FactoryGirl.duplicate_attribute_assignment_from_initialize_with = false
+
+This would allow for attributes declared as ignored to not be ignored, since
+it won't assign them for a second time.
+
 Custom Strategies
 -----------------
 

--- a/lib/factory_girl.rb
+++ b/lib/factory_girl.rb
@@ -37,6 +37,9 @@ require 'factory_girl/syntax'
 require 'factory_girl/syntax_runner'
 require 'factory_girl/find_definitions'
 require 'factory_girl/reload'
+require 'factory_girl/decorator'
+require 'factory_girl/decorator/invocation_tracker'
+require 'factory_girl/decorator/invocation_ignorer'
 require 'factory_girl/version'
 
 module FactoryGirl
@@ -50,7 +53,8 @@ module FactoryGirl
 
   class << self
     delegate :factories, :sequences, :traits, :strategies, :callback_names,
-      :to_create, :skip_create, :initialize_with, :constructor, to: :configuration
+      :to_create, :skip_create, :initialize_with, :constructor, :duplicate_attribute_assignment_from_initialize_with,
+      :duplicate_attribute_assignment_from_initialize_with=, to: :configuration
   end
 
   def self.register_factory(factory)

--- a/lib/factory_girl/configuration.rb
+++ b/lib/factory_girl/configuration.rb
@@ -3,6 +3,8 @@ module FactoryGirl
   class Configuration
     attr_reader :factories, :sequences, :traits, :strategies, :callback_names
 
+    attr_accessor :duplicate_attribute_assignment_from_initialize_with
+
     def initialize
       @factories      = DisallowsDuplicatesRegistry.new(Registry.new('Factory'))
       @sequences      = DisallowsDuplicatesRegistry.new(Registry.new('Sequence'))
@@ -10,6 +12,8 @@ module FactoryGirl
       @strategies     = Registry.new('Strategy')
       @callback_names = Set.new
       @definition     = Definition.new
+
+      @duplicate_attribute_assignment_from_initialize_with = true
 
       to_create {|instance| instance.save! }
       initialize_with { new }

--- a/lib/factory_girl/decorator.rb
+++ b/lib/factory_girl/decorator.rb
@@ -1,0 +1,17 @@
+module FactoryGirl
+  class Decorator < BasicObject
+    undef_method :==
+
+    def initialize(component)
+      @component = component
+    end
+
+    def method_missing(name, *args, &block)
+      @component.send(name, *args, &block)
+    end
+
+    def send(symbol, *args)
+      __send__(symbol, *args)
+    end
+  end
+end

--- a/lib/factory_girl/decorator/invocation_ignorer.rb
+++ b/lib/factory_girl/decorator/invocation_ignorer.rb
@@ -1,0 +1,9 @@
+module FactoryGirl
+  class Decorator
+    class InvocationIgnorer < Decorator
+      def __invoked_methods__
+        []
+      end
+    end
+  end
+end

--- a/lib/factory_girl/decorator/invocation_tracker.rb
+++ b/lib/factory_girl/decorator/invocation_tracker.rb
@@ -1,0 +1,19 @@
+module FactoryGirl
+  class Decorator
+    class InvocationTracker < Decorator
+      def initialize(component)
+        super
+        @invoked_methods = []
+      end
+
+      def method_missing(name, *args, &block)
+        @invoked_methods << name
+        super
+      end
+
+      def __invoked_methods__
+        @invoked_methods.uniq
+      end
+    end
+  end
+end

--- a/spec/acceptance/global_initialize_with_spec.rb
+++ b/spec/acceptance/global_initialize_with_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe 'global initialize_with' do
   before do
+    ActiveSupport::Deprecation.silenced = true
+
     define_class('User') do
       attr_accessor:name
 

--- a/spec/acceptance/traits_spec.rb
+++ b/spec/acceptance/traits_spec.rb
@@ -490,6 +490,8 @@ end
 
 describe "traits with initialize_with" do
   before do
+    ActiveSupport::Deprecation.silenced = true
+
     define_class("User") do
       attr_reader :name
 


### PR DESCRIPTION
By setting:

```
FactoryGirl.duplicate_attribute_assignment_from_initialize_with = false
```

This turns off duplicate assignment of attributes accessed from
initialize_with. This means any attributes accessed from the factory and
assigned in the initialize_with block won't be subsequently set after
the object has been instantiated.

This will be the default functionality in 4.0.
