### PR TITLE
inform the user what model and method violated the stub

### DIFF
--- a/lib/factory_girl/strategy/stub.rb
+++ b/lib/factory_girl/strategy/stub.rb
@@ -33,27 +33,27 @@ module FactoryGirl
           end
 
           def save(*args)
-            raise 'stubbed models are not allowed to access the database'
+            raise "stubbed models are not allowed to access the database - #{self.class.to_s}#save(#{args.join(",")})"
           end
 
           def destroy(*args)
-            raise 'stubbed models are not allowed to access the database'
+            raise "stubbed models are not allowed to access the database - #{self.class.to_s}#destroy(#{args.join(",")})"
           end
 
           def connection
-            raise 'stubbed models are not allowed to access the database'
+            raise "stubbed models are not allowed to access the database - #{self.class.to_s}#connection()"
           end
 
           def reload
-            raise 'stubbed models are not allowed to access the database'
+            raise "stubbed models are not allowed to access the database - #{self.class.to_s}#reload()"
           end
 
           def update_attribute(*args)
-            raise 'stubbed models are not allowed to access the database'
+            raise "stubbed models are not allowed to access the database - #{self.class.to_s}#update_attribute(#{args.join(",")})"
           end
 
           def update_column(*args)
-            raise 'stubbed models are not allowed to access the database'
+            raise "stubbed models are not allowed to access the database - #{self.class.to_s}#update_column(#{args.join(",")})"
           end
         end
 

--- a/spec/factory_girl/strategy/stub_spec.rb
+++ b/spec/factory_girl/strategy/stub_spec.rb
@@ -27,11 +27,11 @@ describe FactoryGirl::Strategy::Stub do
       expect(subject.result(evaluation).created_at).to eq created_at
     end
 
-    [:save, :destroy, :connection, :reload, :update_attribute].each do |database_method|
+    [:save, :destroy, :connection, :reload, :update_attribute, :update_column].each do |database_method|
       it "raises when attempting to connect to the database by calling #{database_method}" do
         expect do
           subject.result(evaluation).send(database_method)
-        end.to raise_error(RuntimeError, "stubbed models are not allowed to access the database")
+        end.to raise_error(RuntimeError, "stubbed models are not allowed to access the database - #{subject.result(evaluation).class}##{database_method}()")
       end
     end
   end


### PR DESCRIPTION
Sometimes when I'm working on large legacy applications and I start using build_stubbed and friends, I get errors about a model trying to save or destroy or similar. This patch helps me figure out which model is responsible in the (sometimes) large object pools.
