### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ More Information
 
 You may also find useful information under the [factory_girl tag on Stack Overflow](http://stackoverflow.com/questions/tagged/factory-girl).
 
-[GETTING_STARTED]: http://rubydoc.info/gems/factory_bot/file/GETTING_STARTED.md
+[GETTING_STARTED]: ./GETTING_STARTED.md
 
 Contributing
 ------------


### PR DESCRIPTION
Somehow https://www.rubydoc.info/gems/factory_bot/file/GETTING_STARTED.md is not accessible anymore, I replace it with the link to [GETTING_STARTED.md](./GETTING_STARTED.md)

![screenshot from 2018-09-02 16-43-18](https://user-images.githubusercontent.com/2213646/44954656-59089c80-aecf-11e8-8c51-6843cecaf793.png)
