### PR TITLE
Fixes for FactoryBot::Evaluator overrides

### DIFF
--- a/lib/factory_bot/evaluator.rb
+++ b/lib/factory_bot/evaluator.rb
@@ -13,7 +13,7 @@ module FactoryBot
     def initialize(build_strategy, overrides = {})
       @build_strategy = build_strategy
       @overrides = overrides
-      @cached_attributes = overrides
+      @cached_attributes = overrides.dup
       @instance = nil
 
       @overrides.each do |name, value|


### PR DESCRIPTION
- Makes `FactoryBot::Evaluator#__override_names__` be consistent.
- Makes it so you can detect overrides in factory callbacks.
- Lets you pass in a frozen hash of overrides without raising exceptions.

Discovered while using override detection to handle denormalized stuff.
The test is not a good example of the best way to handle the situation
specified in the test, but it does verify the problem.