### PR TITLE
Replace map.flatten with flat_map

### DIFF
--- a/lib/factory_girl/attribute_assigner.rb
+++ b/lib/factory_girl/attribute_assigner.rb
@@ -89,9 +89,9 @@ module FactoryGirl
     end
 
     def alias_names_to_ignore
-      @attribute_list.non_ignored.map do |attribute|
+      @attribute_list.non_ignored.flat_map do |attribute|
         override_names.map { |override| attribute.name if attribute.alias_for?(override) && attribute.name != override && !ignored_attribute_names.include?(override) }
-      end.flatten.compact
+      end.compact
     end
   end
 end


### PR DESCRIPTION
As Erik Michaels-Ober recently noted, `flat_map` is significant faster than `map.flatten`

``` ruby
require 'benchmark/ips'

ARRAY = 100.times.map { (0..100).to_a }

def slow
  ARRAY.map { |x| x }.flatten(1)
end

def fast
  ARRAY.flat_map { |x| x }
end

Benchmark.ips do |x|
  x.report('slow') { slow }
  x.report('fast') { fast }
end
```

```
Calculating -------------------------------------
                slow   199.000  i/100ms
                fast     2.626k i/100ms
-------------------------------------------------
                slow      2.053k (± 5.9%) i/s -     10.348k
                fast     24.377k (±12.7%) i/s -    120.796k
```
