### PR TITLE
add license information to the gemspec

### DIFF
--- a/factory_girl.gemspec
+++ b/factory_girl.gemspec
@@ -40,5 +40,6 @@ Gem::Specification.new do |s|
   end
 
   s.add_development_dependency("yard")
+  s.license = "MIT"
 end
 


### PR DESCRIPTION
This way it can be used with rubygems.org API
