### PR TITLE
Improve GETTING_STARTED table of content hierarchy

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -28,7 +28,7 @@ Once your Gemfile is updated, you'll want to update your bundle.
 Configure your test suite
 -------------------------
 
-# RSpec
+### RSpec
 
 ```ruby
 # spec/support/factory_girl.rb
@@ -52,7 +52,7 @@ Remember to require the above file in your rails_helper since the support folder
 require 'support/factory_girl'
 ```
 
-# Test::Unit
+### Test::Unit
 
 ```ruby
 class Test::Unit::TestCase
@@ -60,14 +60,14 @@ class Test::Unit::TestCase
 end
 ```
 
-# Cucumber
+### Cucumber
 
 ```ruby
 # env.rb (Rails example location - RAILS_ROOT/features/support/env.rb)
 World(FactoryGirl::Syntax::Methods)
 ```
 
-# Spinach
+### Spinach
 
 ```ruby
 class Spinach::FeatureSteps
@@ -75,7 +75,7 @@ class Spinach::FeatureSteps
 end
 ```
 
-# Minitest
+### Minitest
 
 ```ruby
 class Minitest::Unit::TestCase
@@ -83,7 +83,7 @@ class Minitest::Unit::TestCase
 end
 ```
 
-# Minitest::Spec
+### Minitest::Spec
 
 ```ruby
 class Minitest::Spec
@@ -91,7 +91,7 @@ class Minitest::Spec
 end
 ```
 
-# minitest-rails
+### minitest-rails
 
 ```ruby
 class ActiveSupport::TestCase


### PR DESCRIPTION
Hello!

The current GETTING_STARTED file has a somewhat confusing table of contents, with the specific names of each test framework as big top-level content, and then the main content (like "Defining factories") as small bullets nested below "minitest-rails":

<img width="1258" alt="screen shot 2017-01-28 at 9 38 26 am" src="https://cloud.githubusercontent.com/assets/994938/22398512/dd013daa-e53e-11e6-8f1c-a3881bce39a3.png">


This PR makes the test suite names sub-headers of "configure your test suite" and makes what I think is the main content top-level headers:

<img width="1280" alt="screen shot 2017-01-28 at 9 36 15 am" src="https://cloud.githubusercontent.com/assets/994938/22398520/f4c4ef18-e53e-11e6-8fc9-ce6da5eb28fa.png">

I think this just brings the file more in line with the intent, but happy to discuss if I'm wrong about that!

(Also note, this will have to land on Rubygems to be live on the documentation site, since the link to GETTING_STARTED in the README is hard-coded.)

