### PR TITLE
[Rubocop] Lint Cop Offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,18 +36,6 @@ Lint/RescueException:
   Exclude:
     - 'spec/support/macros/define_constant.rb'
 
-# Offense count: 13
-# Cop supports --auto-correct.
-# Configuration parameters: IgnoreEmptyBlocks, AllowUnusedKeywordArguments.
-Lint/UnusedBlockArgument:
-  Exclude:
-    - 'spec/acceptance/activesupport_instrumentation_spec.rb'
-    - 'spec/acceptance/build_list_spec.rb'
-    - 'spec/acceptance/callbacks_spec.rb'
-    - 'spec/acceptance/create_list_spec.rb'
-    - 'spec/acceptance/sequence_context_spec.rb'
-    - 'spec/factory_bot/factory_spec.rb'
-
 # Offense count: 5
 # Cop supports --auto-correct.
 # Configuration parameters: AllowUnusedKeywordArguments, IgnoreEmptyMethods.
@@ -158,12 +146,12 @@ Style/HashSyntax:
     - 'spec/acceptance/transient_attributes_spec.rb'
 
 # Offense count: 4
-Style/MethodMissing:
-  Exclude:
-    - 'lib/factory_bot/decorator.rb'
-    - 'lib/factory_bot/decorator/invocation_tracker.rb'
-    - 'lib/factory_bot/definition_proxy.rb'
-    - 'lib/factory_bot/evaluator.rb'
+# Style/MethodMissing:
+#   Exclude:
+#     - 'lib/factory_bot/decorator.rb'
+#     - 'lib/factory_bot/decorator/invocation_tracker.rb'
+#     - 'lib/factory_bot/definition_proxy.rb'
+#     - 'lib/factory_bot/evaluator.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,12 +31,6 @@ Layout/IndentHeredoc:
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: space
 
-# Offense count: 2
-Lint/UselessAssignment:
-  Exclude:
-    - 'lib/factory_bot/declaration_list.rb'
-    - 'spec/factory_bot/evaluator_class_definer_spec.rb'
-
 # Offense count: 1
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,16 +31,6 @@ Layout/IndentHeredoc:
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: space
 
-# Offense count: 5
-# Cop supports --auto-correct.
-# Configuration parameters: AllowUnusedKeywordArguments, IgnoreEmptyMethods.
-Lint/UnusedMethodArgument:
-  Exclude:
-    - 'lib/factory_bot/evaluator.rb'
-    - 'lib/factory_bot/null_object.rb'
-    - 'lib/factory_bot/syntax/default.rb'
-    - 'spec/acceptance/activesupport_instrumentation_spec.rb'
-
 # Offense count: 2
 Lint/UselessAssignment:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,11 +31,6 @@ Layout/IndentHeredoc:
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: space
 
-# Offense count: 1
-Lint/RescueException:
-  Exclude:
-    - 'spec/support/macros/define_constant.rb'
-
 # Offense count: 5
 # Cop supports --auto-correct.
 # Configuration parameters: AllowUnusedKeywordArguments, IgnoreEmptyMethods.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -125,12 +125,12 @@ Style/HashSyntax:
     - 'spec/acceptance/transient_attributes_spec.rb'
 
 # Offense count: 4
-# Style/MethodMissing:
-#   Exclude:
-#     - 'lib/factory_bot/decorator.rb'
-#     - 'lib/factory_bot/decorator/invocation_tracker.rb'
-#     - 'lib/factory_bot/definition_proxy.rb'
-#     - 'lib/factory_bot/evaluator.rb'
+Style/MethodMissing:
+  Exclude:
+    - 'lib/factory_bot/decorator.rb'
+    - 'lib/factory_bot/decorator/invocation_tracker.rb'
+    - 'lib/factory_bot/definition_proxy.rb'
+    - 'lib/factory_bot/evaluator.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/lib/factory_bot/declaration_list.rb
+++ b/lib/factory_bot/declaration_list.rb
@@ -39,7 +39,7 @@ module FactoryBot
     end
 
     def to_attributes
-      @declarations.inject([]) { |result, declaration| result += declaration.to_attributes }
+      @declarations.inject([]) { |result, declaration| result + declaration.to_attributes }
     end
 
     def overridable?

--- a/lib/factory_bot/evaluator.rb
+++ b/lib/factory_bot/evaluator.rb
@@ -45,7 +45,7 @@ module FactoryBot
       end
     end
 
-    def respond_to_missing?(method_name, include_private = false)
+    def respond_to_missing?(method_name, _include_private = false)
       @instance.respond_to?(method_name) || SyntaxRunner.new.respond_to?(method_name)
     end
 

--- a/lib/factory_bot/null_object.rb
+++ b/lib/factory_bot/null_object.rb
@@ -13,11 +13,11 @@ module FactoryBot
       end
     end
 
-    def respond_to?(method, include_private = false)
+    def respond_to?(method, _include_private = false)
       @methods_to_respond_to.include? method.to_s
     end
 
-    def respond_to_missing?(*args)
+    def respond_to_missing?(*)
       false
     end
   end

--- a/lib/factory_bot/syntax/default.rb
+++ b/lib/factory_bot/syntax/default.rb
@@ -59,7 +59,7 @@ module FactoryBot
       end
 
       class ModifyDSL
-        def factory(name, options = {}, &block)
+        def factory(name, _options = {}, &block)
           factory = FactoryBot.factory_by_name(name)
           proxy = FactoryBot::DefinitionProxy.new(factory.definition.overridable)
           proxy.instance_eval(&block)

--- a/spec/acceptance/activesupport_instrumentation_spec.rb
+++ b/spec/acceptance/activesupport_instrumentation_spec.rb
@@ -1,6 +1,6 @@
 unless ActiveSupport::Notifications.respond_to?(:subscribed)
   module SubscribedBehavior
-    def subscribed(callback, *args, &_block)
+    def subscribed(callback, *args)
       subscriber = subscribe(*args, &callback)
       yield
     ensure

--- a/spec/acceptance/activesupport_instrumentation_spec.rb
+++ b/spec/acceptance/activesupport_instrumentation_spec.rb
@@ -1,6 +1,6 @@
 unless ActiveSupport::Notifications.respond_to?(:subscribed)
   module SubscribedBehavior
-    def subscribed(callback, *args, &block)
+    def subscribed(callback, *args, &_block)
       subscriber = subscribe(*args, &callback)
       yield
     ensure

--- a/spec/acceptance/activesupport_instrumentation_spec.rb
+++ b/spec/acceptance/activesupport_instrumentation_spec.rb
@@ -29,7 +29,7 @@ describe "using ActiveSupport::Instrumentation to track factory interaction" do
 
   it "tracks proper time of creating the record" do
     time_to_execute = 0
-    callback = ->(name, start, finish, id, payload) { time_to_execute = finish - start }
+    callback = ->(_name, start, finish, _id, _payload) { time_to_execute = finish - start }
     ActiveSupport::Notifications.subscribed(callback, "factory_bot.run_factory") do
       FactoryBot.build(:slow_user)
     end
@@ -40,7 +40,7 @@ describe "using ActiveSupport::Instrumentation to track factory interaction" do
   it "builds the correct payload" do
     tracked_invocations = {}
 
-    callback = ->(name, start, finish, id, payload) do
+    callback = ->(_name, _start, _finish, _id, payload) do
       factory_name = payload[:name]
       strategy_name = payload[:strategy]
       factory = payload[:factory]

--- a/spec/acceptance/build_list_spec.rb
+++ b/spec/acceptance/build_list_spec.rb
@@ -46,7 +46,7 @@ describe "build multiple instances" do
     end
 
     it "correctly uses the set value" do
-      subject.each_with_index do |record, index|
+      subject.each do |record|
         expect(record.position).to eq record.id
       end
     end

--- a/spec/acceptance/callbacks_spec.rb
+++ b/spec/acceptance/callbacks_spec.rb
@@ -81,7 +81,7 @@ describe "callbacks using syntax methods without referencing FactoryBot explicit
       factory :user do
         after(:stub)   { generate(:sequence_3) }
         after(:build)  { |user| user.first_number = generate(:sequence_1) }
-        after(:create) { |user, evaluator| user.last_number = generate(:sequence_2) }
+        after(:create) { |user, _evaluator| user.last_number = generate(:sequence_2) }
       end
     end
   end

--- a/spec/acceptance/create_list_spec.rb
+++ b/spec/acceptance/create_list_spec.rb
@@ -46,7 +46,7 @@ describe "create multiple instances" do
     end
 
     it "uses the new values" do
-      subject.each_with_index do |record, index|
+      subject.each do |record|
         expect(record.position).to eq record.id
       end
     end

--- a/spec/acceptance/sequence_context_spec.rb
+++ b/spec/acceptance/sequence_context_spec.rb
@@ -22,7 +22,7 @@ describe 'sequences are evaluated in the correct context' do
   it 'invokes the correct method on the instance' do
     FactoryBot.define do
       factory :sequence_with_public_method, class: User do
-        sequence(:id) { |_n| public_method(:awesome).call }
+        sequence(:id) { public_method(:awesome).call }
       end
     end
 
@@ -32,7 +32,7 @@ describe 'sequences are evaluated in the correct context' do
   it 'invokes a method with no arguments on the instance' do
     FactoryBot.define do
       factory :sequence_with_frozen, class: User do
-        sequence(:id) { |_n| frozen? }
+        sequence(:id) { frozen? }
       end
     end
 

--- a/spec/acceptance/sequence_context_spec.rb
+++ b/spec/acceptance/sequence_context_spec.rb
@@ -22,7 +22,7 @@ describe 'sequences are evaluated in the correct context' do
   it 'invokes the correct method on the instance' do
     FactoryBot.define do
       factory :sequence_with_public_method, class: User do
-        sequence(:id) { |n| public_method(:awesome).call }
+        sequence(:id) { |_n| public_method(:awesome).call }
       end
     end
 
@@ -32,7 +32,7 @@ describe 'sequences are evaluated in the correct context' do
   it 'invokes a method with no arguments on the instance' do
     FactoryBot.define do
       factory :sequence_with_frozen, class: User do
-        sequence(:id) { |n| frozen? }
+        sequence(:id) { |_n| frozen? }
       end
     end
 

--- a/spec/factory_bot/evaluator_class_definer_spec.rb
+++ b/spec/factory_bot/evaluator_class_definer_spec.rb
@@ -13,11 +13,6 @@ describe FactoryBot::EvaluatorClassDefiner do
   end
 
   it "evaluates the block in the context of the evaluator" do
-    double(
-      "dependency",
-      name: :dependency,
-      to_proc: -> { 1 },
-    )
     dependency_attribute = stub_attribute(:dependency) { 1 }
     attribute = stub_attribute(:attribute) { dependency + 1 }
     evaluator = define_evaluator(attributes: [dependency_attribute, attribute])

--- a/spec/factory_bot/evaluator_class_definer_spec.rb
+++ b/spec/factory_bot/evaluator_class_definer_spec.rb
@@ -13,7 +13,7 @@ describe FactoryBot::EvaluatorClassDefiner do
   end
 
   it "evaluates the block in the context of the evaluator" do
-    dependency_attribute = double(
+    double(
       "dependency",
       name: :dependency,
       to_proc: -> { 1 },

--- a/spec/factory_bot/factory_spec.rb
+++ b/spec/factory_bot/factory_spec.rb
@@ -259,7 +259,7 @@ describe FactoryBot::Factory, "running a factory" do
 
   it "calls the block and returns the result" do
     block_run = nil
-    block = ->(result) { block_run = "changed" }
+    block = ->(_result) { block_run = "changed" }
     subject.run(FactoryBot::Strategy::Build, {}, &block)
     expect(block_run).to eq "changed"
   end

--- a/spec/support/macros/define_constant.rb
+++ b/spec/support/macros/define_constant.rb
@@ -28,9 +28,9 @@ module DefineConstantMacros
       connection.create_table(table_name, &block)
       @created_tables << table_name
       connection
-    rescue StandardError => error
+    rescue Exception => exception # rubocop:disable Lint/RescueException
       connection.execute("DROP TABLE IF EXISTS #{table_name}")
-      raise error
+      raise exception
     end
   end
 

--- a/spec/support/macros/define_constant.rb
+++ b/spec/support/macros/define_constant.rb
@@ -28,9 +28,9 @@ module DefineConstantMacros
       connection.create_table(table_name, &block)
       @created_tables << table_name
       connection
-    rescue StandardError => exception
+    rescue StandardError => error
       connection.execute("DROP TABLE IF EXISTS #{table_name}")
-      raise exception
+      raise error
     end
   end
 

--- a/spec/support/macros/define_constant.rb
+++ b/spec/support/macros/define_constant.rb
@@ -28,7 +28,7 @@ module DefineConstantMacros
       connection.create_table(table_name, &block)
       @created_tables << table_name
       connection
-    rescue Exception => exception
+    rescue StandardError => exception
       connection.execute("DROP TABLE IF EXISTS #{table_name}")
       raise exception
     end


### PR DESCRIPTION
Continue addressing #1202

Addresses all of the 'Lint' cops. For most of these fixes, I just used the suggested Rubocop fix, but on some others I took them one step further. For example, using `#each` instead of `#each_with_index` when the index wasn't used.

This is my first time contributing, so let me know if I missed any steps.