### PR TITLE
Update GETTING_STARTED.md

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -7,7 +7,7 @@ Update Your Gemfile
 If you're using Rails, you'll need to change the required version of `factory_girl_rails`:
 
 ```ruby
-gem "factory_girl_rails", "~> 4.0"
+gem "factory_girl_rails", "~> 4.4.0"
 ```
 
 If you're *not* using Rails, you'll just have to change the required version of `factory_girl`:


### PR DESCRIPTION
gem "factory_girl_rails", "~> 4.4.0" unless you want Undefined method `lint' for FactoryGirl:Module (NoMethodError).  See #610
