### PR TITLE
Fix linting Rake task to allow task chaining

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1007,7 +1007,7 @@ namespace :factory_bot do
       end
     else
       system("bundle exec rake factory_bot:lint RAILS_ENV='test'")
-      exit $?.exitstatus
+      fail if $?.exitstatus.nonzero?
     end
   end
 end


### PR DESCRIPTION
The suggested [Rake task for linting factories](https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md#linting-factories) doesn't currently support chaining Rake tasks.

For example, if one's `Rakefile` contains:

```ruby
task default: ["factory_bot:lint", :spec]
```

Regardless of whether the linting passes or fails, the second task will never be executed because the linting task `exit`s:

```ruby
exit $?.exitstatus
```

To allow Rake task chaining it'd be preferable to:

```ruby
fail if $?.exitstatus.nonzero?
```

Rake will not-attempt any following tasks & exit with a non-zero exit status if the linting failed. If the linting passes then following tasks will be run.

If the linting Rake task is run alone then it'll exit with status `0` when linting passes, and status `1` when linting fails - which still meets the requirements of the PR which proposed the [original change](https://github.com/thoughtbot/factory_bot/pull/1011).