### PR TITLE
Simplify RSpec configuration instructions

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -30,13 +30,17 @@ Configure your test suite
 
 ### RSpec
 
+If you're using Rails:
+
 ```ruby
-# spec/support/factory_bot.rb
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 end
+```
 
-# RSpec without Rails
+If you're *not* using Rails:
+
+```ruby
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 
@@ -44,12 +48,6 @@ RSpec.configure do |config|
     FactoryBot.find_definitions
   end
 end
-```
-
-Remember to require the above file in your rails_helper since the support folder isn't eagerly loaded
-
-```ruby
-require 'support/factory_bot'
 ```
 
 ### Test::Unit


### PR DESCRIPTION
As noted in the original PR #1105, separating the Rails and non-Rails
configurations makes it easier to copy and paste.

We are also removing the bit about requiring `support/factory_bot`. I
think think it is outside the scope of this documentation to suggest
splitting of RSpec configuration into multiple files. We don't specify
file names for the other test configurations. Also, this line has
led to more confusion than it is probably worth, and has come up
in several PRs: #987, #1025, #1081, #1085, and #1091.

Co-authored-by: Jarvis Johnson <jarviscjohnson@gmail.com>
Co-authored-by: Daniel Colson <danieljamescolson@gmail.com>