### PR TITLE
Remove backport for ActiveModel:Dirty

### DIFF
--- a/lib/factory_bot/strategy/stub.rb
+++ b/lib/factory_bot/strategy/stub.rb
@@ -31,7 +31,7 @@ module FactoryBot
       def result(evaluation)
         evaluation.object.tap do |instance|
           stub_database_interaction_on_result(instance)
-          clear_changed_attributes_on_result(instance)
+          clear_changes_information(instance)
           evaluation.notify(:after_stub, instance)
         end
       end
@@ -87,19 +87,10 @@ module FactoryBot
         end
       end
 
-      def clear_changed_attributes_on_result(result_instance)
-        unless result_instance.respond_to?(:clear_changes_information)
-          result_instance.extend ActiveModelDirtyBackport
+      def clear_changes_information(result_instance)
+        if result_instance.respond_to?(:clear_changes_information)
+          result_instance.clear_changes_information
         end
-
-        result_instance.clear_changes_information
-      end
-    end
-
-    module ActiveModelDirtyBackport
-      def clear_changes_information
-        @previously_changed = ActiveSupport::HashWithIndifferentAccess.new
-        @changed_attributes = ActiveSupport::HashWithIndifferentAccess.new
       end
     end
   end


### PR DESCRIPTION
factory_bot 5 only supports Rails 4.2 and higher,
and #clear_changes_information has been around since then
(https://github.com/rails/rails/commit/66d0a0153578ce760d822580c5b8c0b726042ac2).

Fixes #941, since we will are no longer managing any instance variables.