### PR TITLE
Allows one to pass traits on associations declarations

### DIFF
--- a/lib/factory_girl/declaration/association.rb
+++ b/lib/factory_girl/declaration/association.rb
@@ -4,22 +4,25 @@ module FactoryGirl
     class Association < Declaration
       def initialize(name, options)
         super(name, false)
+        @traits  = options.delete(:traits)
         @options = options
       end
 
       def ==(other)
         name == other.name &&
+          traits == other.traits &&
           options == other.options
       end
 
       protected
-      attr_reader :options
+      attr_reader :traits, :options
 
       private
 
       def build
         factory_name = @options[:factory] || name
-        [Attribute::Association.new(name, factory_name, @options.except(:factory))]
+        traits_and_options = [@traits, @options.except(:factory)].compact.flatten
+        [Attribute::Association.new(name, factory_name, traits_and_options)]
       end
     end
   end

--- a/lib/factory_girl/definition_proxy.rb
+++ b/lib/factory_girl/definition_proxy.rb
@@ -124,7 +124,7 @@ module FactoryGirl
     #   end
     #
     #   factory :post do
-    #     association :author, factory: :user
+    #     association :author, factory: :user, traits: [:active]
     #   end
     #
     # Arguments:
@@ -138,6 +138,8 @@ module FactoryGirl
     #    If no name is given, the name of the attribute is assumed to be the
     #    name of the factory. For example, a "user" association will by
     #    default use the "user" factory.
+    # * traits: +Symbol+ or +Enumerable+
+    #    Traits to be applied on the association.
     def association(name, options = {})
       @definition.declare_attribute(Declaration::Association.new(name, options))
     end

--- a/spec/acceptance/attribute_aliases_spec.rb
+++ b/spec/acceptance/attribute_aliases_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "attribute aliases" do
   before do
-    define_model('User', name: :string, age: :integer)
+    define_model('User', name: :string, age: :integer, active: :boolean)
 
     define_model('Post', user_id: :integer) do
       belongs_to :user
@@ -12,6 +12,10 @@ describe "attribute aliases" do
       factory :user do
         factory :user_with_name do
           name "John Doe"
+
+          trait :active do
+            active true
+          end
         end
       end
 
@@ -20,7 +24,7 @@ describe "attribute aliases" do
       end
 
       factory :post_with_named_user, class: Post do
-        user factory: :user_with_name, age: 20
+        user factory: :user_with_name, traits: :active, age: 20
       end
     end
   end
@@ -39,6 +43,7 @@ describe "attribute aliases" do
     it "assigns attributes correctly" do
       subject.name.should == "John Doe"
       subject.age.should == 20
+      subject.active.should be_true
     end
   end
 end

--- a/spec/factory_girl/definition_proxy_spec.rb
+++ b/spec/factory_girl/definition_proxy_spec.rb
@@ -119,6 +119,11 @@ describe FactoryGirl::DefinitionProxy, "#association" do
     proxy.association(:association_name, { name: "Awesome" })
     subject.should have_association_declaration(:association_name).with_options(name: "Awesome")
   end
+
+  it "declares an association with traits" do
+    proxy.association(:association_name, { traits: [:trait_one, :trait_two] })
+    subject.should have_association_declaration(:association_name).with_traits(:trait_one, :trait_two)
+  end
 end
 
 describe FactoryGirl::DefinitionProxy, "adding callbacks" do

--- a/spec/support/matchers/declaration.rb
+++ b/spec/support/matchers/declaration.rb
@@ -49,6 +49,11 @@ module DeclarationMatchers
       self
     end
 
+    def with_traits(*traits)
+      @traits = traits
+      self
+    end
+
     private
 
     def expected_declaration
@@ -65,7 +70,9 @@ module DeclarationMatchers
     end
 
     def options
-      @options || {}
+      options = @options || {}
+      options[:traits] = @traits if @traits
+      options
     end
   end
 end


### PR DESCRIPTION
Makes this possible:

```
factory :post_with_named_user, class: Post do
  user factory: :user_with_name, traits: :active, age: 20
end
```
