### PR TITLE
#614 - added note about using DatabaseCleaner to wrap lint if any factory builds persist data

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -93,6 +93,17 @@ RSpec.configure do |config|
 end
 ```
 
+Note: if any of your factory builds persist changes directly/indirectly, you may need to rollback those changes after running lint. An easy way to do that is to use [DatabaseCleaner](http://rubygems.org/gems/database_cleaner), e.g.:
+
+```ruby
+begin
+  DatabaseCleaner.start
+  FactoryGirl.lint
+ensure
+  DatabaseCleaner.clean
+end
+```
+
 Defining factories
 ------------------
 


### PR DESCRIPTION
To handle builds that end up persisting data, note that can be wrapped in DatabaseCleaner.

Note: there is also a new method in DatabaseCleaner to make this shorter by wrapping it in a `cleaning` block, but it wasn't yet released at time of writing.
