### PR TITLE
Add information for ugrading on Ubuntu

### DIFF
--- a/UPGRADE_FROM_FACTORY_GIRL.md
+++ b/UPGRADE_FROM_FACTORY_GIRL.md
@@ -38,11 +38,24 @@ example, on OS X:
 grep -e FactoryGirl **/*.rake **/*.rb -s -l | xargs sed -i "" "s|FactoryGirl|FactoryBot|"
 ```
 
+On Ubuntu (16.04 LTS):
+
+```sh
+grep -i -r FactoryGirl **/* --include=*.rb --include=*.rake -s -l | xargs sed -i "s|FactoryGirl|FactoryBot|"
+```
+
+
 ## Replace All Path References
 
 If you're requiring files from factory\_girl or factory\_girl\_rails directly,
-you'll have to update the paths.
+you'll have to update the paths. For example, on OS X:
 
 ```sh
 grep -e factory_girl **/*.rake **/*.rb -s -l | xargs sed -i "" "s|factory_girl|factory_bot|"
+```
+
+On Ubuntu (16.04 LTS):
+
+```sh
+grep -i -r factory_girl **/* --include=*.rb --include=*.rake -s -l | xargs sed -i "s|factory_girl|factory_bot|"
 ```


### PR DESCRIPTION
Using Ubuntu, I had to slightly modify the shell script to replace all occurrences of factory girl with factory bot. Thought I would share that with everyone.

For grep:
`-r` for recursive
`**/*` to follow all paths in the current directory
`--include` to search only .rb and .rake files
The reason the OS X script was not working is that it was not searching recursively. It was filtering out all directories (only files with .rb or .rake were matched) and therefore only producing a partial list of matches.

For sed: Had to drop the first (empty) string argument.

PS: Awesome gem :heart: 
  