### PR TITLE
Update GETTING_STARTED.md

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1155,3 +1155,37 @@ config.after(:suite) do
   puts @factory_girl_results
 end
 ```
+
+Rails Preloaders and RSpec
+--------------------------
+
+When running RSpec with a rails preloader such as `spring` or `zeus`, it's possible
+to encounter an `ActiveRecord::AssocitionTypeMismatch` error when creating a factory
+with associations, as below:
+```ruby
+FactoryGirl.define do
+  factory :united_states, class: Location do
+    name 'United States'
+    association :location_group, factory: :north_america
+  end
+  
+  factory :north_america, class: LocationGroup do
+    name 'North America'
+  end
+end
+```
+
+The error occurs during the run of the test suite:
+```
+Failure/Error: united_states = FactoryGirl.create(:united_states)
+ActiveRecord::AssociationTypeMismatch:
+  LocationGroup(#70251250797320) expected, got LocationGroup(#70251200725840)
+```
+
+The two possible solutions are to either run the suite without the preloader, or
+to add `FactoryGirl.reload` to the RSpec configuration, like so:
+```ruby
+RSpec.configure do |config|
+  config.before(:suite) { FactoryGirl.reload }
+end
+```


### PR DESCRIPTION
Adding documentation for rails preloaders causing an ActiveRecord::AssociationTypeMismatch error when running RSpec.
