### PR TITLE
clarify project name change links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@ factory_bot is a fixtures replacement with a straightforward definition syntax, 
 If you want to use factory_bot with Rails, see
 [factory_bot_rails](https://github.com/thoughtbot/factory_bot_rails).
 
-**A historical note:** factory_bot used to be named factory_girl. An explanation of the name change can be found in the [old factory_girl repository](https://github.com/thoughtbot/factory_girl).
-
-_[Interested in the project name?](NAME.md)._
+**A historical note:** factory_bot [used to be named factory_girl](NAME.md). Read [this comment thread](https://github.com/thoughtbot/factory_bot/issues/921#issuecomment-231735985) for some of the reasoning behind the name change.
 
 Documentation
 -------------


### PR DESCRIPTION
The README referred to NAME.md in the old repository, which now redirects to the new repository, and had a separate "Interested in the name change?" link which pointed to the same NAME.md file in the current repository -- confusing! This commit copyedits that section to more clearly link to both the old explanation and the github issue thread which initially discussed changing the name.