### PR TITLE
Add extra info about requiring helpers in rails

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -46,10 +46,16 @@ RSpec.configure do |config|
 end
 ```
 
-Remember to require the above file in your rails_helper since the support folder isn't eagerly loaded
+Remember to require the above file in your spec_helper since the support folder isn't eagerly loaded
 
 ```ruby
 require 'support/factory_bot'
+```
+
+or if you use rails
+
+```ruby
+require 'factory_bot_rails'
 ```
 
 # Test::Unit


### PR DESCRIPTION
It does not work in rails if you just add require `'support/factory_bot'` to rails helper.