### PR TITLE
correct error message when stubbed reload called with transaction lock a...

### DIFF
--- a/lib/factory_girl/strategy/stub.rb
+++ b/lib/factory_girl/strategy/stub.rb
@@ -44,7 +44,7 @@ module FactoryGirl
             raise "stubbed models are not allowed to access the database - #{self.class.to_s}#connection()"
           end
 
-          def reload
+          def reload(*args)
             raise "stubbed models are not allowed to access the database - #{self.class.to_s}#reload()"
           end
 

--- a/spec/factory_girl/strategy/stub_spec.rb
+++ b/spec/factory_girl/strategy/stub_spec.rb
@@ -34,5 +34,12 @@ describe FactoryGirl::Strategy::Stub do
         end.to raise_error(RuntimeError, "stubbed models are not allowed to access the database - #{subject.result(evaluation).class}##{database_method}()")
       end
     end
+
+    it "raises when attempting to connect to the database by calling reload with optional lock:true" do
+      expect do
+        subject.result(evaluation).reload(lock: true)
+      end.to raise_error(RuntimeError, "stubbed models are not allowed to access the database - #{subject.result(evaluation).class}#reload()")
+    end
+
   end
 end


### PR DESCRIPTION
stubbed models' reload now takes an optional attrs param to cover defined option:

> ActiveRecord::Persistence 
> ...
> **reload**(options = nil)
> The optional :lock flag option allows you to lock the reloaded record:
> reload(lock: true) # reload with pessimistic locking
