### PR TITLE
Fix when FactoryGirl appears twice on same line

### DIFF
--- a/UPGRADE_FROM_FACTORY_GIRL.md
+++ b/UPGRADE_FROM_FACTORY_GIRL.md
@@ -35,7 +35,7 @@ to replace all references with the new constant should do the trick. For
 example, on macOS:
 
 ```sh
-grep -e FactoryGirl **/*.rake **/*.rb -s -l | xargs sed -i "" "s|FactoryGirl|FactoryBot|"
+grep -e FactoryGirl **/*.rake **/*.rb -s -l | xargs sed -i "" "s|FactoryGirl|FactoryBot|g"
 ```
 
 ## Replace All Path References


### PR DESCRIPTION
If a spec has two `FactoryGirl` declarations on the same line, it would only replace the first command. We need to have a `g` to replace all occurrences.