### PR TITLE
Include DatabaseCleaner usage when demoing FactoryGirl.lint

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -88,10 +88,18 @@ RSpec.configure do |config|
   # additional factory_girl configuration
 
   config.before(:suite) do
-    FactoryGirl.lint
+    begin
+      DatabaseCleaner.start
+      FactoryGirl.lint
+    ensure
+      DatabaseCleaner.clean
+    end
   end
 end
 ```
+
+After calling `FactoryGirl.lint`, you'll likely want to clear out the
+database, as built factories will create associated records.
 
 Defining factories
 ------------------


### PR DESCRIPTION
Because built factories create associated records, the database may not be
empty when the suite is run. This encourages developers to start 
DatabaseCleaner and clean after linting is complete to ensure a clean 
database.

cc @jferris
