### PR TITLE
Add list of reserved word to getting started guide

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -273,7 +273,7 @@ transient attributes from there.
 Method Name / Reserved Word Attributes
 -------------------------------
 
-If your attributes conflict with existing methods or reserved words you can define them with `add_attribute`.
+If your attributes conflict with existing methods or reserved words (all methods in the [DefinitionProxy](https://github.com/thoughtbot/factory_bot/blob/master/lib/factory_bot/definition_proxy.rb) class) you can define them with `add_attribute`.
 
 ```ruby
 factory :dna do


### PR DESCRIPTION
Fix #1165 

This list does not include private methods and the methods in the ``UNPROXIED_METHODS`` constant. Should we include these as well? It does include delegates and attr_reader.