### PR TITLE
Adding descriptive error message #467

### DIFF
--- a/lib/factory_girl/declaration/implicit.rb
+++ b/lib/factory_girl/declaration/implicit.rb
@@ -11,6 +11,8 @@ module FactoryGirl
         name == other.name &&
           factory == other.factory &&
           ignored == other.ignored
+      rescue NoMethodError => e
+        raise e, e.message + ". Check if you've used symbol for factory name"
       end
 
       protected

--- a/spec/factory_girl/attribute/implicit_spec.rb
+++ b/spec/factory_girl/attribute/implicit_spec.rb
@@ -2,11 +2,13 @@ require 'spec_helper'
 
 describe FactoryGirl::Declaration::Implicit do
   context "using variable instead of symbol name" do
-  let(:name) { :first_name }
-  let(:first) { FactoryGirl::Declaration::Implicit.new(name) }
-  subject { first == :some_symbol }
+    let(:name) { :first_name }
+    let(:first) { FactoryGirl::Declaration::Implicit.new(name) }
+    subject { first == :some_symbol }
     it "raise error" do
-      expect { subject }.to raise_error(NoMethodError, /symbol for factory name/)
+      expect { subject }.to raise_error(
+        NoMethodError,
+        /symbol for factory name/)
     end
   end
 end

--- a/spec/factory_girl/attribute/implicit_spec.rb
+++ b/spec/factory_girl/attribute/implicit_spec.rb
@@ -6,9 +6,8 @@ describe FactoryGirl::Declaration::Implicit do
     let(:first) { FactoryGirl::Declaration::Implicit.new(name) }
     subject { first == :some_symbol }
     it "raise error" do
-      expect { subject }.to raise_error(
-        NoMethodError,
-        /symbol for factory name/)
+      expect { subject }.to raise_error(NoMethodError,
+                                        /symbol for factory name/)
     end
   end
 end

--- a/spec/factory_girl/attribute/implicit_spec.rb
+++ b/spec/factory_girl/attribute/implicit_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe FactoryGirl::Declaration::Implicit do
+  context "using variable instead of symbol name" do
+  let(:name) { :first_name }
+  let(:first) { FactoryGirl::Declaration::Implicit.new(name) }
+  subject { first == :some_symbol }
+    it "raise error" do
+      expect { subject }.to raise_error(NoMethodError, /symbol for factory name/)
+    end
+  end
+end


### PR DESCRIPTION
I also faced this issue with `undefined method 'name' for ...:Symbol` caused by missing colon.

So first line has mistake, second like works:

~~~
association :received_by, factory: user  # this does not work since we should use symbol
association :received_by, factory: :user
~~~

I think that better error message will help much.
What do you think about this error message ?