### PR TITLE
Fix short syntax

### DIFF
--- a/lib/factory_girl/callback.rb
+++ b/lib/factory_girl/callback.rb
@@ -10,7 +10,7 @@ module FactoryGirl
 
     def run(instance, evaluator)
       case block.arity
-      when 1 then syntax_runner.instance_exec(instance, &block)
+      when 1, -1 then syntax_runner.instance_exec(instance, &block)
       when 2 then syntax_runner.instance_exec(instance, evaluator, &block)
       else        syntax_runner.instance_exec(&block)
       end

--- a/spec/acceptance/callbacks_spec.rb
+++ b/spec/acceptance/callbacks_spec.rb
@@ -46,6 +46,31 @@ describe "callbacks" do
   end
 end
 
+describe 'running callbacks with proc-symbols' do
+  before do
+    define_model("User") do
+      def confirmed?
+        !!@confirmed
+      end
+    
+      def confirm!
+        @confirmed = true
+      end
+    end
+  
+    FactoryGirl.define do
+      factory :user, class: :user do
+        after :build, &:confirm!
+      end
+    end
+  end
+  
+  it 'works as expected' do
+    user = FactoryGirl.build(:user)
+    user.should be_confirmed
+  end
+end
+
 describe "callbacks using syntax methods without referencing FactoryGirl explicitly" do
   before do
     define_model("User", first_name: :string, last_name: :string)


### PR DESCRIPTION
When I wanna define a callback like the following:

``` ruby
factory :user, class: :user do
  after :build, &:confirm!
end
```

I will get an exception `ArgumentError: no receiver given`.
