### PR TITLE
Run specs in random order

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,4 +29,7 @@ RSpec.configure do |config|
   config.after do
     Timecop.return
   end
+
+  config.order = :random
+  Kernel.srand config.seed
 end


### PR DESCRIPTION
Unless you happen to have `--order random` in `~/.rspec`, the specs weren't being run in random order.

Before:

```
......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 4.27 seconds (files took 0.64273 seconds to load)
598 examples, 0 failures
```

After:

```
Randomized with seed 49665
......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 4.77 seconds (files took 0.65235 seconds to load)
598 examples, 0 failures

Randomized with seed 49665
```