### PR TITLE
Update UPGRADE_FROM_FACTORY_GIRL.md

### DIFF
--- a/UPGRADE_FROM_FACTORY_GIRL.md
+++ b/UPGRADE_FROM_FACTORY_GIRL.md
@@ -35,7 +35,7 @@ to replace all references with the new constant should do the trick. For
 example, on OS X:
 
 ```sh
-grep -e FactoryGirl **/*.rake **/*.rb -s -l | xargs sed -i "" "s|FactoryGirl|FactoryBot|"
+grep -rl -e FactoryGirl --include="*.rake" --include="*.rb" . | xargs sed -i "" "s|FactoryGirl|FactoryBot|"
 ```
 
 ## Replace All Path References
@@ -44,5 +44,5 @@ If you're requiring files from factory\_girl or factory\_girl\_rails directly,
 you'll have to update the paths.
 
 ```sh
-grep -e factory_girl **/*.rake **/*.rb -s -l | xargs sed -i "" "s|factory_girl|factory_bot|"
+grep -rls -e factory_girl --include="*.rake" --include="*.rb" . | xargs sed -i "" "s|factory_girl|factory_bot|"
 ```


### PR DESCRIPTION
At my OS X Yosemite 10.10.5 the grep commands does not work. I have updated them with the versions working for me.