### PR TITLE
Make lint indicate factory name when factory build fails

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -75,8 +75,9 @@ FactoryGirl.lint
 ```
 
 `FactoryGirl.lint` builds each factory and subsequently calls `#valid?` on it
-(if `#valid?` is defined); if any calls to `#valid?` return `false`,
-`FactoryGirl::InvalidFactoryError` is raised with a list of the offending
+(if `#valid?` is defined). If a factory build fails or any calls to `#valid?`
+on the factories return `false`, `FactoryGirl::InvalidFactoryError` is raised
+with with the reason for the build failure or a list of the invalid
 factories. Recommended usage of `FactoryGirl.lint` is to invoke this once
 before the test suite is run.
 

--- a/gemfiles/3.2.gemfile.lock
+++ b/gemfiles/3.2.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: /Users/joshuaclayton/dev/gems/factory_girl
+  remote: ../
   specs:
     factory_girl (4.4.0)
       activesupport (>= 3.0.0)

--- a/lib/factory_girl.rb
+++ b/lib/factory_girl.rb
@@ -56,7 +56,11 @@ module FactoryGirl
 
   def self.lint
     invalid_factories = FactoryGirl.factories.select do |factory|
-      built_factory = FactoryGirl.build(factory.name)
+      begin
+        built_factory = FactoryGirl.build(factory.name)
+      rescue StandardError, RuntimeError => e
+        raise InvalidFactoryError, "FactoryGirl.build(#{factory.name.inspect}) failed:\n---\n#{e.class}: #{e.message}\n  #{e.backtrace.join("\n  ")}\n---\n"
+      end
 
       if built_factory.respond_to?(:valid?)
         !built_factory.valid?

--- a/spec/acceptance/lint_spec.rb
+++ b/spec/acceptance/lint_spec.rb
@@ -28,6 +28,38 @@ The following factories are invalid:
     end.to raise_error FactoryGirl::InvalidFactoryError, error_message
   end
 
+  it 'raises InvalidFactoryError containing factory name when a factory build raises RuntimeError' do
+    define_model 'LintBuildFailOnRuntimeError', name: :string do
+    end
+
+    FactoryGirl.define do
+      factory :lint_build_fail_on_runtime_error do
+      end
+    end
+
+    FactoryGirl.stubs(:build).raises(RuntimeError)
+
+    expect do
+      FactoryGirl.lint
+    end.to raise_error FactoryGirl::InvalidFactoryError, /lint_build_fail_on_runtime_error/
+  end
+
+  it 'raises InvalidFactoryError containing factory name when a factory build raises StandardError' do
+    define_model 'LintBuildFailOnStandardError', name: :string do
+    end
+
+    FactoryGirl.define do
+      factory :lint_build_fail_on_standard_error do
+      end
+    end
+
+    FactoryGirl.stubs(:build).raises(StandardError)
+
+    expect do
+      FactoryGirl.lint
+    end.to raise_error FactoryGirl::InvalidFactoryError, /lint_build_fail_on_standard_error/
+  end
+
   it 'does not raise when all factories are valid' do
     define_model 'User', name: :string do
       validates :name, presence: true


### PR DESCRIPTION
The new lint is great, but it would help to have context when a factory build fails. This does that for StandardError and RuntimeError. Hope that's enough. (Also, a minor fix to the one lock file.)
