### PR TITLE
Don't include extra files in the gem

### DIFF
--- a/factory_bot.gemspec
+++ b/factory_bot.gemspec
@@ -10,7 +10,9 @@ Gem::Specification.new do |s|
                   "using factories - less error-prone, more explicit, and "\
                   "all-around easier to work with than fixtures."
 
-  s.files = Dir.glob("lib/**/*") + %w[GETTING_STARTED.md LICENSE README.md]
+  s.files =
+    Dir.glob("lib/**/*") +
+    %w[CONTRIBUTING.md GETTING_STARTED.md LICENSE NAME.md NEWS README.md]
 
   s.require_path = "lib"
   s.required_ruby_version = Gem::Requirement.new(">= 1.9.2")

--- a/factory_bot.gemspec
+++ b/factory_bot.gemspec
@@ -1,18 +1,18 @@
 $LOAD_PATH << File.expand_path("../lib", __FILE__)
-require 'factory_bot/version'
+require "factory_bot/version"
 
 Gem::Specification.new do |s|
-  s.name        = %q{factory_bot}
+  s.name        = "factory_bot"
   s.version     = FactoryBot::VERSION
-  s.summary     = %q{factory_bot provides a framework and DSL for defining and
-                      using model instance factories.}
-  s.description = %q{factory_bot provides a framework and DSL for defining and
-                      using factories - less error-prone, more explicit, and
-                      all-around easier to work with than fixtures.}
+  s.summary     = "factory_bot provides a framework and DSL for defining and "\
+                  "using model instance factories."
+  s.description = "factory_bot provides a framework and DSL for defining and "\
+                  "using factories - less error-prone, more explicit, and "\
+                  "all-around easier to work with than fixtures."
 
-  s.files         = `git ls-files`.split("\n").reject { |f| f.match(%r{^(spec|features)/}) }
+  s.files = Dir.glob("lib/**/*") + %w[GETTING_STARTED.md LICENSE README.md]
 
-  s.require_path = 'lib'
+  s.require_path = "lib"
   s.required_ruby_version = Gem::Requirement.new(">= 1.9.2")
 
   s.authors = ["Josh Clayton", "Joe Ferris"]
@@ -22,14 +22,14 @@ Gem::Specification.new do |s|
 
   s.add_dependency("activesupport", ">= 3.0.0")
 
+  s.add_development_dependency("activerecord", ">= 3.0.0")
+  s.add_development_dependency("appraisal", "~> 2.1.0")
+  s.add_development_dependency("aruba")
+  s.add_development_dependency("cucumber", "~> 1.3.15")
   s.add_development_dependency("rspec",    "~> 3.0")
   s.add_development_dependency("rspec-its", "~> 1.0")
-  s.add_development_dependency("cucumber", "~> 1.3.15")
-  s.add_development_dependency("timecop")
   s.add_development_dependency("simplecov")
-  s.add_development_dependency("aruba")
-  s.add_development_dependency("appraisal", "~> 2.1.0")
-  s.add_development_dependency("activerecord", ">= 3.0.0")
+  s.add_development_dependency("timecop")
   s.add_development_dependency("yard")
 
   s.license = "MIT"


### PR DESCRIPTION
With `git ls-files` we were still including unneeded dotfiles and
appraisal files. This switches to a whitelist of files included in the
gem, rather than a blacklist. I also tried to make RuboCop happy while I
was in here.