### PR TITLE
[Rubocop] Performance Cop Offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 inherit_from:
   - https://raw.githubusercontent.com/thoughtbot/guides/master/style/ruby/.rubocop.yml
 AllCops:
+  TargetRubyVersion: 2.3
   Exclude:
     - 'gemfiles/*'
     - 'tmp/**/*'
@@ -79,12 +80,6 @@ Metrics/LineLength:
 Naming/MemoizedInstanceVariableName:
   Exclude:
     - 'spec/support/macros/define_constant.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Performance/RegexpMatch:
-  Exclude:
-    - 'lib/factory_bot/aliases.rb'
 
 # Offense count: 3
 # Cop supports --auto-correct.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,14 +82,6 @@ Naming/MemoizedInstanceVariableName:
 
 # Offense count: 3
 # Cop supports --auto-correct.
-# Configuration parameters: AutoCorrect.
-Performance/TimesMap:
-  Exclude:
-    - 'lib/factory_bot/strategy_syntax_method_registrar.rb'
-    - 'spec/acceptance/initialize_with_spec.rb'
-
-# Offense count: 3
-# Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, IgnoredMethods.
 # SupportedStyles: line_count_based, semantic, braces_for_chaining
 # ProceduralMethods: benchmark, bm, bmbm, create, each_with_object, measure, new, realtime, tap, with_object

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,6 +80,12 @@ Naming/MemoizedInstanceVariableName:
   Exclude:
     - 'spec/support/macros/define_constant.rb'
 
+# Offense count: 1
+# Cop supports --auto-correct.
+Performance/RegexpMatch:
+  Exclude:
+    - 'lib/factory_bot/aliases.rb'
+
 # Offense count: 3
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, IgnoredMethods.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,12 +80,6 @@ Naming/MemoizedInstanceVariableName:
   Exclude:
     - 'spec/support/macros/define_constant.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Performance/RegexpMatch:
-  Exclude:
-    - 'lib/factory_bot/aliases.rb'
-
 # Offense count: 3
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect.

--- a/lib/factory_bot/aliases.rb
+++ b/lib/factory_bot/aliases.rb
@@ -10,7 +10,7 @@ module FactoryBot
 
   def self.aliases_for(attribute)
     aliases.map do |(pattern, replace)|
-      if pattern.match?(attribute.to_s)
+      if pattern.match(attribute.to_s)
         attribute.to_s.sub(pattern, replace).to_sym
       end
     end.compact << attribute

--- a/lib/factory_bot/aliases.rb
+++ b/lib/factory_bot/aliases.rb
@@ -10,7 +10,7 @@ module FactoryBot
 
   def self.aliases_for(attribute)
     aliases.map do |(pattern, replace)|
-      if pattern.match(attribute.to_s)
+      if pattern.match?(attribute.to_s)
         attribute.to_s.sub(pattern, replace).to_sym
       end
     end.compact << attribute

--- a/lib/factory_bot/strategy_syntax_method_registrar.rb
+++ b/lib/factory_bot/strategy_syntax_method_registrar.rb
@@ -29,7 +29,7 @@ module FactoryBot
           raise ArgumentError, "count missing for #{strategy_name}_list"
         end
 
-        amount.times.map { send(strategy_name, name, *traits_and_overrides, &block) }
+        Array.new(amount) { send(strategy_name, name, *traits_and_overrides, &block) }
       end
     end
 
@@ -37,7 +37,7 @@ module FactoryBot
       strategy_name = @strategy_name
 
       define_syntax_method("#{strategy_name}_pair") do |name, *traits_and_overrides, &block|
-        2.times.map { send(strategy_name, name, *traits_and_overrides, &block) }
+        Array.new(2) { send(strategy_name, name, *traits_and_overrides, &block) }
       end
     end
 

--- a/spec/acceptance/initialize_with_spec.rb
+++ b/spec/acceptance/initialize_with_spec.rb
@@ -59,7 +59,7 @@ describe "initialize_with non-ORM-backed objects" do
     end
 
     FactoryBot.define do
-      sequence(:random_data) { 5.times.map { Kernel.rand(200) } }
+      sequence(:random_data) { Array.new(5) { Kernel.rand(200) } }
 
       factory :report_generator do
         transient do


### PR DESCRIPTION
Continue addressing #1202 

Addresses all the 'Performance' cops. These were all straightforward to fix.

I originally fixed the `Performance/RegexpMatch` offense by using the suggested fix (`Regexp#match?`), but it turns out that the CI uses Ruby 2.3, which doesn't have that method. I fixed this by setting the `TargetRubyVersion` in `.rubocop.yml` to 2.3. The other way to do this is by adding a `.ruby-version` file to the project, then Rubocop will just use what version is specified there.

I looked into fixing the `Naming/MemoizedInstanceVariableName` cop as well in this PR, but it doesn't really fit into what Rubocop wants. The only thing I could think of would be to add a `rubocop:disable` comment, but I'm not sure if that's what the maintainers want.