### PR TITLE
Fix greps to do recursive searches during upgrade

### DIFF
--- a/UPGRADE_FROM_FACTORY_GIRL.md
+++ b/UPGRADE_FROM_FACTORY_GIRL.md
@@ -35,7 +35,7 @@ to replace all references with the new constant should do the trick. For
 example, on OS X:
 
 ```sh
-grep -e FactoryGirl **/*.rake **/*.rb -s -l | xargs sed -i "" "s|FactoryGirl|FactoryBot|"
+grep -r -e FactoryGirl --include=\*.{rb,rake} . -s -l | xargs sed -i "" "s|FactoryGirl|FactoryBot|"
 ```
 
 ## Replace All Path References
@@ -44,5 +44,5 @@ If you're requiring files from factory\_girl or factory\_girl\_rails directly,
 you'll have to update the paths.
 
 ```sh
-grep -e factory_girl **/*.rake **/*.rb -s -l | xargs sed -i "" "s|factory_girl|factory_bot|"
+grep -r -e factory_girl --include=\*.{rb,rake} . -s -l | xargs sed -i "" "s|factory_girl|factory_bot|"
 ```


### PR DESCRIPTION
I found the provided `grep` commands to switch FactoryGirl -> FactoryBot weren't finding everything as they didn't search recursively. Hopefully this helps someone else that hasn't updated yet