### PR TITLE
Update UPGRADE_FROM_FACTORY_GIRL.md

### DIFF
--- a/UPGRADE_FROM_FACTORY_GIRL.md
+++ b/UPGRADE_FROM_FACTORY_GIRL.md
@@ -35,7 +35,7 @@ to replace all references with the new constant should do the trick. For
 example, on OS X:
 
 ```sh
-grep -e FactoryGirl **/*.rake **/*.rb -s -l | xargs sed -i "" "s|FactoryGirl|FactoryBot|"
+grep -e FactoryGirl **/*.rake **/*.rb -s -l | xargs sed -i "" "s|FactoryGirl|FactoryBot|g"
 ```
 
 ## Replace All Path References
@@ -44,5 +44,5 @@ If you're requiring files from factory\_girl or factory\_girl\_rails directly,
 you'll have to update the paths.
 
 ```sh
-grep -e factory_girl **/*.rake **/*.rb -s -l | xargs sed -i "" "s|factory_girl|factory_bot|"
+grep -e factory_girl **/*.rake **/*.rb -s -l | xargs sed -i "" "s|factory_girl|factory_bot"
 ```


### PR DESCRIPTION
The find and replace for `FactoryGirl` to `FactoryBot` needs a `g` to replace multiple occurrences in the same line.

For example. Prior to the change:

`FactoryGirl.create(:book, author: FactoryGirl.create(:author))` became `FactoryBot.create(:book, author: FactoryGirl.create(:author))`

Not the best way to be using factories, but there is probably occurrences like that in legacy apps.