### PR TITLE
Manually raise NoMethodError in definition proxy

### DIFF
--- a/lib/factory_bot/definition_proxy.rb
+++ b/lib/factory_bot/definition_proxy.rb
@@ -78,7 +78,9 @@ module FactoryBot
       elsif args.first.respond_to?(:has_key?) && args.first.has_key?(:factory)
         association(name, *args)
       else
-        super(name, *args, &block)
+        raise NoMethodError.new(
+          "undefined method '#{name}' in '#{@definition.name}' factory",
+        )
       end
     end
 

--- a/spec/factory_bot/definition_proxy_spec.rb
+++ b/spec/factory_bot/definition_proxy_spec.rb
@@ -56,9 +56,15 @@ describe FactoryBot::DefinitionProxy, "#method_missing" do
     expect(subject).to have_dynamic_declaration(:attribute_name).with_value(attribute_value)
   end
 
-  it "calls super" do
+  it "raises a NoMethodError" do
+    definition = FactoryBot::Definition.new(:broken)
+    proxy = FactoryBot::DefinitionProxy.new(definition)
+
     invalid_call = -> { proxy.static_attributes_are_gone true }
-    expect(invalid_call).to raise_error(NoMethodError)
+    expect(invalid_call).to raise_error(
+      NoMethodError,
+      "undefined method 'static_attributes_are_gone' in 'broken' factory",
+    )
   end
 end
 


### PR DESCRIPTION
Inside `super` Ruby calls `inspect`, but since we have undefined
`inspect` on the definition proxy we end up declaring an implicit
`inspect` attribute. We do the same thing with `methods` and
`singleton_methods`, and then `inspect` again. By the time we finally
see the NoMethodError, we see it on a
`FactoryBot::Declaration::Implicit` instead of the definition proxy.

By raising the NoMethodError manually we avoid this nonsense and have
the added benefit of showing the name of the factory where the missing
method came from.