### PR TITLE
Allow created_at to be set when using build_stubbed

### DIFF
--- a/lib/factory_girl/strategy/stub.rb
+++ b/lib/factory_girl/strategy/stub.rb
@@ -27,7 +27,7 @@ module FactoryGirl
             !new_record?
           end
 
-          unless result_instance.respond_to?(:created_at)
+          unless result_instance.respond_to?(:created_at) && result_instance.created_at
             def created_at
               @created_at ||= Time.now
             end

--- a/spec/acceptance/build_stubbed_spec.rb
+++ b/spec/acceptance/build_stubbed_spec.rb
@@ -82,6 +82,14 @@ describe "a generated stub instance" do
 
     post.created_at.should == created_at
   end
+
+  it "defaults created_at to now" do
+    Timecop.freeze do
+      post = build_stubbed(:post)
+
+      post.created_at.should == Time.now
+    end
+  end
 end
 
 describe "calling `build_stubbed` with a block" do


### PR DESCRIPTION
This is a patch for the 2.x series of factory_girl. We were recently upgrading dependencies in our application and we noticed that from factory_girl 1.x -> 2.x we could no longer set created_at when using the stub feature.

It seems that Strategy::Stub is largely dependent on Rails so I don't see too much of a problem with having it depend on the read_attribute method, but I might be missing something.

Any feedback is appreciated.
