### PR TITLE
Allow timestamp assignment in stubbed models

### DIFF
--- a/lib/factory_bot/strategy/stub.rb
+++ b/lib/factory_bot/strategy/stub.rb
@@ -32,6 +32,7 @@ module FactoryBot
         evaluation.object.tap do |instance|
           stub_database_interaction_on_result(instance)
           clear_changes_information(instance)
+          set_timestamps(instance)
           evaluation.notify(:after_stub, instance)
         end
       end
@@ -64,41 +65,34 @@ module FactoryBot
             end
           end
         end
-
-        created_at_missing_default = result_instance.respond_to?(:created_at) && !result_instance.created_at
-
-        if created_at_missing_default
-          result_instance.instance_eval do
-            def created_at
-              @created_at ||= Time.now.in_time_zone
-            end
-
-            def created_at=(date)
-              @created_at = date
-            end
-          end
-        end
-
-        has_updated_at = result_instance.respond_to?(:updated_at)
-        updated_at_no_default = has_updated_at && !result_instance.updated_at
-
-        if updated_at_no_default
-          result_instance.instance_eval do
-            def updated_at
-              @updated_at ||= Time.current
-            end
-
-            def updated_at=(date)
-              @updated_at = date
-            end
-          end
-        end
       end
 
       def clear_changes_information(result_instance)
         if result_instance.respond_to?(:clear_changes_information)
           result_instance.clear_changes_information
         end
+      end
+
+      def set_timestamps(result_instance)
+        if missing_created_at?(result_instance)
+          result_instance.created_at = Time.current
+        end
+
+        if missing_updated_at?(result_instance)
+          result_instance.updated_at = Time.current
+        end
+      end
+
+      def missing_created_at?(result_instance)
+        result_instance.respond_to?(:created_at) &&
+          result_instance.respond_to?(:created_at=) &&
+          result_instance.created_at.blank?
+      end
+
+      def missing_updated_at?(result_instance)
+        result_instance.respond_to?(:updated_at) &&
+          result_instance.respond_to?(:updated_at=) &&
+          result_instance.updated_at.blank?
       end
     end
   end

--- a/lib/factory_bot/strategy/stub.rb
+++ b/lib/factory_bot/strategy/stub.rb
@@ -72,6 +72,10 @@ module FactoryBot
             def created_at
               @created_at ||= Time.now.in_time_zone
             end
+
+            def created_at=(date)
+              @created_at = date
+            end
           end
         end
 
@@ -82,6 +86,10 @@ module FactoryBot
           result_instance.instance_eval do
             def updated_at
               @updated_at ||= Time.current
+            end
+
+            def updated_at=(date)
+              @updated_at = date
             end
           end
         end

--- a/spec/acceptance/build_stubbed_spec.rb
+++ b/spec/acceptance/build_stubbed_spec.rb
@@ -179,6 +179,13 @@ describe "defaulting `created_at`" do
     expect { build_stubbed(:thing_without_timestamp, created_at: Time.now) }.
       to raise_error(NoMethodError, /created_at=/)
   end
+
+  it "allows assignment of created_at" do
+    stub = build_stubbed(:thing_with_timestamp)
+    expect(stub.created_at).to eq Time.now
+    stub.created_at = 3.days.ago
+    expect(stub.created_at).to eq 3.days.ago
+  end
 end
 
 describe "defaulting `updated_at`" do
@@ -214,6 +221,13 @@ describe "defaulting `updated_at`" do
     expect do
       build_stubbed(:thing_without_timestamp, updated_at: Time.now)
     end.to raise_error(NoMethodError, /updated_at=/)
+  end
+
+  it "allows assignment of updated_at" do
+    stub = build_stubbed(:thing_with_timestamp)
+    expect(stub.updated_at).to eq Time.now
+    stub.updated_at = 3.days.ago
+    expect(stub.updated_at).to eq 3.days.ago
   end
 end
 


### PR DESCRIPTION
Closes  #1058

Before this change the build_stubbed strategy would override `#created_at` and `#updated_at`. The new methods store the times in `@created_at` and `@updated_at` instance variables, rather than in `@attributes`. This could cause unexpected behavior when using `#created_at=` or #updated_at=`. As an example, this would fail:

```rb
post = build_stubbed(:post)
timestamp = 1.month.ago
post.created_at = timestamp
expect(post.created_at).to eq(timestamp)
```

Instead of overriding these methods, we can have build_stubbed set the values using `#created_at=` and `#updated_at=`. We need to do this after calling `clear_changes_information` or else we end up with an incorrect timezone.