### PR TITLE
More intuitive attribute-association setting

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -408,7 +408,7 @@ FactoryBot.define do
         posts_count 5
       end
 
-      # within the  the dynamic association block, pass self as the user and
+      # within the dynamic association block, pass self as the user and
       # the post factory will know to associate with the generated user.
       # `create_list`'s second argument is the number of records
       # to create and we make sure the user is associated properly to the post
@@ -456,7 +456,7 @@ FactoryBot.define do
         languages_count 5
       end
 
-      # within the  the dynamic association block, pass [self] as the users and
+      # within the dynamic association block, pass [self] as the users and
       # the post factory will know to associate with the generated user.
       # `create_list`'s second argument is the number of records
       # to create and we make sure the user is associated properly to the post

--- a/lib/factory_bot/attribute_assigner.rb
+++ b/lib/factory_bot/attribute_assigner.rb
@@ -57,7 +57,9 @@ module FactoryBot
       when FactoryGirl::Evaluator
         obj.instance
       when Array
-        obj.map{|o| o.is_a?(FactoryGirl::Evaluator) ? o.instance : o }
+        obj.map do |o|
+          o.is_a?(FactoryGirl::Evaluator) ? o.instance : o
+        end
       else
         obj
       end

--- a/lib/factory_bot/attribute_assigner.rb
+++ b/lib/factory_bot/attribute_assigner.rb
@@ -54,11 +54,11 @@ module FactoryBot
 
     def get(attribute_name)
       case obj = @evaluator.send(attribute_name)
-      when FactoryGirl::Evaluator
+      when FactoryBot::Evaluator
         obj.instance
       when Array
         obj.map do |o|
-          o.is_a?(FactoryGirl::Evaluator) ? o.instance : o
+          o.is_a?(FactoryBot::Evaluator) ? o.instance : o
         end
       else
         obj

--- a/lib/factory_bot/attribute_assigner.rb
+++ b/lib/factory_bot/attribute_assigner.rb
@@ -53,7 +53,14 @@ module FactoryBot
     end
 
     def get(attribute_name)
-      @evaluator.send(attribute_name)
+      case obj = @evaluator.send(attribute_name)
+      when FactoryGirl::Evaluator
+        obj.instance
+      when Array
+        obj.map{|o| o.is_a?(FactoryGirl::Evaluator) ? o.instance : o }
+      else
+        obj
+      end
     end
 
     def attributes_to_set_on_instance

--- a/lib/factory_bot/evaluator.rb
+++ b/lib/factory_bot/evaluator.rb
@@ -44,7 +44,8 @@ module FactoryBot
     end
 
     def respond_to_missing?(method_name, include_private = false)
-      instance.respond_to?(method_name) || SyntaxRunner.new.respond_to?(method_name)
+      instance.respond_to?(method_name) ||
+        SyntaxRunner.new.respond_to?(method_name)
     end
 
     def __override_names__

--- a/lib/factory_bot/evaluator.rb
+++ b/lib/factory_bot/evaluator.rb
@@ -33,20 +33,18 @@ module FactoryBot
       @build_strategy.association(runner)
     end
 
-    def instance=(object_instance)
-      @instance = object_instance
-    end
+    attr_accessor :instance
 
     def method_missing(method_name, *args, &block)
-      if @instance.respond_to?(method_name)
-        @instance.send(method_name, *args, &block)
+      if instance.respond_to?(method_name)
+        instance.send(method_name, *args, &block)
       else
         SyntaxRunner.new.send(method_name, *args, &block)
       end
     end
 
     def respond_to_missing?(method_name, include_private = false)
-      @instance.respond_to?(method_name) || SyntaxRunner.new.respond_to?(method_name)
+      instance.respond_to?(method_name) || SyntaxRunner.new.respond_to?(method_name)
     end
 
     def __override_names__

--- a/spec/acceptance/definition_spec.rb
+++ b/spec/acceptance/definition_spec.rb
@@ -61,7 +61,7 @@ describe "defining has_many associations in an association block" do
     end
     define_model("Post", user_id: :integer) { belongs_to :user }
 
-    FactoryGirl.define do
+    FactoryBot.define do
       factory :user do
         posts { build_list(:post, 2, user: instance) }
         favorite_post { posts.last }
@@ -74,21 +74,21 @@ describe "defining has_many associations in an association block" do
   end
 
   it "correctly sets the opposite association on build" do
-    user = FactoryGirl.build(:user)
+    user = FactoryBot.build(:user)
 
     expect(user.posts.size).to eq(2)
     expect(user.posts.map(&:user)).to all(eq(user))
   end
 
   it "correctly sets the opposite association on create" do
-    user = FactoryGirl.create(:user)
+    user = FactoryBot.create(:user)
 
     expect(user.posts.count).to eq(2)
     expect(user.posts.map(&:user)).to all(eq(user))
   end
 
   it "is usable in other blocks" do
-    user = FactoryGirl.build(:user)
+    user = FactoryBot.build(:user)
 
     expect(user.favorite_post).to be_a(Post)
     expect(user.favorite_post).to eq(user.posts.last)

--- a/spec/acceptance/definition_spec.rb
+++ b/spec/acceptance/definition_spec.rb
@@ -52,3 +52,45 @@ describe "attributes defined using Symbol#to_proc" do
     expect(user.password_confirmation).to eq "bar"
   end
 end
+
+describe "defining has_many associations in an association block" do
+  before do
+    define_model("User") do
+      has_many :posts
+      attr_accessor :favorite_post
+    end
+    define_model("Post", user_id: :integer) { belongs_to :user }
+
+    FactoryGirl.define do
+      factory :user do
+        posts { build_list(:post, 2, user: instance) }
+        favorite_post { posts.last }
+      end
+
+      factory :post do
+        user
+      end
+    end
+  end
+
+  it "correctly sets the opposite association on build" do
+    user = FactoryGirl.build(:user)
+
+    expect(user.posts.size).to eq(2)
+    expect(user.posts.map(&:user)).to all(eq(user))
+  end
+
+  it "correctly sets the opposite association on create" do
+    user = FactoryGirl.create(:user)
+
+    expect(user.posts.count).to eq(2)
+    expect(user.posts.map(&:user)).to all(eq(user))
+  end
+
+  it "is usable in other blocks" do
+    user = FactoryGirl.build(:user)
+
+    expect(user.favorite_post).to be_a(Post)
+    expect(user.favorite_post).to eq(user.posts.last)
+  end
+end

--- a/spec/acceptance/pass_evaluator_as_attribute_spec.rb
+++ b/spec/acceptance/pass_evaluator_as_attribute_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe "when passing evaluator as attribute" do
+  before do
+    define_model('Comment', title: :string, post_id: :integer) do
+      belongs_to :post
+    end
+    define_model('Post', title: :string, user_id: :integer) do
+      has_many :comments
+      belongs_to :user
+    end
+    define_model('User', name: :string) { has_many :posts }
+
+    FactoryGirl.define do
+      factory(:comment) do
+        post { build(:post, comments: [self]) }
+        title { "re: #{post.title}" }
+      end
+
+      factory(:post) do
+        user { build :user, posts: [self] }
+        comments { build_list(:comment, 1, post: self) }
+        title { "Through #{user.name}'s Looking Glass" }
+      end
+
+      factory(:user) do |user|
+        name 'Macguffin'
+        posts { build_list(:post, 1, user: self) }
+      end
+    end
+  end
+
+  it "will save the instance" do
+    FactoryGirl.create(:user)
+    expect(Comment.last.title).to eq("re: Through Macguffin's Looking Glass")
+  end
+
+  it "saves correctly going the opposite way up the assn chain" do
+    FactoryGirl.create(:comment)
+    expect(Comment.last.title).to eq("re: Through Macguffin's Looking Glass")
+  end
+end

--- a/spec/acceptance/pass_evaluator_as_attribute_spec.rb
+++ b/spec/acceptance/pass_evaluator_as_attribute_spec.rb
@@ -11,7 +11,7 @@ describe "when passing evaluator as attribute" do
     end
     define_model("User", name: :string) { has_many :posts }
 
-    FactoryGirl.define do
+    FactoryBot.define do
       factory(:comment) do
         post { build(:post, comments: [self]) }
         title { "re: #{post.title}" }
@@ -31,12 +31,12 @@ describe "when passing evaluator as attribute" do
   end
 
   it "will save the instance" do
-    FactoryGirl.create(:user)
+    FactoryBot.create(:user)
     expect(Comment.last.title).to eq("re: Through Macguffin's Looking Glass")
   end
 
   it "saves correctly going the opposite way up the assn chain" do
-    FactoryGirl.create(:comment)
+    FactoryBot.create(:comment)
     expect(Comment.last.title).to eq("re: Through Macguffin's Looking Glass")
   end
 end

--- a/spec/acceptance/pass_evaluator_as_attribute_spec.rb
+++ b/spec/acceptance/pass_evaluator_as_attribute_spec.rb
@@ -1,15 +1,15 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe "when passing evaluator as attribute" do
   before do
-    define_model('Comment', title: :string, post_id: :integer) do
+    define_model("Comment", title: :string, post_id: :integer) do
       belongs_to :post
     end
-    define_model('Post', title: :string, user_id: :integer) do
+    define_model("Post", title: :string, user_id: :integer) do
       has_many :comments
       belongs_to :user
     end
-    define_model('User', name: :string) { has_many :posts }
+    define_model("User", name: :string) { has_many :posts }
 
     FactoryGirl.define do
       factory(:comment) do
@@ -23,8 +23,8 @@ describe "when passing evaluator as attribute" do
         title { "Through #{user.name}'s Looking Glass" }
       end
 
-      factory(:user) do |user|
-        name 'Macguffin'
+      factory(:user) do
+        name "Macguffin"
         posts { build_list(:post, 1, user: self) }
       end
     end


### PR DESCRIPTION
When building a factory, self in attribute blocks feels like it should
somehow be related to the instance. This commit allows self to be passed
like the instance. This allow for a more fluid definition of factories
in which you can pass self, and then on the other side access attributes
like they already exist.

In the specs you can see that the comment factory uses the post title,
despite the post title being in a delayed execution block which I think
is a huge deal for enabling simpler factories and could allow for 95% of
callback related code to be deleted.