### PR TITLE
Refactor Linter to simplify adding verbose option

### DIFF
--- a/lib/factory_bot.rb
+++ b/lib/factory_bot.rb
@@ -63,9 +63,7 @@ module FactoryBot
   def self.lint(*args)
     options = args.extract_options!
     factories_to_lint = args[0] || FactoryBot.factories
-    linting_strategy = options[:traits] ? :factory_and_traits : :factory
-    factory_strategy = options[:strategy] || :create
-    Linter.new(factories_to_lint, linting_strategy, factory_strategy).lint!
+    Linter.new(factories_to_lint, options).lint!
   end
 
   class << self

--- a/lib/factory_bot/linter.rb
+++ b/lib/factory_bot/linter.rb
@@ -1,9 +1,9 @@
 module FactoryBot
   class Linter
-    def initialize(factories, linting_strategy, factory_strategy = :create)
+    def initialize(factories, strategy: :create, traits: false)
       @factories_to_lint = factories
-      @linting_method = "lint_#{linting_strategy}"
-      @factory_strategy = factory_strategy
+      @factory_strategy = strategy
+      @traits = traits
       @invalid_factories = calculate_invalid_factories
     end
 
@@ -19,7 +19,7 @@ module FactoryBot
 
     def calculate_invalid_factories
       factories_to_lint.reduce(Hash.new([])) do |result, factory|
-        errors = send(@linting_method, factory)
+        errors = lint(factory)
         result[factory] |= errors unless errors.empty?
         result
       end
@@ -52,6 +52,14 @@ module FactoryBot
       end
     end
 
+    def lint(factory)
+      if @traits
+        lint_factory(factory) + lint_traits(factory)
+      else
+        lint_factory(factory)
+      end
+    end
+
     def lint_factory(factory)
       result = []
       begin
@@ -73,12 +81,6 @@ module FactoryBot
         end
       end
       result
-    end
-
-    def lint_factory_and_traits(factory)
-      errors = lint_factory(factory)
-      errors |= lint_traits(factory)
-      errors
     end
 
     def error_message


### PR DESCRIPTION
This refactoring work should make adding the verbose linting option
(started in PR #1233) fairly simple.

I moved the linting option defaults into keyword argument defaults for
Linter#initialize. With keyword arguments we will now get an error if we
pass an option the Linter doesn't understand (we were doing exactly this
in one of our tests before 6e511597). Adding the verbose option will
involve adding one more keyword argument.