### PR TITLE
FactoryGirl should refuse to assign to a private setter.

### DIFF
--- a/lib/factory_girl/attribute_assigner.rb
+++ b/lib/factory_girl/attribute_assigner.rb
@@ -13,7 +13,7 @@ module FactoryGirl
       @evaluator.instance = build_class_instance
       build_class_instance.tap do |instance|
         attributes_to_set_on_instance.each do |attribute|
-          instance.send("#{attribute}=", get(attribute))
+          instance.public_send("#{attribute}=", get(attribute))
           @attribute_names_assigned << attribute
         end
       end


### PR DESCRIPTION
As part of a refactoring, I'm making one of the association setters on one of my ActiveRecord models private, something like:

``` ruby
class Human < ActiveRecord::Base
  belongs_to :favorite_soda, class_name: :Soda
  private :favorite_soda=
end
```

But FactoryGirl will still gladly assign to it:

``` ruby
FactoryGirl.build(:human, favorite_soda: Soda.first)
```

This is because the `AttributeAssigner` uses `#send` instead of `#public_send`. This PR changes that.

I haven't added a test for it because I wasn't sure where it should be tested. `AttributeAssigner` doesn't appear to have its own spec (though I might just not be seeing it).

This change doesn't break any specs, but it's possible that users are depending on FactoryGirl being able to assign to private setters. I think it's unlikely they're intending to do that, though. At least, I can't come up with a reason you'd want to make something private but then assign it from a factory.

Thoughts?
