### PR TITLE
remove deprecation warnings

### DIFF
--- a/spec/factory_girl/callback_spec.rb
+++ b/spec/factory_girl/callback_spec.rb
@@ -30,7 +30,7 @@ describe FactoryGirl::Callback do
   it "allows valid callback names to be assigned" do
     FactoryGirl.callback_names.each do |callback_name|
       expect { FactoryGirl::Callback.new(callback_name, -> {}) }.
-        to_not raise_error(FactoryGirl::InvalidCallbackNameError)
+        to_not raise_error()
     end
   end
 


### PR DESCRIPTION
Fixes for this:

```
DEPRECATION: `expect { }.not_to raise_error(SpecificErrorClass)` is deprecated. Use `expect { }.not_to raise_error()` instead. 
```
