### PR TITLE
Enable nonpersisting stub methods

### DIFF
--- a/lib/factory_bot/strategy/stub.rb
+++ b/lib/factory_bot/strategy/stub.rb
@@ -6,12 +6,10 @@ module FactoryBot
       DISABLED_PERSISTENCE_METHODS = [
         :connection,
         :decrement!,
-        :decrement,
         :delete,
         :destroy!,
         :destroy,
         :increment!,
-        :increment,
         :reload,
         :save!,
         :save,

--- a/lib/factory_bot/strategy/stub.rb
+++ b/lib/factory_bot/strategy/stub.rb
@@ -14,7 +14,6 @@ module FactoryBot
         :save!,
         :save,
         :toggle!,
-        :toggle,
         :touch,
         :update!,
         :update,

--- a/spec/acceptance/build_stubbed_spec.rb
+++ b/spec/acceptance/build_stubbed_spec.rb
@@ -9,7 +9,8 @@ describe "a generated stub instance" do
     define_model('Post', title:   :string,
                          body:    :string,
                          age:     :integer,
-                         user_id: :integer) do
+                         user_id: :integer,
+                         is_draft: :boolean) do
       belongs_to :user
     end
 
@@ -79,12 +80,34 @@ describe "a generated stub instance" do
     expect { subject.save }.to raise_error(RuntimeError)
   end
 
-  it "disables increment" do
+  it "disables increment!" do
     expect { subject.increment!(:age) }.to raise_error(RuntimeError)
   end
 
-  it "disables decrement" do
+  it "disables decrement!" do
     expect { subject.decrement!(:age) }.to raise_error(RuntimeError)
+  end
+
+  it "disables toggle!" do
+    expect { subject.toggle!(:is_draft) }.to raise_error(RuntimeError)
+  end
+
+  it "can increment" do
+    subject.age = 1
+    subject.increment(:age)
+    expect(subject.age).to eq(2)
+  end
+
+  it "can decrement" do
+    subject.age = 1
+    subject.decrement(:age)
+    expect(subject.age).to eq(0)
+  end
+
+  it "can toggle" do
+    subject.is_draft = true
+    subject.toggle(:is_draft)
+    expect(subject.is_draft?).to be_falsey
   end
 end
 

--- a/spec/factory_bot/strategy/stub_spec.rb
+++ b/spec/factory_bot/strategy/stub_spec.rb
@@ -54,12 +54,10 @@ describe FactoryBot::Strategy::Stub do
     include_examples "disabled persistence method", :delete
     include_examples "disabled persistence method", :destroy
     include_examples "disabled persistence method", :destroy!
-    include_examples "disabled persistence method", :increment
     include_examples "disabled persistence method", :increment!
     include_examples "disabled persistence method", :reload
     include_examples "disabled persistence method", :save
     include_examples "disabled persistence method", :save!
-    include_examples "disabled persistence method", :toggle
     include_examples "disabled persistence method", :toggle!
     include_examples "disabled persistence method", :touch
     include_examples "disabled persistence method", :update

--- a/spec/factory_bot/strategy/stub_spec.rb
+++ b/spec/factory_bot/strategy/stub_spec.rb
@@ -50,7 +50,6 @@ describe FactoryBot::Strategy::Stub do
     end
 
     include_examples "disabled persistence method", :connection
-    include_examples "disabled persistence method", :decrement
     include_examples "disabled persistence method", :decrement!
     include_examples "disabled persistence method", :delete
     include_examples "disabled persistence method", :destroy


### PR DESCRIPTION
This closes https://github.com/thoughtbot/factory_bot/issues/996, https://github.com/thoughtbot/factory_bot/pull/997

## Overview

As described in #996, there are methods such as `increment`/`decrement` that do not persist but are disabled in FactoryBot. Going through the issues, I saw #997 fixed the issue with `increment`/`decrement`, but `toggle seemed like another reasonable method to enable, so I thought of fixing `toggle` myself.

It turns out after the fact that `toggle` was also addressed in #997. So what I did for this PR is the following:

* Cherry-pick @michaelkoper's commits from #997 
* Update the spec test to cover the newly enabled methods
    * `increment`
    * `decrement`
    * `toggle`