### PR TITLE
Print warning about static attribute deprecation

### DIFF
--- a/lib/factory_bot/definition_proxy.rb
+++ b/lib/factory_bot/definition_proxy.rb
@@ -45,16 +45,7 @@ module FactoryBot
       declaration = if block_given?
         Declaration::Dynamic.new(name, @ignore, block)
       else
-        attribute_caller = caller
-
-        if attribute_caller[0].include?("method_missing")
-          attribute_caller = caller(2)
-        end
-
-        ActiveSupport::Deprecation.warn("Static attributes will be removed in "\
-          "FactoryBot 5.0. Please use dynamic attributes instead. Static "\
-          "attribute=#{name.inspect} value=#{value.inspect}", attribute_caller)
-
+        warn_static_attribute_deprecation(name, value)
         Declaration::Static.new(name, value, @ignore)
       end
 
@@ -179,6 +170,20 @@ module FactoryBot
 
     def initialize_with(&block)
       @definition.define_constructor(&block)
+    end
+
+    private
+
+    def warn_static_attribute_deprecation(name, value)
+      attribute_caller = caller(2)
+
+      if attribute_caller[0].include?("method_missing")
+        attribute_caller = caller(3)
+      end
+
+      ActiveSupport::Deprecation.warn("Static attributes will be removed in "\
+        "FactoryBot 5.0. Please use dynamic attributes instead. Static "\
+        "attribute=#{name.inspect} value=#{value.inspect}", attribute_caller)
     end
   end
 end

--- a/lib/factory_bot/definition_proxy.rb
+++ b/lib/factory_bot/definition_proxy.rb
@@ -45,6 +45,9 @@ module FactoryBot
       declaration = if block_given?
         Declaration::Dynamic.new(name, @ignore, block)
       else
+        ActiveSupport::Deprecation.warn "Static attributes will be removed in "\
+          "FactoryBot 5.0. Please use dynamic attributes instead. Static "\
+          "variable used for attribute=#{name} value=#{value}"
         Declaration::Static.new(name, value, @ignore)
       end
 

--- a/lib/factory_bot/definition_proxy.rb
+++ b/lib/factory_bot/definition_proxy.rb
@@ -45,9 +45,16 @@ module FactoryBot
       declaration = if block_given?
         Declaration::Dynamic.new(name, @ignore, block)
       else
-        ActiveSupport::Deprecation.warn "Static attributes will be removed in "\
+        attribute_caller = caller
+
+        if attribute_caller[0].include?("method_missing")
+          attribute_caller = caller(2)
+        end
+
+        ActiveSupport::Deprecation.warn("Static attributes will be removed in "\
           "FactoryBot 5.0. Please use dynamic attributes instead. Static "\
-          "variable used for attribute=#{name} value=#{value}"
+          "attribute=#{name.inspect} value=#{value.inspect}", attribute_caller)
+
         Declaration::Static.new(name, value, @ignore)
       end
 

--- a/spec/acceptance/static_attribute_deprecation_spec.rb
+++ b/spec/acceptance/static_attribute_deprecation_spec.rb
@@ -1,0 +1,37 @@
+describe "static attribute deprecation warnings" do
+  context "using #add_attribute" do
+    it "prints where attribute is declared" do
+      define_model("User", name: :string)
+
+      declare_factory = Proc.new do
+        FactoryBot.define do
+          factory :user do
+            add_attribute(:name, "alice")
+          end
+        end
+      end
+
+      expect(declare_factory).to output(
+        /called from .*static_attribute_deprecation_spec\.rb:9/m
+      ).to_stderr
+    end
+  end
+
+  context "an implicit attribute via method missing" do
+    it "prints where attribute is declared" do
+      define_model("User", name: :string)
+
+      declare_factory = Proc.new do
+        FactoryBot.define do
+          factory :user do
+            name "Alice"
+          end
+        end
+      end
+
+      expect(declare_factory).to output(
+        /called from .*static_attribute_deprecation_spec\.rb:27/m
+      ).to_stderr
+    end
+  end
+end


### PR DESCRIPTION
On `stderr` a message will be displayed like:

```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic attributes instead. Static attribute=:rockstar value=true (called from block (5 levels) in <top (required)> at /Users/oli/workspace/factory_bot/spec/acceptance/transient_attributes_spec.rb:11)
```

The caller / callsite in the message is set to where the attribute is declared. 

For further background on the motivation behind this change, see this commit: https://github.com/thoughtbot/factory_bot/commit/eaf2b403f35b2b7c9a014675d15d8b2646bd0601