### PR TITLE
rspec configuration changed from spec/suport to rails_helper.rb

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -30,8 +30,11 @@ Configure your test suite
 
 ```ruby
 # RSpec
-# spec/support/factory_girl.rb
+# Add the following line inside the Rspec.configure block of the spec/rails_helper.rb
+config.include FactoryGirl::Syntax::Methods
+# spec/rails_helper.rb
 RSpec.configure do |config|
+  ...
   config.include FactoryGirl::Syntax::Methods
 end
 


### PR DESCRIPTION
config line in rspec is now added to the rails_helper.rb file so that factor girl methods can be accessed the previously on support/factory_girl.rb which dont work.
