### PR TITLE
Inherit from BasicObject instead of undefining

### DIFF
--- a/spec/factory_bot/definition_proxy_spec.rb
+++ b/spec/factory_bot/definition_proxy_spec.rb
@@ -79,6 +79,17 @@ describe FactoryBot::DefinitionProxy, "#method_missing" do
     proxy.attribute_name(&attribute_value)
     expect(subject).to have_dynamic_declaration(:attribute_name).with_value(attribute_value)
   end
+
+  it "handles methods added to Kernel" do
+    Kernel.send(:define_method, :method_added_to_kernel) { |arg| }
+
+    proxy.method_added_to_kernel
+
+    expect(subject).to have_implicit_declaration(:method_added_to_kernel).
+      with_factory(subject)
+
+    Kernel.send(:undef_method, :method_added_to_kernel)
+  end
 end
 
 describe FactoryBot::DefinitionProxy, "#sequence" do


### PR DESCRIPTION
`FactoryBot::DefinitionProxy` currently undefines all but a few methods.
Instead, it can inherit from `BasicObject` and then get any other methods
it needs (`#block_given?` and `#raise` are it as far as I can tell)
directly from `Kernel`.

This way if somebody adds a method to Kernel after loading a factory
that has an attribute of the same name as that method, there is still
some hope their code might work. (Of course nobody is ever adding
methods to Kernel, right?)