### PR TITLE
quick doc fix: replaced reference to "stub" build strategy

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -101,7 +101,7 @@ are defined in files at the following locations:
 Using factories
 ---------------
 
-factory\_girl supports several different build strategies: build, create, attributes\_for and stub:
+factory\_girl supports several different build strategies: build, create, attributes\_for and build\_stubbed:
 
 ```ruby
 # Returns a User instance that's not saved


### PR DESCRIPTION
I got confused for a second thinking there was a "stub" in addition to "build_stubbed".
