### PR TITLE
Do not reset use_parent_strategy on reload

### DIFF
--- a/lib/factory_bot.rb
+++ b/lib/factory_bot.rb
@@ -1,5 +1,6 @@
 require "set"
 require "active_support/core_ext/module/delegation"
+require "active_support/core_ext/module/attribute_accessors"
 require "active_support/deprecation"
 require "active_support/notifications"
 
@@ -54,6 +55,8 @@ module FactoryBot
     @configuration = nil
   end
 
+  mattr_accessor :use_parent_strategy, instance_accessor: false, default: false
+
   # Look for errors in factories and (optionally) their traits.
   # Parameters:
   # factories - which factories to lint; omit for all factories
@@ -78,8 +81,6 @@ module FactoryBot
              :skip_create,
              :initialize_with,
              :constructor,
-             :use_parent_strategy,
-             :use_parent_strategy=,
              to: :configuration
   end
 

--- a/lib/factory_bot/configuration.rb
+++ b/lib/factory_bot/configuration.rb
@@ -3,8 +3,6 @@ module FactoryBot
   class Configuration
     attr_reader :factories, :sequences, :traits, :strategies, :callback_names
 
-    attr_accessor :use_parent_strategy
-
     def initialize
       @factories      = Decorator::DisallowsDuplicatesRegistry.new(Registry.new("Factory"))
       @sequences      = Decorator::DisallowsDuplicatesRegistry.new(Registry.new("Sequence"))

--- a/spec/acceptance/build_spec.rb
+++ b/spec/acceptance/build_spec.rb
@@ -21,8 +21,8 @@ describe "a built instance" do
 
   it { should be_new_record }
 
-  context "when the :use_parent_strategy config option has not been set" do
-    before { FactoryBot.use_parent_strategy = nil }
+  context "when the :use_parent_strategy config option is set to false" do
+    before { FactoryBot.use_parent_strategy = false }
 
     it "assigns and saves associations" do
       expect(subject.user).to be_kind_of(User)
@@ -30,20 +30,13 @@ describe "a built instance" do
     end
   end
 
-  context "when the :use_parent_strategy config option has been enabled" do
+  context "when the :use_parent_strategy config option is set to true" do
     before { FactoryBot.use_parent_strategy = true }
 
     it "assigns but does not save associations" do
       expect(subject.user).to be_kind_of(User)
       expect(subject.user).to be_new_record
     end
-  end
-
-  it "assigns but does not save associations when using parent strategy" do
-    FactoryBot.use_parent_strategy = true
-
-    expect(subject.user).to be_kind_of(User)
-    expect(subject.user).to be_new_record
   end
 end
 

--- a/spec/acceptance/register_strategies_spec.rb
+++ b/spec/acceptance/register_strategies_spec.rb
@@ -98,8 +98,8 @@ describe "associations without overriding :strategy" do
     end
   end
 
-  context "when the :use_parent_strategy config option has not been enabled" do
-    before { FactoryBot.use_parent_strategy = nil }
+  context "when the :use_parent_strategy config option is set to false" do
+    before { FactoryBot.use_parent_strategy = false }
 
     it "uses the overridden strategy on the association" do
       FactoryBot.register_strategy(:create, custom_strategy)
@@ -109,7 +109,7 @@ describe "associations without overriding :strategy" do
     end
   end
 
-  context "when the :use_parent_strategy config option has been enabled" do
+  context "when the :use_parent_strategy config option is set to true" do
     before { FactoryBot.use_parent_strategy = true }
 
     it "uses the parent strategy on the association" do

--- a/spec/acceptance/reload_spec.rb
+++ b/spec/acceptance/reload_spec.rb
@@ -1,0 +1,10 @@
+describe "reload" do
+  it "does not reset the value of use_parent_strategy" do
+    use_parent_strategy = :custom_use_parent_strategy_value
+    FactoryBot.use_parent_strategy = use_parent_strategy
+
+    FactoryBot.reload
+
+    expect(FactoryBot.use_parent_strategy).to eq use_parent_strategy
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ RSpec.configure do |config|
 
   config.before do
     FactoryBot.reload
+    FactoryBot.use_parent_strategy = false
   end
 
   config.after do


### PR DESCRIPTION
Before this PR, `use_parent_strategy` was set on the configuration
instance. Since `FactoryBot.reload` wipes out the configuration, it also
ends up resetting `use_parent_strategy` back to `nil`.

This can cause problems when using factory_bot_rails with Spring, since
factory_bot_rails calls `FactoryBot.reload` each time Spring forks. If
`use_parent_strategy` is set in a file that Spring preloads, like in an
initializer, then the value will get wiped out.

With this PR, we set `use_parent_strategy` directly on FactoryBot,
rather than on the configuration instance, and so reloading no longer
has any effect.

Related to #1236 and #1240 