### PR TITLE
[Rubocop] Style Cop Offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,12 +92,6 @@ Style/BlockDelimiters:
     - 'spec/**/*'
 
 # Offense count: 1
-# Cop supports --auto-correct.
-Style/ExpandPathArguments:
-  Exclude:
-    - 'factory_bot.gemspec'
-
-# Offense count: 1
 # Configuration parameters: .
 # SupportedStyles: annotated, template, unannotated
 Style/FormatStringToken:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -104,6 +104,12 @@ Style/MethodMissing:
     - 'lib/factory_bot/definition_proxy.rb'
     - 'lib/factory_bot/evaluator.rb'
 
+# Offense count: 1	
+# Cop supports --auto-correct.	
+Style/RedundantBegin:	
+  Exclude:	
+    - 'lib/factory_bot/linter.rb'
+
 # Offense count: 308
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -111,15 +111,6 @@ Style/MethodMissing:
 Style/StringLiterals:
   Enabled: false
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: single_quotes, double_quotes
-Style/StringLiteralsInInterpolation:
-  Exclude:
-    - 'lib/factory_bot/strategy/stub.rb'
-    - 'spec/acceptance/transient_attributes_spec.rb'
-
 # Offense count: 21
 # Cop supports --auto-correct.
 # Configuration parameters: MinSize.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,12 +66,6 @@ Style/MethodMissing:
     - 'lib/factory_bot/definition_proxy.rb'
     - 'lib/factory_bot/evaluator.rb'
 
-# Offense count: 1	
-# Cop supports --auto-correct.	
-Style/RedundantBegin:	
-  Exclude:	
-    - 'lib/factory_bot/linter.rb'
-
 # Offense count: 308
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -117,14 +117,6 @@ Style/StringLiterals:
 Style/SymbolArray:
   EnforcedStyle: brackets
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInHashLiteral:
-  Exclude:
-    - 'lib/factory_bot/factory_runner.rb'
-
 # Offense count: 196
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,12 +106,6 @@ Style/MethodMissing:
 
 # Offense count: 1
 # Cop supports --auto-correct.
-Style/MutableConstant:
-  Exclude:
-    - 'lib/factory_bot/definition_proxy.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
 Style/RedundantBegin:
   Exclude:
     - 'lib/factory_bot/linter.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -111,7 +111,6 @@ Style/MethodMissing:
 Style/StringLiterals:
   Enabled: false
 
-# Offense count: 21
 # Cop supports --auto-correct.
 # Configuration parameters: MinSize.
 # SupportedStyles: percent, brackets

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -104,14 +104,6 @@ Style/MethodMissing:
     - 'lib/factory_bot/definition_proxy.rb'
     - 'lib/factory_bot/evaluator.rb'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: implicit, explicit
-Style/RescueStandardError:
-  Exclude:
-    - 'lib/factory_bot/linter.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: ConvertCodeThatCanStartToReturnNil, Whitelist.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,7 +81,6 @@ Naming/MemoizedInstanceVariableName:
   Exclude:
     - 'spec/support/macros/define_constant.rb'
 
-# Offense count: 3
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, IgnoredMethods.
 # SupportedStyles: line_count_based, semantic, braces_for_chaining
@@ -90,9 +89,7 @@ Naming/MemoizedInstanceVariableName:
 # IgnoredMethods: lambda, proc, it
 Style/BlockDelimiters:
   Exclude:
-    - 'spec/acceptance/modify_factories_spec.rb'
-    - 'spec/factory_bot/attribute_list_spec.rb'
-    - 'spec/factory_bot/attribute_spec.rb'
+    - 'spec/**/*'
 
 # Offense count: 3
 # Cop supports --auto-correct.
@@ -145,12 +142,12 @@ Style/HashSyntax:
     - 'spec/acceptance/transient_attributes_spec.rb'
 
 # Offense count: 4
-Style/MethodMissing:
-  Exclude:
-    - 'lib/factory_bot/decorator.rb'
-    - 'lib/factory_bot/decorator/invocation_tracker.rb'
-    - 'lib/factory_bot/definition_proxy.rb'
-    - 'lib/factory_bot/evaluator.rb'
+# Style/MethodMissing:
+#   Exclude:
+#     - 'lib/factory_bot/decorator.rb'
+#     - 'lib/factory_bot/decorator/invocation_tracker.rb'
+#     - 'lib/factory_bot/definition_proxy.rb'
+#     - 'lib/factory_bot/evaluator.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -91,7 +91,6 @@ Style/BlockDelimiters:
   Exclude:
     - 'spec/**/*'
 
-# Offense count: 1
 # Configuration parameters: .
 # SupportedStyles: annotated, template, unannotated
 Style/FormatStringToken:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -117,15 +117,6 @@ Style/StringLiterals:
 Style/SymbolArray:
   EnforcedStyle: brackets
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInArrayLiteral:
-  Exclude:
-    - 'lib/factory_bot/aliases.rb'
-    - 'spec/support/matchers/declaration.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleForMultiline.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -104,12 +104,6 @@ Style/MethodMissing:
     - 'lib/factory_bot/definition_proxy.rb'
     - 'lib/factory_bot/evaluator.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/RedundantSelf:
-  Exclude:
-    - 'lib/factory_bot/factory.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,15 +93,6 @@ Style/BlockDelimiters:
 
 # Offense count: 3
 # Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: braces, no_braces, context_dependent
-Style/BracesAroundHashParameters:
-  Exclude:
-    - 'spec/factory_bot/definition_proxy_spec.rb'
-    - 'spec/support/shared_examples/strategy.rb'
-
-# Offense count: 3
-# Cop supports --auto-correct.
 # Configuration parameters: PreferredMethods.
 Style/CollectionMethods:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -117,17 +117,6 @@ Style/StringLiterals:
 Style/SymbolArray:
   EnforcedStyle: brackets
 
-# Offense count: 5
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInArguments:
-  Exclude:
-    - 'features/support/factories.rb'
-    - 'lib/factory_bot/attribute_assigner.rb'
-    - 'spec/factory_bot/evaluator_class_definer_spec.rb'
-    - 'spec/support/macros/define_constant.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleForMultiline.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,15 +93,6 @@ Style/BlockDelimiters:
 
 # Offense count: 3
 # Cop supports --auto-correct.
-# Configuration parameters: PreferredMethods.
-Style/CollectionMethods:
-  Exclude:
-    - 'lib/factory_bot/attribute_assigner.rb'
-    - 'lib/factory_bot/declaration_list.rb'
-    - 'spec/support/macros/define_constant.rb'
-
-# Offense count: 3
-# Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: compact, expanded
 Style/EmptyMethod:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -117,15 +117,6 @@ Style/StringLiterals:
 Style/SymbolArray:
   EnforcedStyle: brackets
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: IgnoredMethods.
-# IgnoredMethods: respond_to, define_method
-Style/SymbolProc:
-  Exclude:
-    - 'lib/factory_bot/configuration.rb'
-    - 'spec/acceptance/create_spec.rb'
-
 # Offense count: 5
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleForMultiline.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,9 +106,9 @@ Style/MethodMissing:
 
 # Offense count: 1	
 # Cop supports --auto-correct.	
-# Style/RedundantBegin:	
-#   Exclude:	
-#     - 'lib/factory_bot/linter.rb'
+Style/RedundantBegin:	
+  Exclude:	
+    - 'lib/factory_bot/linter.rb'
 
 # Offense count: 308
 # Cop supports --auto-correct.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,12 +106,6 @@ Style/MethodMissing:
 
 # Offense count: 1
 # Cop supports --auto-correct.
-Style/RedundantBegin:
-  Exclude:
-    - 'lib/factory_bot/linter.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
 Style/RedundantSelf:
   Exclude:
     - 'lib/factory_bot/factory.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -96,24 +96,13 @@ Style/BlockDelimiters:
 Style/FormatStringToken:
   EnforcedStyle: unannotated
 
-# Offense count: 24
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
-# SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-Style/HashSyntax:
-  Exclude:
-    - 'Rakefile'
-    - 'spec/acceptance/build_stubbed_spec.rb'
-    - 'spec/acceptance/nested_attributes_spec.rb'
-    - 'spec/acceptance/transient_attributes_spec.rb'
-
 # Offense count: 4
-# Style/MethodMissing:
-#   Exclude:
-#     - 'lib/factory_bot/decorator.rb'
-#     - 'lib/factory_bot/decorator/invocation_tracker.rb'
-#     - 'lib/factory_bot/definition_proxy.rb'
-#     - 'lib/factory_bot/evaluator.rb'
+Style/MethodMissing:
+  Exclude:
+    - 'lib/factory_bot/decorator.rb'
+    - 'lib/factory_bot/decorator/invocation_tracker.rb'
+    - 'lib/factory_bot/definition_proxy.rb'
+    - 'lib/factory_bot/evaluator.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -104,14 +104,6 @@ Style/MethodMissing:
     - 'lib/factory_bot/definition_proxy.rb'
     - 'lib/factory_bot/evaluator.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: ConvertCodeThatCanStartToReturnNil, Whitelist.
-# Whitelist: present?, blank?, presence, try
-Style/SafeNavigation:
-  Exclude:
-    - 'spec/acceptance/overrides_spec.rb'
-
 # Offense count: 308
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -91,15 +91,6 @@ Style/BlockDelimiters:
   Exclude:
     - 'spec/**/*'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: compact, expanded
-Style/EmptyMethod:
-  Exclude:
-    - 'lib/factory_bot/strategy/null.rb'
-    - 'spec/acceptance/attribute_existing_on_object_spec.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 Style/ExpandPathArguments:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,9 +106,9 @@ Style/MethodMissing:
 
 # Offense count: 1	
 # Cop supports --auto-correct.	
-Style/RedundantBegin:	
-  Exclude:	
-    - 'lib/factory_bot/linter.rb'
+# Style/RedundantBegin:	
+#   Exclude:	
+#     - 'lib/factory_bot/linter.rb'
 
 # Offense count: 308
 # Cop supports --auto-correct.

--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ namespace :spec do
 end
 
 desc "Run the unit and acceptance specs"
-task :spec => ['spec:unit', 'spec:acceptance']
+task spec: ['spec:unit', 'spec:acceptance']
 
 Cucumber::Rake::Task.new(:features) do |t|
   t.fork = true

--- a/factory_bot.gemspec
+++ b/factory_bot.gemspec
@@ -1,4 +1,4 @@
-$LOAD_PATH << File.expand_path("../lib", __FILE__)
+$LOAD_PATH << File.expand_path('lib', __dir__)
 require "factory_bot/version"
 
 Gem::Specification.new do |s|

--- a/features/support/factories.rb
+++ b/features/support/factories.rb
@@ -1,6 +1,6 @@
 ActiveRecord::Base.establish_connection(
   adapter: 'sqlite3',
-  database: File.join(File.dirname(__FILE__), 'test.db')
+  database: File.join(File.dirname(__FILE__), 'test.db'),
 )
 
 migration_class =

--- a/lib/factory_bot/aliases.rb
+++ b/lib/factory_bot/aliases.rb
@@ -5,7 +5,7 @@ module FactoryBot
 
   self.aliases = [
     [/(.+)_id/, '\1'],
-    [/(.*)/, '\1_id']
+    [/(.*)/, '\1_id'],
   ]
 
   def self.aliases_for(attribute)

--- a/lib/factory_bot/attribute_assigner.rb
+++ b/lib/factory_bot/attribute_assigner.rb
@@ -36,7 +36,7 @@ module FactoryBot
 
     def decorated_evaluator
       Decorator::InvocationTracker.new(
-        Decorator::NewConstructor.new(@evaluator, @build_class)
+        Decorator::NewConstructor.new(@evaluator, @build_class),
       )
     end
 

--- a/lib/factory_bot/attribute_assigner.rb
+++ b/lib/factory_bot/attribute_assigner.rb
@@ -22,7 +22,7 @@ module FactoryBot
     def hash
       @evaluator.instance = build_hash
 
-      attributes_to_set_on_hash.inject({}) do |result, attribute|
+      attributes_to_set_on_hash.reduce({}) do |result, attribute|
         result[attribute] = get(attribute)
         result
       end

--- a/lib/factory_bot/configuration.rb
+++ b/lib/factory_bot/configuration.rb
@@ -15,7 +15,7 @@ module FactoryBot
 
       @allow_class_lookup = true
 
-      to_create { |instance| instance.save! }
+      to_create(&:save!)
       initialize_with { new }
     end
 

--- a/lib/factory_bot/declaration_list.rb
+++ b/lib/factory_bot/declaration_list.rb
@@ -39,7 +39,7 @@ module FactoryBot
     end
 
     def to_attributes
-      @declarations.inject([]) { |result, declaration| result += declaration.to_attributes }
+      @declarations.reduce([]) { |result, declaration| result += declaration.to_attributes }
     end
 
     def overridable?

--- a/lib/factory_bot/definition_proxy.rb
+++ b/lib/factory_bot/definition_proxy.rb
@@ -1,6 +1,6 @@
 module FactoryBot
   class DefinitionProxy
-    UNPROXIED_METHODS = %w(__send__ __id__ nil? send object_id extend instance_eval initialize block_given? raise caller method)
+    UNPROXIED_METHODS = %w(__send__ __id__ nil? send object_id extend instance_eval initialize block_given? raise caller method).freeze
 
     (instance_methods + private_instance_methods).each do |method|
       undef_method(method) unless UNPROXIED_METHODS.include?(method.to_s)

--- a/lib/factory_bot/factory.rb
+++ b/lib/factory_bot/factory.rb
@@ -91,7 +91,7 @@ module FactoryBot
     end
 
     def with_traits(traits)
-      self.clone.tap do |factory_with_traits|
+      clone.tap do |factory_with_traits|
         factory_with_traits.append_traits traits
       end
     end

--- a/lib/factory_bot/factory_runner.rb
+++ b/lib/factory_bot/factory_runner.rb
@@ -22,7 +22,7 @@ module FactoryBot
         strategy: runner_strategy,
         traits: @traits,
         overrides: @overrides,
-        factory: factory
+        factory: factory,
       }
 
       ActiveSupport::Notifications.instrument('factory_bot.run_factory', instrumentation_payload) do

--- a/lib/factory_bot/linter.rb
+++ b/lib/factory_bot/linter.rb
@@ -56,7 +56,7 @@ module FactoryBot
       result = []
       begin
         FactoryBot.public_send(factory_strategy, factory.name)
-      rescue => error
+      rescue StandardError => error
         result |= [FactoryError.new(error, factory)]
       end
       result
@@ -67,7 +67,7 @@ module FactoryBot
       factory.definition.defined_traits.map(&:name).each do |trait_name|
         
           FactoryBot.public_send(factory_strategy, factory.name, trait_name)
-        rescue => error
+        rescue StandardError => error
           result |=
             [FactoryTraitError.new(error, factory, trait_name)]
         

--- a/lib/factory_bot/linter.rb
+++ b/lib/factory_bot/linter.rb
@@ -65,12 +65,12 @@ module FactoryBot
     def lint_traits(factory)
       result = []
       factory.definition.defined_traits.map(&:name).each do |trait_name|
-        begin
+        
           FactoryBot.public_send(factory_strategy, factory.name, trait_name)
         rescue => error
           result |=
             [FactoryTraitError.new(error, factory, trait_name)]
-        end
+        
       end
       result
     end

--- a/lib/factory_bot/linter.rb
+++ b/lib/factory_bot/linter.rb
@@ -65,12 +65,10 @@ module FactoryBot
     def lint_traits(factory)
       result = []
       factory.definition.defined_traits.map(&:name).each do |trait_name|
-        
-          FactoryBot.public_send(factory_strategy, factory.name, trait_name)
-        rescue StandardError => error
-          result |=
-            [FactoryTraitError.new(error, factory, trait_name)]
-        
+        FactoryBot.public_send(factory_strategy, factory.name, trait_name)
+      rescue StandardError => error
+        result |=
+          [FactoryTraitError.new(error, factory, trait_name)]
       end
       result
     end

--- a/lib/factory_bot/linter.rb
+++ b/lib/factory_bot/linter.rb
@@ -65,12 +65,10 @@ module FactoryBot
     def lint_traits(factory)
       result = []
       factory.definition.defined_traits.map(&:name).each do |trait_name|
-        begin
-          FactoryBot.public_send(factory_strategy, factory.name, trait_name)
-        rescue StandardError => error
-          result |=
-            [FactoryTraitError.new(error, factory, trait_name)]
-        end
+        FactoryBot.public_send(factory_strategy, factory.name, trait_name)
+      rescue StandardError => error
+        result |=
+          [FactoryTraitError.new(error, factory, trait_name)]
       end
       result
     end

--- a/lib/factory_bot/linter.rb
+++ b/lib/factory_bot/linter.rb
@@ -65,10 +65,12 @@ module FactoryBot
     def lint_traits(factory)
       result = []
       factory.definition.defined_traits.map(&:name).each do |trait_name|
-        FactoryBot.public_send(factory_strategy, factory.name, trait_name)
-      rescue StandardError => error
-        result |=
-          [FactoryTraitError.new(error, factory, trait_name)]
+        begin
+          FactoryBot.public_send(factory_strategy, factory.name, trait_name)
+        rescue StandardError => error
+          result |=
+            [FactoryTraitError.new(error, factory, trait_name)]
+        end
       end
       result
     end

--- a/lib/factory_bot/strategy/null.rb
+++ b/lib/factory_bot/strategy/null.rb
@@ -1,11 +1,9 @@
 module FactoryBot
   module Strategy
     class Null
-      def association(runner)
-      end
+      def association(runner); end
 
-      def result(evaluation)
-      end
+      def result(evaluation); end
     end
   end
 end

--- a/lib/factory_bot/strategy/stub.rb
+++ b/lib/factory_bot/strategy/stub.rb
@@ -60,7 +60,7 @@ module FactoryBot
 
           DISABLED_PERSISTENCE_METHODS.each do |write_method|
             define_singleton_method(write_method) do |*args|
-              raise "stubbed models are not allowed to access the database - #{self.class}##{write_method}(#{args.join(",")})"
+              raise "stubbed models are not allowed to access the database - #{self.class}##{write_method}(#{args.join(',')})"
             end
           end
         end

--- a/spec/acceptance/attribute_existing_on_object_spec.rb
+++ b/spec/acceptance/attribute_existing_on_object_spec.rb
@@ -25,8 +25,7 @@ describe "assigning overrides that are also private methods on object" do
     Object.class_eval do
       private
 
-      def some_funky_method(args)
-      end
+      def some_funky_method(args); end
     end
 
     FactoryBot.define do

--- a/spec/acceptance/build_stubbed_spec.rb
+++ b/spec/acceptance/build_stubbed_spec.rb
@@ -176,7 +176,7 @@ describe "defaulting `created_at`" do
   end
 
   it "doesn't allow setting created_at on an object that doesn't define it" do
-    expect { build_stubbed(:thing_without_timestamp, :created_at => Time.now) }.to raise_error(NoMethodError, /created_at=/)
+    expect { build_stubbed(:thing_without_timestamp, created_at: Time.now) }.to raise_error(NoMethodError, /created_at=/)
   end
 end
 

--- a/spec/acceptance/create_spec.rb
+++ b/spec/acceptance/create_spec.rb
@@ -74,9 +74,7 @@ describe "a custom create" do
 
     FactoryBot.define do
       factory :user do
-        to_create do |user|
-          user.persist
-        end
+        to_create(&:persist)
       end
     end
   end

--- a/spec/acceptance/nested_attributes_spec.rb
+++ b/spec/acceptance/nested_attributes_spec.rb
@@ -25,6 +25,6 @@ describe "association assignment from nested attributes" do
   end
 
   it "assigns the correct amount of comments when overridden" do
-    expect(FactoryBot.create(:post, :comments_attributes => [FactoryBot.attributes_for(:comment)]).comments.count).to eq 1
+    expect(FactoryBot.create(:post, comments_attributes: [FactoryBot.attributes_for(:comment)]).comments.count).to eq 1
   end
 end

--- a/spec/acceptance/overrides_spec.rb
+++ b/spec/acceptance/overrides_spec.rb
@@ -7,7 +7,7 @@ describe "attribute overrides" do
       belongs_to :user
 
       def secure=(value)
-        return unless user && user.admin?
+        return unless user&.admin?
         write_attribute(:secure, value)
       end
     end

--- a/spec/acceptance/transient_attributes_spec.rb
+++ b/spec/acceptance/transient_attributes_spec.rb
@@ -115,7 +115,7 @@ describe "assigning values from a transient attribute" do
   end
 
   it "does not ignore an _id attribute that is an alias for a transient attribute" do
-    user = FactoryBot.build(:user, :foo => Foo.new('passed-in-id-of-foo', 'passed-in-name-of-foo'))
+    user = FactoryBot.build(:user, foo: Foo.new('passed-in-id-of-foo', 'passed-in-name-of-foo'))
     expect(user.foo_id).to eq 'passed-in-id-of-foo'
     expect(user.foo_name).to eq 'passed-in-name-of-foo'
   end

--- a/spec/acceptance/transient_attributes_spec.rb
+++ b/spec/acceptance/transient_attributes_spec.rb
@@ -12,7 +12,7 @@ describe "transient attributes" do
           upcased  { false }
         end
 
-        name  { "#{FactoryBot.generate(:name)}#{" - Rockstar" if rockstar}" }
+        name  { "#{FactoryBot.generate(:name)}#{' - Rockstar' if rockstar}" }
         email { "#{name.downcase}#{four}@example.com" }
 
         after(:create) do |user, evaluator|

--- a/spec/factory_bot/definition_proxy_spec.rb
+++ b/spec/factory_bot/definition_proxy_spec.rb
@@ -140,7 +140,7 @@ describe FactoryBot::DefinitionProxy, "#association" do
   end
 
   it "declares an association with options" do
-    proxy.association(:association_name, { name: "Awesome" })
+    proxy.association(:association_name, name: "Awesome")
     expect(subject).to have_association_declaration(:association_name).
       with_options(name: "Awesome")
   end
@@ -206,7 +206,7 @@ describe FactoryBot::DefinitionProxy, "#factory" do
   end
 
   it "with options" do
-    proxy.factory(:child, { awesome: true })
+    proxy.factory(:child, awesome: true)
     expect(proxy.child_factories).to include([:child, { awesome: true }, nil])
   end
 

--- a/spec/factory_bot/evaluator_class_definer_spec.rb
+++ b/spec/factory_bot/evaluator_class_definer_spec.rb
@@ -52,7 +52,7 @@ describe FactoryBot::EvaluatorClassDefiner do
       child_attributes = [stub_attribute, stub_attribute]
       child_evaluator = define_evaluator(
         attributes: child_attributes,
-        parent_class: parent_evaluator_class
+        parent_class: parent_evaluator_class,
       )
 
       expect(child_evaluator.attribute_lists).to eq [parent_attributes, child_attributes]
@@ -67,7 +67,7 @@ describe FactoryBot::EvaluatorClassDefiner do
   def define_evaluator_class(arguments = {})
     evaluator_class_definer = FactoryBot::EvaluatorClassDefiner.new(
       arguments[:attributes] || [],
-      arguments[:parent_class] || FactoryBot::Evaluator
+      arguments[:parent_class] || FactoryBot::Evaluator,
     )
     evaluator_class_definer.evaluator_class
   end

--- a/spec/support/macros/define_constant.rb
+++ b/spec/support/macros/define_constant.rb
@@ -71,7 +71,7 @@ RSpec.configure do |config|
   config.before(:all) do
     ActiveRecord::Base.establish_connection(
       adapter:  'sqlite3',
-      database: File.join(File.dirname(__FILE__), 'test.db')
+      database: File.join(File.dirname(__FILE__), 'test.db'),
     )
   end
 

--- a/spec/support/macros/define_constant.rb
+++ b/spec/support/macros/define_constant.rb
@@ -37,7 +37,7 @@ module DefineConstantMacros
   def constant_path(constant_name)
     names = constant_name.split('::')
     class_name = names.pop
-    namespace = names.inject(Object) { |result, name| result.const_get(name) }
+    namespace = names.reduce(Object) { |result, name| result.const_get(name) }
     [namespace, class_name]
   end
 

--- a/spec/support/matchers/declaration.rb
+++ b/spec/support/matchers/declaration.rb
@@ -48,7 +48,7 @@ module DeclarationMatchers
     def failure_message
       [
         "expected declarations to include declaration of type #{@declaration_type}",
-        @options ? "with options #{options}" : nil
+        @options ? "with options #{options}" : nil,
       ].compact.join ' '
     end
 

--- a/spec/support/shared_examples/strategy.rb
+++ b/spec/support/shared_examples/strategy.rb
@@ -59,7 +59,7 @@ shared_examples_for "strategy with strategy: :build" do |factory_bot_strategy_na
 
   it "runs the factory with the correct overrides" do
     association_named(:author, strategy: :build, great: "value")
-    expect(factory).to have_received(:run).with(factory_bot_strategy_name, { great: "value" })
+    expect(factory).to have_received(:run).with(factory_bot_strategy_name, great: "value")
   end
 
   it "finds the factory with the correct factory name" do


### PR DESCRIPTION
Continue addressing #1202 

Addresses most of the 'Style' cops. I opted to skip a couple cops, because I don't have enough knowledge about them to know how to correctly fix them. The first is the `Style/MethodMissing` cop. I saw [this thread](https://github.com/rubocop-hq/rubocop/issues/3760) and thought that that same issue may apply. If anyone has a suggestion on what route to go on this, I can make the change if requested.

The other is the `Style/StringLiterals` cop. There is a big split on strings that use single and double quotes, so I'm not sure if we want to settle on one and use it. If someone tells me the preference, I can easily fix this as well.

I also had to omit fixing the `Style/RedundantBegin` cop because after making the change, Hound complained about invalid syntax. I'm guessing Hound must be checking for an older Ruby syntax before method blocks counted as an implicit `begin`. This could be fixed by setting a [`TargetRubyVersion`](https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md#setting-the-target-ruby-version) in the Rubocop config file.

Last thing I want to point out is that I made a change to the Rubocop config based on the current style in the code. In spec files, curly braces are used for multi-line chained blocks with some `expect` blocks:

```ruby
expect {
  2.times { subject.define_attribute(attribute) }
}.to raise_error(...)
```

I omitted spec files for the `Style/BlockDelimiters` cop because this was used in a few different places in the specs. If a reviewer decides this isn't the desired fix, I can either use `do/end` blocks instead, or convert these to single-lines instead.