### PR TITLE
Remove deprecated methods

### DIFF
--- a/lib/factory_bot.rb
+++ b/lib/factory_bot.rb
@@ -80,8 +80,6 @@ module FactoryBot
              :skip_create,
              :initialize_with,
              :constructor,
-             :duplicate_attribute_assignment_from_initialize_with,
-             :duplicate_attribute_assignment_from_initialize_with=,
              :allow_class_lookup,
              :allow_class_lookup=,
              :use_parent_strategy,

--- a/lib/factory_bot/configuration.rb
+++ b/lib/factory_bot/configuration.rb
@@ -25,13 +25,5 @@ module FactoryBot
     def initialize_with(&block)
       @definition.define_constructor(&block)
     end
-
-    def duplicate_attribute_assignment_from_initialize_with
-      false
-    end
-
-    def duplicate_attribute_assignment_from_initialize_with=(value)
-      ActiveSupport::Deprecation.warn 'Assignment of duplicate_attribute_assignment_from_initialize_with is unnecessary as this is now default behavior in FactoryBot 4.0; this line can be removed', caller
-    end
   end
 end

--- a/lib/factory_bot/definition_proxy.rb
+++ b/lib/factory_bot/definition_proxy.rb
@@ -52,12 +52,6 @@ module FactoryBot
       @definition.declare_attribute(declaration)
     end
 
-    def ignore(&block)
-      ActiveSupport::Deprecation.warn "`#ignore` is deprecated and will be "\
-        "removed in 5.0. Please use `#transient` instead."
-      transient(&block)
-    end
-
     def transient(&block)
       proxy = DefinitionProxy.new(@definition, true)
       proxy.instance_eval(&block)

--- a/spec/acceptance/transient_attributes_spec.rb
+++ b/spec/acceptance/transient_attributes_spec.rb
@@ -65,26 +65,6 @@ describe "transient attributes" do
       expect(rockstar.name).to eq "John 1 - Rockstar"
     end
   end
-
-  context "using aliased 'ignore' method name", :silence_deprecation do
-    before do
-      FactoryBot.define do
-        factory :user_using_ignore, class: User do
-          ignore do
-            honorific "Esteemed"
-          end
-
-          name { "#{honorific} Jane Doe" }
-        end
-      end
-    end
-
-    let(:esteemed) { FactoryBot.create(:user_using_ignore) }
-
-    it "uses the default value of the attribute" do
-      expect(esteemed.name).to eq "Esteemed Jane Doe"
-    end
-  end
 end
 
 describe "transient sequences" do


### PR DESCRIPTION
Since we have started work on factory_bot 5, we no longer need to keep
these deprecated methods around.