### PR TITLE
clarify how to include spec/support/factory_bot.rb to avoid confusion

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -30,13 +30,19 @@ Configure your test suite
 
 ### RSpec
 
+If you're using Rails:
+
 ```ruby
 # spec/support/factory_bot.rb
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 end
+```
 
-# RSpec without Rails
+If you're *not* using Rails:
+
+```ruby
+# spec/support/factory_bot.rb
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 
@@ -46,7 +52,7 @@ RSpec.configure do |config|
 end
 ```
 
-Remember to require the above file in your rails_helper since the support folder isn't eagerly loaded
+Remember to require the above file in your rails_helper (spec_helper if not using Rails) since the support folder isn't eagerly loaded
 
 ```ruby
 require 'support/factory_bot'


### PR DESCRIPTION
It's pretty easy to load `spec/support/factory_bot.rb` twice accidentally by including this whole snippet: 

```ruby 
# spec/support/factory_bot.rb
RSpec.configure do |config|
  config.include FactoryBot::Syntax::Methods
end

# RSpec without Rails
RSpec.configure do |config|
  config.include FactoryBot::Syntax::Methods

  config.before(:suite) do
    FactoryBot.find_definitions
  end
end
```

not realizing one is for Rails and one not. This just clarifies the docs to hopefully avoid the mistake I (and [a few others](https://stackoverflow.com/questions/9300231/factory-already-registered-user-factorygirlduplicatedefinitionerror/#answer-41080111)) have made.

Thanks!