### PR TITLE
Fix association reference in example

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -684,7 +684,7 @@ factory :post do
 end
 
 # creates an admin user with name "John Doe"
-FactoryGirl.create(:post).user
+FactoryGirl.create(:post).author
 ```
 Callbacks
 ---------


### PR DESCRIPTION
The example defines the association as `author` but was incorrectly referenced as `user`
