### PR TITLE
Modified define_list_strategy_method to accept and use a block.

### DIFF
--- a/lib/factory_girl/strategy_syntax_method_registrar.rb
+++ b/lib/factory_girl/strategy_syntax_method_registrar.rb
@@ -23,8 +23,8 @@ module FactoryGirl
     def define_list_strategy_method
       strategy_name = @strategy_name
 
-      define_syntax_method("#{strategy_name}_list") do |name, amount, *traits_and_overrides|
-        amount.times.map { send(strategy_name, name, *traits_and_overrides) }
+      define_syntax_method("#{strategy_name}_list") do |name, amount, *traits_and_overrides, &block|
+        amount.times.map { send(strategy_name, name, *traits_and_overrides, &block) }
       end
     end
 

--- a/spec/acceptance/build_list_spec.rb
+++ b/spec/acceptance/build_list_spec.rb
@@ -2,11 +2,12 @@ require 'spec_helper'
 
 describe "build multiple instances" do
   before do
-    define_model('Post', title: :string)
+    define_model('Post', title: :string, position: :integer)
 
     FactoryGirl.define do
       factory(:post) do |post|
         post.title "Through the Looking Glass"
+        post.position { rand(10**4) }
       end
     end
   end
@@ -35,6 +36,20 @@ describe "build multiple instances" do
     it "overrides the default values" do
       subject.each do |record|
         record.title.should == "The Hunting of the Snark"
+      end
+    end
+  end
+
+  context "with a block" do
+    subject do
+      FactoryGirl.build_list(:post, 20, title: "The Listing of the Block") do |post|
+        post.position = post.id
+      end
+    end
+
+    it "correctly uses the set value" do
+      subject.each_with_index do |record, index|
+        record.position.should == record.id
       end
     end
   end

--- a/spec/acceptance/create_list_spec.rb
+++ b/spec/acceptance/create_list_spec.rb
@@ -2,11 +2,12 @@ require 'spec_helper'
 
 describe "create multiple instances" do
   before do
-    define_model('Post', title: :string)
+    define_model('Post', title: :string, position: :integer)
 
     FactoryGirl.define do
       factory(:post) do |post|
         post.title "Through the Looking Glass"
+        post.position { rand(10**4) }
       end
     end
   end
@@ -35,6 +36,20 @@ describe "create multiple instances" do
     it "overrides the default values" do
       subject.each do |record|
         record.title.should == "The Hunting of the Snark"
+      end
+    end
+  end
+
+  context "with a block" do
+    subject do
+      FactoryGirl.create_list(:post, 20, title: "The Listing of the Block") do |post|
+        post.position = post.id
+      end
+    end
+
+    it "uses the new values" do
+      subject.each_with_index do |record, index|
+        record.position.should == record.id
       end
     end
   end


### PR DESCRIPTION
A small change to `create_list` and `build_list` (and any future `*_list` methods) to accept a block, like `create` and `build` do already. 

I can write code like this:

``` ruby
@tag = FactoryGirl.create(:tag) do |tag|
  tag.tag_types = Array.wrap(@tag_type)
end
```

I should be able to write code like this:

``` ruby
@tags = FactoryGirl.create_list(:tag, 3) do |tag|
  tag.tag_types = Array.wrap(@tag_type)
end
```
