### PR TITLE
FactoryBot.lint exposes original exceptions

### DIFF
--- a/lib/factory_bot/errors.rb
+++ b/lib/factory_bot/errors.rb
@@ -21,5 +21,7 @@ module FactoryBot
   class MethodDefinitionError < RuntimeError; end
 
   # Raised when any factory is considered invalid
-  class InvalidFactoryError < RuntimeError; end
+  class InvalidFactoryError < RuntimeError
+    attr_accessor :exceptions
+  end
 end


### PR DESCRIPTION
When FactoryBot.lint runs into an exception while testing a factory, only the message of that exception is preserved in the error returned by FactoryBot. Without the stack trace of that exception, it can be hard to figure out where the error breaking the factory is originating.

This PR makes the original errors accessible.