### PR TITLE
Include rubocop-rspec autocorrect in deprecation

### DIFF
--- a/lib/factory_bot/definition_proxy.rb
+++ b/lib/factory_bot/definition_proxy.rb
@@ -181,9 +181,21 @@ module FactoryBot
         attribute_caller = caller(3)
       end
 
-      ActiveSupport::Deprecation.warn("Static attributes will be removed in "\
-        "FactoryBot 5.0. Please use dynamic attributes instead. Static "\
-        "attribute=#{name.inspect} value=#{value.inspect}", attribute_caller)
+      ActiveSupport::Deprecation.warn(<<-MSG, attribute_caller)
+Static attributes will be removed in FactoryBot 5.0. Please use dynamic
+attributes instead by wrapping the attribute value in a block:
+
+#{name} { #{value.inspect} }
+
+To automatically update from static attributes to dynamic ones,
+install rubocop-rspec and run:
+
+rubocop \\
+  --require rubocop-rspec \\
+  --only FactoryBot/AttributeDefinedStatically \\
+  --auto-correct
+
+      MSG
     end
   end
 end


### PR DESCRIPTION
Fixes #1160

https://github.com/rubocop-hq/rubocop-rspec/pull/666 was merged. I
would like to wait until the next version of rubocop-rspec is
released, then release factory_bot 4.11 with this deprecation.