### PR TITLE
Adds require factory_bot

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -32,6 +32,7 @@ Configure your test suite
 
 ```ruby
 # spec/support/factory_bot.rb
+require 'factory_bot'
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
Without requiring factory_bot, on a fresh Rails 5 installation, you get an uninitialized constant FactoryBot error when trying to run rspec as per the docs.

See https://stackoverflow.com/a/48091777/592229 for others experiencing the same issue.