### PR TITLE
Must lock version to previous number to upgrade

### DIFF
--- a/UPGRADE_FROM_FACTORY_GIRL.md
+++ b/UPGRADE_FROM_FACTORY_GIRL.md
@@ -22,7 +22,7 @@ end
 
 # new
 group :development, :test do
-  gem "factory_bot_rails"
+  gem 'factory_bot_rails', '~> 4.8.2'
   # or
   gem "factory_bot"
 end


### PR DESCRIPTION
Until/unless repository owners fix the release schedule to put gems back in synch with 4.9.0