### PR TITLE
Rename `ignore` to `transient`

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -237,7 +237,7 @@ There may be times where your code can be DRYed up by passing in transient attri
 
 ```ruby
 factory :user do
-  ignore do
+  transient do
     rockstar true
     upcased  false
   end
@@ -254,14 +254,14 @@ create(:user, upcased: true).name
 #=> "JOHN DOE - ROCKSTAR"
 ```
 
-Static and dynamic attributes can be ignored. Ignored attributes will be ignored
-within attributes\_for and won't be set on the model, even if the attribute
-exists or you attempt to override it.
+Static and dynamic attributes can be created as transient attributes. Transient
+attributes will be ignored within attributes\_for and won't be set on the model,
+even if the attribute exists or you attempt to override it.
 
-Within factory_girl's dynamic attributes, you can access ignored attributes as
+Within factory_girl's dynamic attributes, you can access transient attributes as
 you would expect. If you need to access the evaluator in a factory_girl callback,
 you'll need to declare a second block argument (for the evaluator) and access
-ignored attributes from there.
+transient attributes from there.
 
 Associations
 ------------
@@ -340,14 +340,14 @@ FactoryGirl.define do
 
     # user_with_posts will create post data after the user has been created
     factory :user_with_posts do
-      # posts_count is declared as an ignored attribute and available in
+      # posts_count is declared as a transient attribute and available in
       # attributes on the factory, as well as the callback via the evaluator
-      ignore do
+      transient do
         posts_count 5
       end
 
       # the after(:create) yields two values; the user instance itself and the
-      # evaluator, which stores all values from the factory, including ignored
+      # evaluator, which stores all values from the factory, including transient
       # attributes; `create_list`'s second argument is the number of records
       # to create and we make sure the user is associated properly to the post
       after(:create) do |user, evaluator|
@@ -914,7 +914,7 @@ by calling `attributes`:
 
 ```ruby
 factory :user do
-  ignore do
+  transient do
     comments_count 5
   end
 
@@ -925,7 +925,7 @@ end
 ```
 
 This will build a hash of all attributes to be passed to `new`. It won't
-include ignored attributes, but everything else defined in the factory will be
+include transient attributes, but everything else defined in the factory will be
 passed (associations, evalued sequences, etc.)
 
 You can define `initialize_with` for all factories by including it in the

--- a/lib/factory_girl/definition_proxy.rb
+++ b/lib/factory_girl/definition_proxy.rb
@@ -52,6 +52,12 @@ module FactoryGirl
     end
 
     def ignore(&block)
+      ActiveSupport::Deprecation.warn "`#ignore` is deprecated and will be "\
+        "removed in 5.0. Please use `#transient` instead."
+      transient &block
+    end
+
+    def transient(&block)
       proxy = DefinitionProxy.new(@definition, true)
       proxy.instance_eval(&block)
     end

--- a/spec/acceptance/create_list_spec.rb
+++ b/spec/acceptance/create_list_spec.rb
@@ -55,7 +55,7 @@ describe "create multiple instances" do
   end
 end
 
-describe "multiple creates and ignored attributes to dynamically build attribute lists" do
+describe "multiple creates and transient attributes to dynamically build attribute lists" do
   before do
     define_model('User', name: :string) do
       has_many :posts
@@ -75,7 +75,7 @@ describe "multiple creates and ignored attributes to dynamically build attribute
         name "John Doe"
 
         factory :user_with_posts do
-          ignore do
+          transient do
             posts_count 5
           end
 

--- a/spec/acceptance/initialize_with_spec.rb
+++ b/spec/acceptance/initialize_with_spec.rb
@@ -22,7 +22,7 @@ describe "initialize_with with non-FG attributes" do
   its(:age)  { should eq 21 }
 end
 
-describe "initialize_with with FG attributes that are ignored" do
+describe "initialize_with with FG attributes that are transient" do
   include FactoryGirl::Syntax::Methods
 
   before do
@@ -34,7 +34,7 @@ describe "initialize_with with FG attributes that are ignored" do
 
     FactoryGirl.define do
       factory :user do
-        ignore do
+        transient do
           name { "Handsome Chap" }
         end
 
@@ -64,7 +64,7 @@ describe "initialize_with non-ORM-backed objects" do
       sequence(:random_data) { 5.times.map { Kernel.rand(200) } }
 
       factory :report_generator do
-        ignore do
+        transient do
           name "My Awesome Report"
         end
 
@@ -94,14 +94,14 @@ describe "initialize_with parent and child factories" do
 
     FactoryGirl.define do
       factory :awesome do
-        ignore do
+        transient do
           name "Great"
         end
 
         initialize_with { Awesome.new(name) }
 
         factory :sub_awesome do
-          ignore do
+          transient do
             name "Sub"
           end
         end
@@ -134,7 +134,7 @@ describe "initialize_with implicit constructor" do
 
     FactoryGirl.define do
       factory :awesome do
-        ignore do
+        transient do
           name "Great"
         end
 
@@ -195,7 +195,7 @@ describe "initialize_with has access to all attributes for construction" do
       sequence(:email) { |n| "person#{n}@example.com" }
 
       factory :user do
-        ignore do
+        transient do
           ignored "of course!"
         end
 

--- a/spec/acceptance/transient_attributes_spec.rb
+++ b/spec/acceptance/transient_attributes_spec.rb
@@ -8,7 +8,7 @@ describe "transient attributes" do
       sequence(:name) { |n| "John #{n}" }
 
       factory :user do
-        ignore do
+        transient do
           four     { 2 + 2 }
           rockstar true
           upcased  false
@@ -67,6 +67,33 @@ describe "transient attributes" do
       expect(rockstar.name).to eq "John 1 - Rockstar"
     end
   end
+
+  context "using aliased 'ignore' method name" do
+    around do |example|
+      cached_silenced = ActiveSupport::Deprecation.silenced
+      ActiveSupport::Deprecation.silenced = true
+      example.run
+      ActiveSupport::Deprecation.silenced = cached_silenced
+    end
+
+    before do
+      FactoryGirl.define do
+        factory :user_using_ignore, class: User do
+          ignore do
+            honorific "Esteemed"
+          end
+
+          name { "#{honorific} Jane Doe" }
+        end
+      end
+    end
+
+    let(:esteemed) { FactoryGirl.create(:user_using_ignore) }
+
+    it "uses the default value of the attribute" do
+      expect(esteemed.name).to eq "Esteemed Jane Doe"
+    end
+  end
 end
 
 describe "transient sequences" do
@@ -75,7 +102,7 @@ describe "transient sequences" do
 
     FactoryGirl.define do
       factory :user do
-        ignore do
+        transient do
           sequence(:counter)
         end
 
@@ -106,7 +133,7 @@ describe "assigning values from a transient attribute" do
 
     FactoryGirl.define do
       factory :user do
-        ignore do
+        transient do
           foo { Foo.new('id-of-foo', 'name-of-foo')}
         end
 

--- a/spec/factory_girl/definition_proxy_spec.rb
+++ b/spec/factory_girl/definition_proxy_spec.rb
@@ -44,12 +44,12 @@ describe FactoryGirl::DefinitionProxy, "#add_attribute when the proxy ignores at
   end
 end
 
-describe FactoryGirl::DefinitionProxy, "#ignore" do
+describe FactoryGirl::DefinitionProxy, "#transient" do
   subject     { FactoryGirl::Definition.new }
   let(:proxy) { FactoryGirl::DefinitionProxy.new(subject) }
 
   it "makes all attributes added ignored" do
-    proxy.ignore do
+    proxy.transient do
       add_attribute(:attribute_name, "attribute value")
     end
 


### PR DESCRIPTION
FactoryGirl has a feature called "Transient Attributes" that allows factories to define attributes that can be used inside the factory, but are not to be persisted to the model. The API for this has been to pass a block to a method called `ignore`. The name `ignore` is inconsistent with the feature name of "Transient Attributes".

This pull request deprecates the `ignore` method, and creates a new `transient` method with the same functionality.

One concern is that the internal API for querying transient attributes is still called `ignored` and `non_ignored`. This seems inconsistent, but that is up for debate.
