### PR TITLE
Allow timestamp assignment in stubbed models

### DIFF
--- a/lib/factory_bot/strategy/stub.rb
+++ b/lib/factory_bot/strategy/stub.rb
@@ -76,6 +76,10 @@ module FactoryBot
             def created_at
               @created_at ||= Time.now.in_time_zone
             end
+
+            def created_at=(date)
+              @created_at = date
+            end
           end
         end
 
@@ -87,6 +91,10 @@ module FactoryBot
           result_instance.instance_eval do
             def updated_at
               @updated_at ||= Time.current
+            end
+
+            def updated_at=(date)
+              @updated_at = date
             end
           end
         end

--- a/spec/acceptance/build_stubbed_spec.rb
+++ b/spec/acceptance/build_stubbed_spec.rb
@@ -156,6 +156,13 @@ describe "defaulting `created_at`" do
   it "doesn't allow setting created_at on an object that doesn't define it" do
     expect { build_stubbed(:thing_without_timestamp, :created_at => Time.now) }.to raise_error(NoMethodError, /created_at=/)
   end
+
+  it "allows assignment of created_at" do
+    stub = build_stubbed(:thing_with_timestamp)
+    expect(stub.created_at).to eq Time.now
+    stub.created_at = 3.days.ago
+    expect(stub.created_at).to eq 3.days.ago
+  end
 end
 
 describe "defaulting `updated_at`" do
@@ -190,6 +197,13 @@ describe "defaulting `updated_at`" do
     expect do
       build_stubbed(:thing_without_timestamp, updated_at: Time.now)
     end.to raise_error(NoMethodError, /updated_at=/)
+  end
+
+  it "allows assignment of updated_at" do
+    stub = build_stubbed(:thing_with_timestamp)
+    expect(stub.updated_at).to eq Time.now
+    stub.updated_at = 3.days.ago
+    expect(stub.updated_at).to eq 3.days.ago
   end
 end
 


### PR DESCRIPTION
This is in response to the following issue: https://github.com/thoughtbot/factory_bot_rails/issues/233

Consider the following code snippet:

```
model = build_stubbed(:some_model)
timestamp = 1.month.ago
model.created_at = timestamp
expect(model.created_at).to eq(timestamp)
```

FactoryBot will currently fail because the stub only installs a `created_at` method but not a `created_at=` method. As a result, the stub instance variable doesn't get updated.

Incidentally, `timestamp` still gets assigned to the ActiveRecord attribute - it just gets masked by FactoryBot's `created_at`.