### PR TITLE
Add note regarding version, #ignore, & #transient

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -263,6 +263,8 @@ you would expect. If you need to access the evaluator in a factory_girl callback
 you'll need to declare a second block argument (for the evaluator) and access
 transient attributes from there.
 
+If you are using the factory_girl gem `<= 4.4.0`, you will need to use the `#ignore` method instead of the `#transient` method.  `#ignore` will be depreicated in version `5.0.0`
+
 Associations
 ------------
 


### PR DESCRIPTION
The docs were updated before the actual gem was. For a getting started guide, this can be really frustrating if there is no mention of what it was in the prior (or especially current) version.  This would resolve #658 
