### PR TITLE
Re: #431 -- Added a note about `strategy: :build`

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -321,6 +321,15 @@ post.new_record?        # => true
 post.author.new_record? # => true
 ```
 
+Please note that the `strategy: :build` option must be passed to an explicit call to `association`,
+and cannot be used with implicit associations:
+
+```ruby
+factory :post do
+  # ...
+  author strategy: :build    # <<< this does *not* work; causes author_id to be nil
+```
+
 Generating data for a `has_many` relationship is a bit more involved,
 depending on the amount of flexibility desired, but here's a surefire example
 of generating associated data.


### PR DESCRIPTION
Added a note to the Getting Started guide in the "Associations" section that using `strategy: :build` requires an explicit call to `association`.
