### PR TITLE
Use dedicated methods for memoized values

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,11 +76,6 @@ Metrics/BlockLength:
 Metrics/LineLength:
   Max: 189
 
-# Offense count: 1
-Naming/MemoizedInstanceVariableName:
-  Exclude:
-    - 'spec/support/macros/define_constant.rb'
-
 # Offense count: 3
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, IgnoredMethods.


### PR DESCRIPTION
RuboCop didn't seem to like having memoization in the
`default_constants` method that didn't match the method name. This
satisfies RuboCop, and saves us an array allocation or two when we run
specs that don't use any of these helpers.