### PR TITLE
Changing gem install command to use single quotes to appease Rubocop

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -7,13 +7,13 @@ Update Your Gemfile
 If you're using Rails, you'll need to change the required version of `factory_bot_rails`:
 
 ```ruby
-gem "factory_bot_rails", "~> 4.0"
+gem 'factory_bot_rails', '~> 4.0'
 ```
 
 If you're *not* using Rails, you'll just have to change the required version of `factory_bot`:
 
 ```ruby
-gem "factory_bot", "~> 4.0"
+gem 'factory_bot', '~> 4.0'
 ```
 
 JRuby users: factory_bot works with JRuby starting with 1.6.7.2 (latest stable, as per July 2012).


### PR DESCRIPTION
If you're copying + pasting this into a Gemfile, Rubocop will complain about the double quotes.