### PR TITLE
Failing spec for trait with same name as factory

### DIFF
--- a/spec/acceptance/traits_spec.rb
+++ b/spec/acceptance/traits_spec.rb
@@ -725,3 +725,36 @@ describe "traits used in associations" do
     expect(creator.name).to eq 'Joe Creator'
   end
 end
+
+describe "associations set in traits" do
+  before do
+    define_model("Person", name: :string)
+
+    define_model("Book", name: :string, author_id: :integer) do
+      belongs_to :author, class_name: "Person"
+    end
+
+    FactoryGirl.define do
+      factory :person do
+        name "Ploni"
+      end
+
+      factory :bob, parent: :person do
+        name "Bob"
+      end
+
+      factory :book do
+        association :author, factory: :person
+      end
+
+      trait :bob do
+        association :author, factory: :bob
+      end
+    end
+  end
+
+  it "a trait can be used that has the same name as a factory" do
+    book = FactoryGirl.create(:book, :bob)
+    expect(book.author.name).to eq("Bob")
+  end
+end


### PR DESCRIPTION
After upgrading from 2.6.4 → 4.8.0 we started getting a "Self-referencing association" error.  The problem is that the trait in question had the same name as a factory, as this spec illustrates.