### PR TITLE
More specific rspec path in GETTING_STARTED

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -29,7 +29,7 @@ Configure your test suite
 -------------------------
 
 ```ruby
-# rspec
+# RSpec in spec/spec_helper.rb
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 end


### PR DESCRIPTION
As a rails beginner I was struggling to find out where to put these configs (than I googled it), so I think that the path to the spec_helper should be included in the wiki. 
