### PR TITLE
WIP - aliases interfere with fields ending in _id with no association

### DIFF
--- a/spec/acceptance/aliases_spec.rb
+++ b/spec/acceptance/aliases_spec.rb
@@ -14,4 +14,23 @@ describe "aliases and overrides" do
   subject { FactoryBot.create(:user, one: "override") }
   its(:one) { should eq "override" }
   its(:two) { should be_nil }
+
+  context "don't alias" do
+    before do
+      # Enable this to get the tests to pass
+      # FactoryBot.aliases = [[/^((?!item_type).)_id/, '\1']]
+      define_model("Item", item_type_id: :string, item_type: :string)
+
+      FactoryBot.define do
+        factory :item do
+          item_type_id { "id value" }
+          item_type { "type value" }
+        end
+      end
+    end
+
+    subject { FactoryBot.create(:item, item_type: "some type", item_type_id: "some id") }
+    its(:item_type) { should eq "some type" }
+    its(:item_type_id) { should eq "some id" }
+  end
 end


### PR DESCRIPTION
If a field name ends in _id and isn't intended for an association,
the default FactoryBot.aliases interfere.

There doesn't seem to be a clear way to fix this problem.  One idea
would be to have a way in a factory definition to mark an attribute
to not be aliased.

The committed spec will fail with the default aliases.  The user can
always override this with the following to get tests passing:

`FactoryBot.aliases = [[/^((?!item_type).)_id/, '\1']]`

This is feasible but not an ideal situation.