### PR TITLE
Improving the documentation around Factory Linting and the DatabaseCleaner class.

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -88,18 +88,35 @@ RSpec.configure do |config|
   # additional factory_girl configuration
 
   config.before(:suite) do
-    begin
-      DatabaseCleaner.start
-      FactoryGirl.lint
-    ensure
-      DatabaseCleaner.clean
-    end
+    FactoryGirl.lint
   end
 end
 ```
 
 After calling `FactoryGirl.lint`, you'll likely want to clear out the
-database, as built factories will create associated records.
+database, as built factories will create associated records. To do this,
+you can use the `database_cleaner` gem. After adding `database_cleaner` to your
+gemfile, we can expand on the previous example to lint the factories once before
+the test suite is ran, and clearing out the database in between RSpec examples.
+
+```ruby
+# spec/support/factory_girl.rb
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction    
+    DatabaseCleaner.clean_with(:truncation)
+    FactoryGirl.lint
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+end
+```
 
 Defining factories
 ------------------


### PR DESCRIPTION
If you follow the "Linting Factories" instructions in your [GETTING_STARTED.md](https://github.com/thoughtbot/factory_girl/blob/master/GETTING_STARTED.md#linting-factories) file, a Rails application will break with this error message:

`uninitialized constant DatabaseCleaner (NameError)`

This is because `DatabaseCleaner` is class defined in the `database_cleaner` gem.

After reporting this in [Issue #644](https://github.com/thoughtbot/factory_girl/issues/644), it was suggested that I could help by improving the documentation around Factory Linting and the DatabaseCleaner class in the `GETTING_STARTED.md` file. Hence this pull request :-]
