### PR TITLE
Raise helpful error when block given to association

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+Unreleased
+  Add helpful error when confused user gives block to `association`
+
 4.8.0 (December 16, 2016)
   Improve documentation
   Add `FactoryGirl.generate_list` to be consistent with `build_list`/`create_list` and friends

--- a/lib/factory_girl/definition_proxy.rb
+++ b/lib/factory_girl/definition_proxy.rb
@@ -1,5 +1,7 @@
 module FactoryGirl
   class DefinitionProxy
+    E_ASSOC_NO_BLOCK = "In factory definitions, the association method " \
+      "does not accept blocks".freeze
     UNPROXIED_METHODS = %w(__send__ __id__ nil? send object_id extend instance_eval initialize block_given? raise caller method)
 
     (instance_methods + private_instance_methods).each do |method|
@@ -148,6 +150,7 @@ module FactoryGirl
     #    name of the factory. For example, a "user" association will by
     #    default use the "user" factory.
     def association(name, *options)
+      raise E_ASSOC_NO_BLOCK if block_given?
       @definition.declare_attribute(Declaration::Association.new(name, *options))
     end
 

--- a/spec/factory_girl/definition_proxy_spec.rb
+++ b/spec/factory_girl/definition_proxy_spec.rb
@@ -119,6 +119,14 @@ describe FactoryGirl::DefinitionProxy, "#association" do
     proxy.association(:association_name, { name: "Awesome" })
     expect(subject).to have_association_declaration(:association_name).with_options(name: "Awesome")
   end
+
+  context "a confused user provides a block" do
+    it "raises a helpful error" do
+      expect do
+        proxy.association(:association_name) { i_am_a_confused_user }
+      end.to raise_error(FactoryGirl::DefinitionProxy::E_ASSOC_NO_BLOCK)
+    end
+  end
 end
 
 describe FactoryGirl::DefinitionProxy, "adding callbacks" do


### PR DESCRIPTION
> Arguably, association should raise and let the developer know
> they're using it in an unexpected way. I'd love to see a PR for
> that (with a test!), so if you're interested in contributing that,
> please do!
> https://github.com/thoughtbot/factory_girl/issues/1032#issuecomment-329297006