### PR TITLE
Rewinding all sequences and not just the global ones

### DIFF
--- a/lib/factory_bot.rb
+++ b/lib/factory_bot.rb
@@ -107,6 +107,14 @@ module FactoryBot
     sequence
   end
 
+  def self.register_sequence_uuid(sequence)
+    return unless sequence
+    sequence.uuids.each do |uuid|
+      sequences.register(uuid, sequence)
+    end
+    sequence
+  end
+
   def self.sequence_by_name(name)
     sequences.find(name)
   end

--- a/lib/factory_bot/definition_proxy.rb
+++ b/lib/factory_bot/definition_proxy.rb
@@ -121,6 +121,7 @@ module FactoryBot
     # Except that no globally available sequence will be defined.
     def sequence(name, *args, &block)
       sequence = Sequence.new(name, *args, &block)
+      FactoryBot.register_sequence_uuid(sequence)
       add_attribute(name) { increment_sequence(sequence) }
     end
 

--- a/lib/factory_bot/sequence.rb
+++ b/lib/factory_bot/sequence.rb
@@ -20,8 +20,9 @@ module FactoryBot
     end
 
     def uuids
+      proc = @proc || -> {}
       names.map do |name|
-        [name, @proc.try(:object_id)].join
+        [name, proc.try(:to_s)].join
       end
     end
 

--- a/lib/factory_bot/sequence.rb
+++ b/lib/factory_bot/sequence.rb
@@ -19,6 +19,12 @@ module FactoryBot
       end
     end
 
+    def uuids
+      names.map do |name|
+        [name, @proc.try(:object_id)].join
+      end
+    end
+
     def next(scope = nil)
       if @proc && scope
         scope.instance_exec(value, &@proc)

--- a/spec/acceptance/sequence_resetting_spec.rb
+++ b/spec/acceptance/sequence_resetting_spec.rb
@@ -3,6 +3,16 @@ require "spec_helper"
 describe "FactoryBot.rewind_sequences" do
   include FactoryBot::Syntax::Methods
 
+  before do
+    define_model('User', age: :integer)
+    FactoryBot.define do
+      factory :user do
+        sequence(:id)
+        sequence(:age)
+      end
+    end
+  end
+
   it "resets all sequences back to their starting values" do
     FactoryBot.define do
       sequence(:email) { |n| "somebody#{n}@example.com" }
@@ -21,5 +31,32 @@ describe "FactoryBot.rewind_sequences" do
 
     expect(email).to eq "somebody1@example.com"
     expect(name).to eq "Joe"
+  end
+
+  it "resets all sequences back to their starting values for factory specific sequences" do
+    user1 = FactoryBot.create(:user)
+    user2 = FactoryBot.create(:user)
+
+    expect(user1.id).to eq 1
+    expect(user1.age).to eq 1
+
+    expect(user2.id).to eq 2
+    expect(user2.age).to eq 2
+
+    User.destroy_all
+    FactoryBot.rewind_sequences
+
+    user1 = FactoryBot.create(:user)
+    user2 = FactoryBot.create(:user)
+    user3 = FactoryBot.create(:user)
+
+    expect(user1.id).to eq 1
+    expect(user1.age).to eq 1
+
+    expect(user2.id).to eq 2
+    expect(user2.age).to eq 2
+
+    expect(user3.id).to eq 3
+    expect(user3.age).to eq 3
   end
 end

--- a/spec/acceptance/sequence_resetting_spec.rb
+++ b/spec/acceptance/sequence_resetting_spec.rb
@@ -11,6 +11,15 @@ describe "FactoryBot.rewind_sequences" do
         sequence(:age)
       end
     end
+
+    define_model("Project", number: :integer)
+    FactoryBot.define do
+      factory :project do
+        sequence(:id)
+        sequence(:number)
+      end
+    end
+
   end
 
   it "resets all sequences back to their starting values" do
@@ -58,5 +67,49 @@ describe "FactoryBot.rewind_sequences" do
 
     expect(user3.id).to eq 3
     expect(user3.age).to eq 3
+  end
+
+  it "resets without conflict with other factories" do
+    # Create users
+    user1 = FactoryBot.create(:user)
+    user2 = FactoryBot.create(:user)
+
+    expect(user1.id).to eq 1
+    expect(user1.age).to eq 1
+
+    expect(user2.id).to eq 2
+    expect(user2.age).to eq 2
+
+    # Create projects
+    project1 = FactoryBot.create(:project)
+    project2 = FactoryBot.create(:project)
+
+    expect(project1.id).to eq 1
+    expect(project1.number).to eq 1
+
+    expect(project2.id).to eq 2
+    expect(project2.number).to eq 2
+
+    User.destroy_all
+    Project.destroy_all
+    FactoryBot.rewind_sequences
+
+    user1 = FactoryBot.create(:user)
+    user2 = FactoryBot.create(:user)
+    expect(user1.id).to eq 1
+    expect(user1.age).to eq 1
+
+    expect(user2.id).to eq 2
+    expect(user2.age).to eq 2
+
+    # Create projects
+    project1 = FactoryBot.create(:project)
+    project2 = FactoryBot.create(:project)
+
+    expect(project1.id).to eq 1
+    expect(project1.number).to eq 1
+
+    expect(project2.id).to eq 2
+    expect(project2.number).to eq 2
   end
 end

--- a/spec/acceptance/sequence_resetting_spec.rb
+++ b/spec/acceptance/sequence_resetting_spec.rb
@@ -4,7 +4,7 @@ describe "FactoryBot.rewind_sequences" do
   include FactoryBot::Syntax::Methods
 
   before do
-    define_model('User', age: :integer)
+    define_model("User", age: :integer)
     FactoryBot.define do
       factory :user do
         sequence(:id)
@@ -33,7 +33,7 @@ describe "FactoryBot.rewind_sequences" do
     expect(name).to eq "Joe"
   end
 
-  it "resets all sequences back to their starting values for factory specific sequences" do
+  it "resets sequences back to their starting values for factory sequences" do
     user1 = FactoryBot.create(:user)
     user2 = FactoryBot.create(:user)
 

--- a/spec/acceptance/sequence_resetting_spec.rb
+++ b/spec/acceptance/sequence_resetting_spec.rb
@@ -19,7 +19,6 @@ describe "FactoryBot.rewind_sequences" do
         sequence(:number)
       end
     end
-
   end
 
   it "resets all sequences back to their starting values" do


### PR DESCRIPTION
The previous PR (https://github.com/thoughtbot/factory_bot/commit/50eeb67241ea78a6b138eea694a2a25413052f49) added a feature to rewind registered sequences but this one can rewind all sequences for all factories.

You can call `FactoryBot.rewind_sequences` this way:
```ruby
before :all do
  FactoryBot.rewind_sequences
end
```

I had a specific use case with VCR and I needed to have the same model ids (and other attributes) in the requests to be sure the VCR cassettes will always match. Rewind all the sequences at the beginning of the specs was the simplest solution I found.

Let me know what you thing about this.
