### PR TITLE
Document use_parent_strategy configuration

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -384,6 +384,28 @@ factory :post do
   author strategy: :build    # <<< this does *not* work; causes author_id to be nil
 ```
 
+To have unspecified associations use the parent's strategy, instead of using :create, you can use the configuration `use_parent_strategy`:
+
+```ruby
+FactoryBot.use_parent_strategy = true
+
+factory :post do
+  # ...
+  author
+end
+
+post = build(:post)
+post.new_record?        # => true
+post.author.new_record? # => true
+
+post = create(:post)
+post.new_record?        # => false
+post.author.new_record? # => false
+```
+
+If you are using rspec, you can set this configuration in your spec_helper.rb (or rails_helper.rb, if using Rails).
+If you want to set it globally, you can use an intializer (if using Rails).
+
 Generating data for a `has_many` relationship is a bit more involved,
 depending on the amount of flexibility desired, but here's a surefire example
 of generating associated data.


### PR DESCRIPTION
Add documentation to the associations section to mention the `use_parent_strategy` configuration, and demonstrate it.