### PR TITLE
Allow to use AR class names as arguments to create, build etc

### DIFF
--- a/lib/factory_girl.rb
+++ b/lib/factory_girl.rb
@@ -65,6 +65,7 @@ module FactoryGirl
   end
 
   def self.factory_by_name(name)
+    name = name.to_s.underscore unless name.class.in? String, Symbol # looks like AR object
     factories.find(name)
   end
 

--- a/spec/factory_girl_spec.rb
+++ b/spec/factory_girl_spec.rb
@@ -10,6 +10,13 @@ describe FactoryGirl do
     FactoryGirl.factory_by_name(factory.name).should == factory
   end
 
+  it "finds registered factory by object name" do
+    class MultiWordClass < ActiveRecord::Base; end
+    fact = FactoryGirl::Factory.new :multi_word_class
+    FactoryGirl.register_factory(fact)
+    FactoryGirl.factory_by_name(MultiWordClass).should == fact
+  end
+
   it "finds a registered sequence" do
     FactoryGirl.register_sequence(sequence)
     FactoryGirl.sequence_by_name(sequence.name).should == sequence


### PR DESCRIPTION
According to discussion in https://github.com/thoughtbot/factory_girl/commit/c006dd186ff71356217de40a9f146ae35e340e78#commitcomment-1320334
As Object.make syntax is deprecated now, we need a way to pass classes to build/create methods. Currently you have to do

``` ruby
my_class = BookAuthor
create my_class.to_s.underscore
```

This commit allows to do

``` ruby
my_class = BookAuthor
create my_class
```

I never looked into FG internals, so please let me know if this patch should be modified or rewritten.
