### PR TITLE
code example error in GETTING_STARTED.md fix

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1123,19 +1123,19 @@ throughout your test suite. If you're using RSpec, it's as simple as adding a
 `before(:suite)` and `after(:suite)`:
 
 ```ruby
+factory_girl_results = {}
 config.before(:suite) do
-  @factory_girl_results = {}
   ActiveSupport::Notifications.subscribe("factory_girl.run_factory") do |name, start, finish, id, payload|
     factory_name = payload[:name]
     strategy_name = payload[:strategy]
-    @factory_girl_results[factory_name] ||= {}
-    @factory_girl_results[factory_name][strategy_name] ||= 0
-    @factory_girl_results[factory_name][strategy_name] += 1
+    factory_girl_results[factory_name] ||= {}
+    factory_girl_results[factory_name][strategy_name] ||= 0
+    factory_girl_results[factory_name][strategy_name] += 1
   end
 end
 
 config.after(:suite) do
-  puts @factory_girl_results
+  puts factory_girl_results
 end
 ```
 


### PR DESCRIPTION
Example for integration with RSpec and ActiveSupport::Notification is not valid.

Here is original example:

``` ruby
config.before(:suite) do
  @factory_girl_results = {}
  ActiveSupport::Notifications.subscribe("factory_girl.run_factory") do |name, start, finish, id, payload|
    factory_name = payload[:name]
    strategy_name = payload[:strategy]
    @factory_girl_results[factory_name] ||= {}
    @factory_girl_results[factory_name][strategy_name] ||= 0
    @factory_girl_results[factory_name][strategy_name] += 1
  end
end

config.after(:suite) do
  puts @factory_girl_results
end
```

This will never give you expected results since that two blocks run in different contexts. For example `self` for the first block is `#<RSpec::Core::ExampleGroup:0x0000000a6739c8 @factory_girl_results={}>` and for the second is `#<RSpec::Core::ExampleGroup:0x0000000a444c38>` during single `rspec` run.
Blocks are not closures for instance variable `@factory_girl_results`.

My fix looks like:

``` ruby
factory_girl_results = {}
config.before(:suite) do
  ActiveSupport::Notifications.subscribe("factory_girl.run_factory") do |name, start, finish, id, payload|
    factory_name = payload[:name]
    strategy_name = payload[:strategy]
    factory_girl_results[factory_name] ||= {}
    factory_girl_results[factory_name][strategy_name] ||= 0
    factory_girl_results[factory_name][strategy_name] += 1
  end
end

config.after(:suite) do
  puts factory_girl_results
end
```

I just replaced instance variable with closure.

FYI: I did not provide test example for the issue because it's in documentation, but I'll do if it is necessary.
