### PR TITLE
Update 2.6.x's README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Documentation
 
 You should find the documentation for your version of factory_girl on [Rubygems](https://rubygems.org/gems/factory_girl).
 
-See [GETTING_STARTED](https://github.com/thoughtbot/factory_girl/blob/master/GETTING_STARTED.md) for information on defining and using factories.
+See [GETTING_STARTED](https://github.com/thoughtbot/factory_girl/blob/2.6.x/GETTING_STARTED.md) for information on defining and using factories.
 
 Install
 --------


### PR DESCRIPTION
On the 2.6.x branch, the link to GETTING_STARTED.md used to point to the master branch's version of the file. Now it points to 2.6.x's version.
