### PR TITLE
Rubocop: Fix Layout/IndentHeredoc issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,14 +16,6 @@ AllCops:
 # versions of RuboCop, may require this file to be generated again.
 
 # Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForEmptyBraces.
-# SupportedStyles: space, no_space, compact
-# SupportedStylesForEmptyBraces: space, no_space
-Layout/SpaceInsideHashLiteralBraces:
-  EnforcedStyle: space
-
-# Offense count: 1
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
   Max: 26
@@ -69,9 +61,3 @@ Style/StringLiterals:
 # SupportedStyles: percent, brackets
 Style/SymbolArray:
   EnforcedStyle: brackets
-
-# Offense count: 196
-# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
-# URISchemes: http, https
-Metrics/LineLength:
-  Max: 189

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,15 +15,6 @@ AllCops:
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: auto_detection, squiggly, active_support, powerpack, unindent
-Layout/IndentHeredoc:
-  Exclude:
-    - 'lib/factory_bot/linter.rb'
-    - 'spec/acceptance/lint_spec.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleForEmptyBraces.

--- a/lib/factory_bot/linter.rb
+++ b/lib/factory_bot/linter.rb
@@ -86,10 +86,10 @@ module FactoryBot
         exceptions.map(&:message)
       end.flatten
 
-      <<-ERROR_MESSAGE.strip
-The following factories are invalid:
+      <<~ERROR_MESSAGE.strip
+        The following factories are invalid:
 
-#{lines.join("\n")}
+        #{lines.join("\n")}
       ERROR_MESSAGE
     end
   end

--- a/spec/acceptance/lint_spec.rb
+++ b/spec/acceptance/lint_spec.rb
@@ -14,11 +14,11 @@ describe "FactoryBot.lint" do
       factory :always_valid
     end
 
-    error_message = <<-ERROR_MESSAGE.strip
-The following factories are invalid:
+    error_message = <<~ERROR_MESSAGE.strip
+      The following factories are invalid:
 
-* user - Validation failed: Name can't be blank (ActiveRecord::RecordInvalid)
-* admin_user - Validation failed: Name can't be blank (ActiveRecord::RecordInvalid)
+      * user - Validation failed: Name can't be blank (ActiveRecord::RecordInvalid)
+      * admin_user - Validation failed: Name can't be blank (ActiveRecord::RecordInvalid)
     ERROR_MESSAGE
 
     expect do
@@ -105,10 +105,10 @@ The following factories are invalid:
           end
         end
 
-        error_message = <<-ERROR_MESSAGE.strip
-The following factories are invalid:
+        error_message = <<~ERROR_MESSAGE.strip
+          The following factories are invalid:
 
-* user+unnamed - Validation failed: Name can't be blank (ActiveRecord::RecordInvalid)
+          * user+unnamed - Validation failed: Name can't be blank (ActiveRecord::RecordInvalid)
         ERROR_MESSAGE
 
         expect do


### PR DESCRIPTION
I removed the exclusionary line from the rubocop file, and then ran `rubocop -a`.
On visually inspecting the resulting output, I manually adjusted the offenses in `lint_spec` as the autocorrect did some weird things with it.
I also took a look at the `Layout/SpaceInsideHashLiteralBraces` TODO, and couldn't find the offense. Was it possibly fixed in a different PR? Can we remove that line from the rubocop file list?