### PR TITLE
Raise more meaningful error for unregistered trait

### DIFF
--- a/lib/factory_bot/declaration/association.rb
+++ b/lib/factory_bot/declaration/association.rb
@@ -10,7 +10,8 @@ module FactoryBot
       end
 
       def ==(other)
-        name == other.name &&
+        self.class == other.class &&
+          name == other.name &&
           options == other.options
       end
 

--- a/lib/factory_bot/declaration/dynamic.rb
+++ b/lib/factory_bot/declaration/dynamic.rb
@@ -8,7 +8,8 @@ module FactoryBot
       end
 
       def ==(other)
-        name == other.name &&
+        self.class == other.class &&
+          name == other.name &&
           ignored == other.ignored &&
           block == other.block
       end

--- a/lib/factory_bot/declaration/implicit.rb
+++ b/lib/factory_bot/declaration/implicit.rb
@@ -8,7 +8,8 @@ module FactoryBot
       end
 
       def ==(other)
-        name == other.name &&
+        self.class == other.class &&
+          name == other.name &&
           factory == other.factory &&
           ignored == other.ignored
       end

--- a/spec/acceptance/associations_spec.rb
+++ b/spec/acceptance/associations_spec.rb
@@ -1,0 +1,16 @@
+describe "associations" do
+  context "when accidentally using an implicit delcaration for the factory" do
+    it "raises an error about the trait not being registered" do
+      define_class("Post")
+
+      FactoryBot.define do
+        factory :post do
+          author factory: user
+        end
+      end
+
+      expect { FactoryBot.build(:post) }.
+        to raise_error("Trait not registered: user")
+    end
+  end
+end

--- a/spec/factory_bot/declaration/association_spec.rb
+++ b/spec/factory_bot/declaration/association_spec.rb
@@ -1,0 +1,38 @@
+describe FactoryBot::Declaration::Association do
+  describe "#==" do
+    context "when the attributes are equal" do
+      it "the objects are equal" do
+        declaration = described_class.new(:name, options: true)
+        other_declaration = described_class.new(:name, options: true)
+
+        expect(declaration).to eq(other_declaration)
+      end
+    end
+
+    context "when the names are different" do
+      it "the objects are NOT equal" do
+        declaration = described_class.new(:name, options: true)
+        other_declaration = described_class.new(:other_name, options: true)
+
+        expect(declaration).not_to eq(other_declaration)
+      end
+    end
+
+    context "when the options are different" do
+      it "the objects are NOT equal" do
+        declaration = described_class.new(:name, options: true)
+        other_declaration = described_class.new(:name, other_options: true)
+
+        expect(declaration).not_to eq(other_declaration)
+      end
+    end
+
+    context "when comparing against another type of object" do
+      it "the objects are NOT equal" do
+        declaration = described_class.new(:name)
+
+        expect(declaration).not_to eq(:not_a_declaration)
+      end
+    end
+  end
+end

--- a/spec/factory_bot/declaration/dynamic_spec.rb
+++ b/spec/factory_bot/declaration/dynamic_spec.rb
@@ -1,0 +1,50 @@
+describe FactoryBot::Declaration::Dynamic do
+  describe "#==" do
+    context "when the attributes are equal" do
+      it "the objects are equal" do
+        block = -> {}
+        declaration = described_class.new(:name, false, block)
+        other_declaration = described_class.new(:name, false, block)
+
+        expect(declaration).to eq(other_declaration)
+      end
+    end
+
+    context "when the names are different" do
+      it "the objects are NOT equal" do
+        block = -> {}
+        declaration = described_class.new(:name, false, block)
+        other_declaration = described_class.new(:other_name, false, block)
+
+        expect(declaration).not_to eq(other_declaration)
+      end
+    end
+
+    context "when the blocks are different" do
+      it "the objects are NOT equal" do
+        declaration = described_class.new(:name, false, -> {})
+        other_declaration = described_class.new(:name, false, -> {})
+
+        expect(declaration).not_to eq(other_declaration)
+      end
+    end
+
+    context "when one is ignored and the other isn't" do
+      it "the objects are NOT equal" do
+        block = -> {}
+        declaration = described_class.new(:name, false, block)
+        other_declaration = described_class.new(:name, true, block)
+
+        expect(declaration).not_to eq(other_declaration)
+      end
+    end
+
+    context "when comparing against another type of object" do
+      it "the objects are NOT equal" do
+        declaration = described_class.new(:name, false, -> {})
+
+        expect(declaration).not_to eq(:not_a_declaration)
+      end
+    end
+  end
+end

--- a/spec/factory_bot/declaration/implicit_spec.rb
+++ b/spec/factory_bot/declaration/implicit_spec.rb
@@ -1,23 +1,88 @@
 describe FactoryBot::Declaration::Implicit do
-  let(:name)        { :author }
-  let(:declaration) { FactoryBot::Declaration::Implicit.new(name) }
-  subject           { declaration.to_attributes.first }
-
   context "with a known factory" do
-    before do
+    it "creates an association attribute" do
       allow(FactoryBot.factories).to receive(:registered?).and_return true
+
+      declaration = FactoryBot::Declaration::Implicit.new(:name)
+      attribute = declaration.to_attributes.first
+
+      expect(attribute).to be_association
     end
 
-    it { should be_association }
-    its(:factory) { should eq name }
+    it "has the correct factory name" do
+      allow(FactoryBot.factories).to receive(:registered?).and_return true
+      name = :factory_name
+
+      declaration = FactoryBot::Declaration::Implicit.new(name)
+      attribute = declaration.to_attributes.first
+
+      expect(attribute.factory).to eq(name)
+    end
   end
 
   context "with a known sequence" do
-    before do
+    it "does not create an assocition attribute" do
       allow(FactoryBot.sequences).to receive(:registered?).and_return true
+
+      declaration = FactoryBot::Declaration::Implicit.new(:name)
+      attribute = declaration.to_attributes.first
+
+      expect(attribute).not_to be_association
     end
 
-    it { should_not be_association }
-    it { should be_a(FactoryBot::Attribute::Sequence) }
+    it "creates a sequence attribute" do
+      allow(FactoryBot.sequences).to receive(:registered?).and_return true
+
+      declaration = FactoryBot::Declaration::Implicit.new(:name)
+      attribute = declaration.to_attributes.first
+
+      expect(attribute).to be_a(FactoryBot::Attribute::Sequence)
+    end
+  end
+
+  describe "#==" do
+    context "when the attributes are equal" do
+      it "the objects are equal" do
+        declaration = described_class.new(:name, :factory, false)
+        other_declaration = described_class.new(:name, :factory, false)
+
+        expect(declaration).to eq(other_declaration)
+      end
+    end
+
+    context "when the names are different" do
+      it "the objects are NOT equal" do
+        declaration = described_class.new(:name, :factory, false)
+        other_declaration = described_class.new(:other_name, :factory, false)
+
+        expect(declaration).not_to eq(other_declaration)
+      end
+    end
+
+    context "when the factories are different" do
+      it "the objects are NOT equal" do
+        declaration = described_class.new(:name, :factory, false)
+        other_declaration = described_class.new(:name, :other_factory, false)
+
+        expect(declaration).not_to eq(other_declaration)
+      end
+    end
+
+    context "when one is ignored and the other isn't" do
+      it "the objects are NOT equal" do
+        declaration = described_class.new(:name, :factory, false)
+        other_declaration = described_class.new(:name, :factory, true)
+
+        expect(declaration).not_to eq(other_declaration)
+      end
+    end
+
+    context "when comparing against another type of object" do
+      it "the objects are NOT equal" do
+        declaration = described_class.new(:name, :factory, false)
+
+        expect(declaration).not_to eq(:not_a_declaration)
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #970

In this code we are passing an implicit declaration `user`, rather than
the symbol `:user`:

```rb
factory :post do
  author factory: user
end
```

This will raise a confusing error:
`undefined method 'name' for :post:Symbol`.

This is coming from the implicit declaration `#==` method,
which ends up getting called [here](https://github.com/thoughtbot/factory_bot/blob/7925c47653b4e3c06661ffefac192efcf0c48144/lib/factory_bot/attribute_list.rb#L56).
This `#==` method wasn't ever designed to compare against
objects of different classes. I added some tests for all the declaration
classes to handle being compared against other kinds of objects.

Now we will get a more meaningful error `Trait not registered: user`

Co-authored-by: Dusan Orlovic <duleorlovic@gmail.com>