### PR TITLE
Added Unix instructions to upgrade guide from FactoryGirl to FactoryBot

### DIFF
--- a/UPGRADE_FROM_FACTORY_GIRL.md
+++ b/UPGRADE_FROM_FACTORY_GIRL.md
@@ -32,10 +32,18 @@ end
 
 A global find-and-replace of `FactoryGirl` to `FactoryBot` across the codebase
 to replace all references with the new constant should do the trick. For
-example, on OS X:
+example:
+
+### OS X:
 
 ```sh
 grep -e FactoryGirl **/*.rake **/*.rb -s -l | xargs sed -i "" "s|FactoryGirl|FactoryBot|"
+```
+
+### Unix:
+
+```sh
+grep -r FactoryGirl --include=\*.rb --include=\*.rake -l | xargs -r sed -i -e 's|FactoryGirl|FactoryBot|'
 ```
 
 ## Replace All Path References
@@ -43,6 +51,14 @@ grep -e FactoryGirl **/*.rake **/*.rb -s -l | xargs sed -i "" "s|FactoryGirl|Fac
 If you're requiring files from factory\_girl or factory\_girl\_rails directly,
 you'll have to update the paths.
 
+### OS X:
+
 ```sh
 grep -e factory_girl **/*.rake **/*.rb -s -l | xargs sed -i "" "s|factory_girl|factory_bot|"
+```
+
+### Unix:
+
+```sh
+grep -r factory_girl --include=\*.rb --include=\*.rake -l | xargs -r sed -i -e 's|factory_girl|factory_bot|'
 ```


### PR DESCRIPTION
The new 4.9.0 version issues a deprecation warning when I run my tests, and tell me to go to [UPGRADE_FROM_FACTORY_GIRL.md](https://github.com/thoughtbot/factory_bot/blob/v4.9.0/UPGRADE_FROM_FACTORY_GIRL.md) to see how to upgrade.

This page contains an example grep + sed command to automatically do the job for you. However it didn't work for me running Ubuntu 16.04.

I then fixed the command to work on Unix and made this patch to add the unix example command.