### PR TITLE
 docs: Make doc more clear for spec in rails.

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -30,10 +30,14 @@ Configure your test suite
 
 ### RSpec
 
-If you're using Rails:
+If you're using Rails, you need to Add these code in `spec/spec_helper.rb`
 
 ```ruby
+require 'factory_bot'
+...
+
 RSpec.configure do |config|
+  ...
   config.include FactoryBot::Syntax::Methods
 end
 ```


### PR DESCRIPTION
Some new use in factory_bot may forget to add the require to the config file. in addition they don't know the locales of the config file.