### PR TITLE
Always use parent strategy

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -347,65 +347,6 @@ factory :post do
 end
 ```
 
-The behavior of the association method varies depending on the build strategy used for the parent object.
-
-```ruby
-# Builds and saves a User and a Post
-post = create(:post)
-post.new_record?        # => false
-post.author.new_record? # => false
-
-# Builds and saves a User, and then builds but does not save a Post
-post = build(:post)
-post.new_record?        # => true
-post.author.new_record? # => false
-```
-
-To not save the associated object, specify strategy: :build in the factory:
-
-```ruby
-factory :post do
-  # ...
-  association :author, factory: :user, strategy: :build
-end
-
-# Builds a User, and then builds a Post, but does not save either
-post = build(:post)
-post.new_record?        # => true
-post.author.new_record? # => true
-```
-
-Please note that the `strategy: :build` option must be passed to an explicit call to `association`,
-and cannot be used with implicit associations:
-
-```ruby
-factory :post do
-  # ...
-  author strategy: :build    # <<< this does *not* work; causes author_id to be nil
-```
-
-To have unspecified associations use the parent's strategy, instead of using :create, you can use the configuration `use_parent_strategy`:
-
-```ruby
-FactoryBot.use_parent_strategy = true
-
-factory :post do
-  # ...
-  author
-end
-
-post = build(:post)
-post.new_record?        # => true
-post.author.new_record? # => true
-
-post = create(:post)
-post.new_record?        # => false
-post.author.new_record? # => false
-```
-
-If you are using rspec, you can set this configuration in your spec_helper.rb (or rails_helper.rb, if using Rails).
-If you want to set it globally, you can use an intializer (if using Rails).
-
 Generating data for a `has_many` relationship is a bit more involved,
 depending on the amount of flexibility desired, but here's a surefire example
 of generating associated data.

--- a/lib/factory_bot.rb
+++ b/lib/factory_bot.rb
@@ -46,6 +46,8 @@ require "factory_bot/linter"
 require "factory_bot/version"
 
 module FactoryBot
+  DEPRECATOR = ActiveSupport::Deprecation.new("6.0", "factory_bot")
+
   def self.configuration
     @configuration ||= Configuration.new
   end
@@ -78,9 +80,10 @@ module FactoryBot
              :skip_create,
              :initialize_with,
              :constructor,
-             :use_parent_strategy,
-             :use_parent_strategy=,
              to: :configuration
+
+    attr_accessor :use_parent_strategy
+    deprecate :use_parent_strategy, :use_parent_strategy=, deprecator: DEPRECATOR
   end
 
   def self.register_factory(factory)

--- a/lib/factory_bot/configuration.rb
+++ b/lib/factory_bot/configuration.rb
@@ -3,8 +3,6 @@ module FactoryBot
   class Configuration
     attr_reader :factories, :sequences, :traits, :strategies, :callback_names
 
-    attr_accessor :use_parent_strategy
-
     def initialize
       @factories      = Decorator::DisallowsDuplicatesRegistry.new(Registry.new("Factory"))
       @sequences      = Decorator::DisallowsDuplicatesRegistry.new(Registry.new("Sequence"))

--- a/lib/factory_bot/evaluator.rb
+++ b/lib/factory_bot/evaluator.rb
@@ -23,9 +23,7 @@ module FactoryBot
 
     def association(factory_name, *traits_and_overrides)
       overrides = traits_and_overrides.extract_options!
-      strategy_override = overrides.fetch(:strategy) do
-        FactoryBot.use_parent_strategy ? @build_strategy.class : :create
-      end
+      strategy_override = overrides.fetch(:strategy, @build_strategy.class)
 
       traits_and_overrides += [overrides.except(:strategy)]
 

--- a/spec/acceptance/build_spec.rb
+++ b/spec/acceptance/build_spec.rb
@@ -21,27 +21,7 @@ describe "a built instance" do
 
   it { should be_new_record }
 
-  context "when the :use_parent_strategy config option has not been set" do
-    before { FactoryBot.use_parent_strategy = nil }
-
-    it "assigns and saves associations" do
-      expect(subject.user).to be_kind_of(User)
-      expect(subject.user).not_to be_new_record
-    end
-  end
-
-  context "when the :use_parent_strategy config option has been enabled" do
-    before { FactoryBot.use_parent_strategy = true }
-
-    it "assigns but does not save associations" do
-      expect(subject.user).to be_kind_of(User)
-      expect(subject.user).to be_new_record
-    end
-  end
-
-  it "assigns but does not save associations when using parent strategy" do
-    FactoryBot.use_parent_strategy = true
-
+  it "assigns but does not save associations" do
     expect(subject.user).to be_kind_of(User)
     expect(subject.user).to be_new_record
   end

--- a/spec/acceptance/register_strategies_spec.rb
+++ b/spec/acceptance/register_strategies_spec.rb
@@ -98,26 +98,11 @@ describe "associations without overriding :strategy" do
     end
   end
 
-  context "when the :use_parent_strategy config option has not been enabled" do
-    before { FactoryBot.use_parent_strategy = nil }
+  it "uses the parent strategy on the association" do
+    FactoryBot.register_strategy(:create, custom_strategy)
 
-    it "uses the overridden strategy on the association" do
-      FactoryBot.register_strategy(:create, custom_strategy)
-
-      post = FactoryBot.build(:post)
-      expect(post.user.name).to eq "Custom strategy"
-    end
-  end
-
-  context "when the :use_parent_strategy config option has been enabled" do
-    before { FactoryBot.use_parent_strategy = true }
-
-    it "uses the parent strategy on the association" do
-      FactoryBot.register_strategy(:create, custom_strategy)
-
-      post = FactoryBot.build(:post)
-      expect(post.user.name).to eq "John Doe"
-    end
+    post = FactoryBot.build(:post)
+    expect(post.user.name).to eq "John Doe"
   end
 end
 


### PR DESCRIPTION
Closes #1236

Background
---

In issues #64 and #66 (from 2010) people expressed surprise
that using the `build` strategy would still `create` any associations.
I remember being similarly surprised by that behavior when I first
started using factory_bot.

The main reason for this behavior is to ensure the built instance will
be valid if there were any foreign key validations
(like `validates_presence_of :user_id`). If we don't save the
associations, there won't be any ids present.

PR #191 (from 2011) offers a workaround for people who don't want
records to be saved automatically. Passing `strategy: :build`
(originally `method: :build`, but later renamed) when declaring the
association will prevent it from being saved when using `build`.

But #191 isn't really a complete solution (as discussed on the PR
after it was merged). `strategy: :build` may do
the right thing when building objects with the `build` strategy, but it
can cause new problems when using the `create` strategy.

A better solution would be something like:
`strategy: <whatever strategy I was already using>`.
PRs #749 and #961 (merged in 2016) introduce something like that,
with the `use_parent_strategy` configuration option.
With this turned on `build` end up being generally [a little faster][]
than `build_stubbed`, since it no longer needs to hit the database for
each association.

[a little faster]: https://gist.github.com/composerinteralia/d4796df9140f431e36f88dfb6fe9733a

I have set `use_parent_strategy` on several projects now. I also added
it to suspenders in thoughtbot/suspenders#952.
On newer projects I have not run into any problems. On existing
projects I have seen the occasional test failure, which are easy enough
to fix by changing `build` to `create`.

Unfortunately I don't think `use_parent_strategy` is widely known,
since it wasn't documented until #1234 (about a month ago).
I also learned in #1234 that the `use_parent_strategy` setting gets
wiped out with `FactoryBot.reload`, which can be problematic when using
factory_bot_rails.

To summarize, we have been exploring having a `build` strategy that uses
`build` all the way down since 2010, but there still isn't a totally
reliable way to get that.

This PR
---

* Default to using the parent strategy for factory_bot 5, as suggested
in #749.
* Get rid of the `use_parent_strategy` option, since it doesn't play
well with `FactoryBot.reload`

I think this PR will also make the `strategy` option unnecessary, but I
would want to explore deprecating that in a separate PR.

If dealing with foreign key validations is important, maybe we can
rethink that from the ground up.