### PR TITLE
Avoid id collisions with build_stubbed

### DIFF
--- a/lib/factory_girl.rb
+++ b/lib/factory_girl.rb
@@ -84,6 +84,7 @@ module FactoryGirl
              :allow_class_lookup=,
              :use_parent_strategy,
              :use_parent_strategy=,
+             :build_stubbed_starting_id=,
              to: :configuration
   end
 

--- a/lib/factory_girl/configuration.rb
+++ b/lib/factory_girl/configuration.rb
@@ -33,5 +33,9 @@ module FactoryGirl
     def duplicate_attribute_assignment_from_initialize_with=(value)
       ActiveSupport::Deprecation.warn 'Assignment of duplicate_attribute_assignment_from_initialize_with is unnecessary as this is now default behavior in FactoryGirl 4.0; this line can be removed', caller
     end
+
+    def build_stubbed_starting_id=(starting_id)
+      Strategy::Stub.next_id = starting_id - 1
+    end
   end
 end

--- a/lib/factory_girl/strategy/stub.rb
+++ b/lib/factory_girl/strategy/stub.rb
@@ -39,6 +39,10 @@ module FactoryGirl
         end
       end
 
+      def self.next_id=(id)
+        @@next_id = id
+      end
+
       private
 
       def next_id

--- a/spec/acceptance/build_stubbed_spec.rb
+++ b/spec/acceptance/build_stubbed_spec.rb
@@ -206,3 +206,18 @@ describe 'defaulting `id`' do
     expect(FactoryGirl.build_stubbed(:post, id: 12).id).to eq 12
   end
 end
+
+describe "configuring the starting id" do
+  before do
+    define_model("Post")
+
+    FactoryGirl.define do
+      factory :post
+    end
+  end
+
+  it "defines which id build_stubbed instances start with" do
+    FactoryGirl.build_stubbed_starting_id = 3000
+    expect(FactoryGirl.build_stubbed(:post).id).to eq 3000
+  end
+end


### PR DESCRIPTION
Hi there!

Thanks for building FactoryGirl. :) We've recently had failing builds because of id collisions between records created with `FactoryGirl.create` and `FactoryGirl.build_stubbed`.

Without changing the way ids are generated by the stub strategy, this should keep us safe for a while. :)