### PR TITLE
Update appraisals

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -11,5 +11,5 @@ appraise "3.2" do
 end
 
 appraise '4.0' do
-  gem 'activerecord', github: 'rails/rails'
+  gem 'activerecord', "~> 4.0.0"
 end

--- a/gemfiles/3.0.gemfile.lock
+++ b/gemfiles/3.0.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: /Users/joshuaclayton/dev/gems/factory_girl
+  remote: ../
   specs:
     factory_girl (4.2.0)
       activesupport (>= 3.0.0)

--- a/gemfiles/3.1.gemfile.lock
+++ b/gemfiles/3.1.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: /Users/joshuaclayton/dev/gems/factory_girl
+  remote: ../
   specs:
     factory_girl (4.2.0)
       activesupport (>= 3.0.0)

--- a/gemfiles/3.2.gemfile.lock
+++ b/gemfiles/3.2.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: /Users/joshuaclayton/dev/gems/factory_girl
+  remote: ../
   specs:
     factory_girl (4.2.0)
       activesupport (>= 3.0.0)

--- a/gemfiles/4.0.gemfile
+++ b/gemfiles/4.0.gemfile
@@ -2,6 +2,6 @@
 
 source "http://rubygems.org"
 
-gem "activerecord", :github=>"rails/rails"
+gem "activerecord", "~> 4.0.0"
 
 gemspec :path=>"../"

--- a/gemfiles/4.0.gemfile.lock
+++ b/gemfiles/4.0.gemfile.lock
@@ -1,24 +1,5 @@
-GIT
-  remote: git://github.com/rails/rails.git
-  revision: add318c7f4b5c0e353a0f74c77661fef612efa65
-  specs:
-    activemodel (4.1.0.beta)
-      activesupport (= 4.1.0.beta)
-      builder (~> 3.1.0)
-    activerecord (4.1.0.beta)
-      activemodel (= 4.1.0.beta)
-      activerecord-deprecated_finders (~> 1.0.2)
-      activesupport (= 4.1.0.beta)
-      arel (~> 4.0.0)
-    activesupport (4.1.0.beta)
-      i18n (~> 0.6, >= 0.6.4)
-      json (~> 1.7)
-      minitest (~> 5.0)
-      thread_safe (~> 0.1)
-      tzinfo (~> 0.3.37)
-
 PATH
-  remote: /Users/joshuaclayton/dev/gems/factory_girl
+  remote: ../
   specs:
     factory_girl (4.2.0)
       activesupport (>= 3.0.0)
@@ -26,7 +7,21 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
+    activemodel (4.0.0)
+      activesupport (= 4.0.0)
+      builder (~> 3.1.0)
+    activerecord (4.0.0)
+      activemodel (= 4.0.0)
+      activerecord-deprecated_finders (~> 1.0.2)
+      activesupport (= 4.0.0)
+      arel (~> 4.0.0)
     activerecord-deprecated_finders (1.0.3)
+    activesupport (4.0.0)
+      i18n (~> 0.6, >= 0.6.4)
+      minitest (~> 4.2)
+      multi_json (~> 1.3)
+      thread_safe (~> 0.1)
+      tzinfo (~> 0.3.37)
     appraisal (0.5.2)
       bundler
       rake
@@ -35,7 +30,7 @@ GEM
       childprocess (>= 0.3.6)
       cucumber (>= 1.1.1)
       rspec-expectations (>= 2.7.0)
-    atomic (1.1.9)
+    atomic (1.1.10)
     bourne (1.4.0)
       mocha (~> 0.13.2)
     builder (3.1.4)
@@ -51,9 +46,8 @@ GEM
     gherkin (2.11.8)
       multi_json (~> 1.3)
     i18n (0.6.4)
-    json (1.8.0)
     metaclass (0.0.1)
-    minitest (5.0.4)
+    minitest (4.7.5)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
     multi_json (1.7.7)
@@ -81,7 +75,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord!
+  activerecord (~> 4.0.0)
   appraisal (~> 0.5.1)
   aruba
   bourne


### PR DESCRIPTION
- Use the release version of Rails 4.0 instead of master
- Update .lock files to use relative path so they don't keep changing
  per developer.
