### PR TITLE
public api for removing factories

### DIFF
--- a/lib/factory_girl.rb
+++ b/lib/factory_girl.rb
@@ -81,6 +81,10 @@ module FactoryGirl
     factory
   end
 
+  def self.remove_factory(name)
+    factories.remove(name)
+  end
+
   def self.factory_by_name(name)
     factories.find(name)
   end

--- a/lib/factory_girl/registry.rb
+++ b/lib/factory_girl/registry.rb
@@ -13,6 +13,10 @@ module FactoryGirl
       @items.clear
     end
 
+    def remove(name)
+      @items.delete(name.to_sym)
+    end
+
     def each(&block)
       @items.values.uniq.each(&block)
     end

--- a/spec/factory_girl/registry_spec.rb
+++ b/spec/factory_girl/registry_spec.rb
@@ -57,4 +57,19 @@ describe FactoryGirl::Registry do
     subject.clear
     expect(subject.count).to be_zero
   end
+
+  it "removes a factory" do
+    subject.register(:object_name, registered_object)
+    expect do
+      expect(subject.remove(:object_name)).to eq(registered_object)
+    end.to change { subject.count }.by(-1)
+    expect { subject.find(:object_name) }.to raise_error(ArgumentError, "Great thing not registered: object_name")
+  end
+
+  it "no-ops removing a factory that isn't registered" do
+    subject.register(:object_name, registered_object)
+    expect do
+      expect(subject.remove(:no_such_object_name)).to be_nil
+    end.to_not change { subject.count }
+  end
 end

--- a/spec/factory_girl_spec.rb
+++ b/spec/factory_girl_spec.rb
@@ -10,6 +10,12 @@ describe FactoryGirl do
     expect(FactoryGirl.factory_by_name(factory.name)).to eq factory
   end
 
+  it "removes a registered factory" do
+    FactoryGirl.register_factory(factory)
+    expect(FactoryGirl.remove_factory(factory.name)).to eq(factory)
+    expect{ FactoryGirl.factory_by_name(factory.name) }.to raise_error(ArgumentError)
+  end
+
   it "finds a registered sequence" do
     FactoryGirl.register_sequence(sequence)
     expect(FactoryGirl.sequence_by_name(sequence.name)).to eq sequence


### PR DESCRIPTION
FG already has a way to modify existing factories (`FactoryGirl.modify`),
which is great when there are factories supplied by a gem you need
to tweak. 

But sometimes you need to remove entirely a factory supplied by a gem.
Often because you can't do things like _remove_ an attribute or 
callback from an existing factory. It's best just to remove it, and
start over from scratch with your own `define`. 

This adds some simple public API for un-registering factories.
