### PR TITLE
Update development dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,3 @@
 source "https://rubygems.org"
 
 gemspec name: "factory_bot"
-
-gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
-gem "jdbc-sqlite3", platforms: :jruby
-
-gem "sqlite3", "~> 1.3.10", platforms: :ruby
-
-gem "rake"
-gem "rubocop", "0.54", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,18 +7,18 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.1)
-      activesupport (= 5.2.1)
-    activerecord (5.2.1)
-      activemodel (= 5.2.1)
-      activesupport (= 5.2.1)
+    activemodel (5.2.2)
+      activesupport (= 5.2.2)
+    activerecord (5.2.2)
+      activemodel (= 5.2.2)
+      activesupport (= 5.2.2)
       arel (>= 9.0)
-    activesupport (5.2.1)
+    activesupport (5.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    appraisal (2.1.0)
+    appraisal (2.2.0)
       bundler
       rake
       thor (>= 0.14.0)
@@ -31,23 +31,33 @@ GEM
       rspec-expectations (>= 2.99)
       thor (~> 0.19)
     ast (2.4.0)
+    backports (3.11.4)
     builder (3.2.3)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.4)
     contracts (0.16.0)
-    cucumber (1.3.20)
+    cucumber (3.1.2)
       builder (>= 2.1.2)
-      diff-lcs (>= 1.1.3)
-      gherkin (~> 2.12)
+      cucumber-core (~> 3.2.0)
+      cucumber-expressions (~> 6.0.1)
+      cucumber-wire (~> 0.0.1)
+      diff-lcs (~> 1.3)
+      gherkin (~> 5.1.0)
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.1.2)
+    cucumber-core (3.2.1)
+      backports (>= 3.8.0)
+      cucumber-tag_expressions (~> 1.1.0)
+      gherkin (~> 5.0)
+    cucumber-expressions (6.0.1)
+    cucumber-tag_expressions (1.1.1)
+    cucumber-wire (0.0.1)
     diff-lcs (1.3)
     docile (1.3.1)
     ffi (1.9.25)
-    gherkin (2.12.2)
-      multi_json (~> 1.3)
-    i18n (1.1.1)
+    gherkin (5.1.0)
+    i18n (1.4.0)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     minitest (5.11.3)
@@ -58,7 +68,7 @@ GEM
       ast (~> 2.4.0)
     powerpack (0.1.2)
     rainbow (3.0.0)
-    rake (12.3.1)
+    rake (12.3.2)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -89,31 +99,29 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     sqlite3 (1.3.13)
-    thor (0.20.0)
+    thor (0.20.3)
     thread_safe (0.3.6)
     timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    unicode-display_width (1.4.0)
+    unicode-display_width (1.4.1)
     yard (0.9.16)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (>= 3.0.0)
-  activerecord-jdbcsqlite3-adapter
-  appraisal (~> 2.1.0)
+  activerecord
+  appraisal
   aruba
-  cucumber (~> 1.3.15)
+  cucumber
   factory_bot!
-  jdbc-sqlite3
   rake
-  rspec (~> 3.0)
-  rspec-its (~> 1.0)
+  rspec
+  rspec-its
   rubocop (= 0.54)
   simplecov
-  sqlite3 (~> 1.3.10)
+  sqlite3
   timecop
   yard
 

--- a/factory_bot.gemspec
+++ b/factory_bot.gemspec
@@ -24,13 +24,16 @@ Gem::Specification.new do |s|
 
   s.add_dependency("activesupport", ">= 3.0.0")
 
-  s.add_development_dependency("activerecord", ">= 3.0.0")
-  s.add_development_dependency("appraisal", "~> 2.1.0")
+  s.add_development_dependency("activerecord")
+  s.add_development_dependency("appraisal")
   s.add_development_dependency("aruba")
-  s.add_development_dependency("cucumber", "~> 1.3.15")
-  s.add_development_dependency("rspec",    "~> 3.0")
-  s.add_development_dependency("rspec-its", "~> 1.0")
+  s.add_development_dependency("cucumber")
+  s.add_development_dependency("rake")
+  s.add_development_dependency("rspec")
+  s.add_development_dependency("rspec-its")
+  s.add_development_dependency("rubocop", "0.54")
   s.add_development_dependency("simplecov")
+  s.add_development_dependency("sqlite3")
   s.add_development_dependency("timecop")
   s.add_development_dependency("yard")
 

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -2,11 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord-jdbcsqlite3-adapter", :platforms => :jruby
-gem "jdbc-sqlite3", :platforms => :jruby
-gem "sqlite3", "~> 1.3.10", :platforms => :ruby
-gem "rake"
-gem "rubocop", "0.54", :require => false
 gem "activerecord", "~> 4.2.5.1"
 
-gemspec :name => "factory_bot", :path => "../"
+gemspec name: "factory_bot", path: "../"

--- a/gemfiles/4.2.gemfile.lock
+++ b/gemfiles/4.2.gemfile.lock
@@ -20,7 +20,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    appraisal (2.1.0)
+    appraisal (2.2.0)
       bundler
       rake
       thor (>= 0.14.0)
@@ -33,22 +33,32 @@ GEM
       rspec-expectations (>= 2.99)
       thor (~> 0.19)
     ast (2.4.0)
+    backports (3.11.4)
     builder (3.2.3)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.4)
     contracts (0.16.0)
-    cucumber (1.3.20)
+    cucumber (3.1.2)
       builder (>= 2.1.2)
-      diff-lcs (>= 1.1.3)
-      gherkin (~> 2.12)
+      cucumber-core (~> 3.2.0)
+      cucumber-expressions (~> 6.0.1)
+      cucumber-wire (~> 0.0.1)
+      diff-lcs (~> 1.3)
+      gherkin (~> 5.1.0)
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.1.2)
+    cucumber-core (3.2.1)
+      backports (>= 3.8.0)
+      cucumber-tag_expressions (~> 1.1.0)
+      gherkin (~> 5.0)
+    cucumber-expressions (6.0.1)
+    cucumber-tag_expressions (1.1.1)
+    cucumber-wire (0.0.1)
     diff-lcs (1.3)
     docile (1.3.1)
     ffi (1.9.25)
-    gherkin (2.12.2)
-      multi_json (~> 1.3)
+    gherkin (5.1.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     json (1.8.6)
@@ -60,7 +70,7 @@ GEM
       ast (~> 2.4.0)
     powerpack (0.1.2)
     rainbow (3.0.0)
-    rake (12.3.1)
+    rake (12.3.2)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -96,7 +106,7 @@ GEM
     timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    unicode-display_width (1.4.0)
+    unicode-display_width (1.4.1)
     yard (0.9.16)
 
 PLATFORMS
@@ -104,18 +114,16 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 4.2.5.1)
-  activerecord-jdbcsqlite3-adapter
-  appraisal (~> 2.1.0)
+  appraisal
   aruba
-  cucumber (~> 1.3.15)
+  cucumber
   factory_bot!
-  jdbc-sqlite3
   rake
-  rspec (~> 3.0)
-  rspec-its (~> 1.0)
+  rspec
+  rspec-its
   rubocop (= 0.54)
   simplecov
-  sqlite3 (~> 1.3.10)
+  sqlite3
   timecop
   yard
 

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -2,11 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord-jdbcsqlite3-adapter", :platforms => :jruby
-gem "jdbc-sqlite3", :platforms => :jruby
-gem "sqlite3", "~> 1.3.10", :platforms => :ruby
-gem "rake"
-gem "rubocop", "0.54", :require => false
 gem "activerecord", "~> 5.0.0"
 
-gemspec :name => "factory_bot", :path => "../"
+gemspec name: "factory_bot", path: "../"

--- a/gemfiles/5.0.gemfile.lock
+++ b/gemfiles/5.0.gemfile.lock
@@ -18,7 +18,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    appraisal (2.1.0)
+    appraisal (2.2.0)
       bundler
       rake
       thor (>= 0.14.0)
@@ -31,23 +31,33 @@ GEM
       rspec-expectations (>= 2.99)
       thor (~> 0.19)
     ast (2.4.0)
+    backports (3.11.4)
     builder (3.2.3)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.4)
     contracts (0.16.0)
-    cucumber (1.3.20)
+    cucumber (3.1.2)
       builder (>= 2.1.2)
-      diff-lcs (>= 1.1.3)
-      gherkin (~> 2.12)
+      cucumber-core (~> 3.2.0)
+      cucumber-expressions (~> 6.0.1)
+      cucumber-wire (~> 0.0.1)
+      diff-lcs (~> 1.3)
+      gherkin (~> 5.1.0)
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.1.2)
+    cucumber-core (3.2.1)
+      backports (>= 3.8.0)
+      cucumber-tag_expressions (~> 1.1.0)
+      gherkin (~> 5.0)
+    cucumber-expressions (6.0.1)
+    cucumber-tag_expressions (1.1.1)
+    cucumber-wire (0.0.1)
     diff-lcs (1.3)
     docile (1.3.1)
     ffi (1.9.25)
-    gherkin (2.12.2)
-      multi_json (~> 1.3)
-    i18n (1.1.1)
+    gherkin (5.1.0)
+    i18n (1.4.0)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     minitest (5.11.3)
@@ -58,7 +68,7 @@ GEM
       ast (~> 2.4.0)
     powerpack (0.1.2)
     rainbow (3.0.0)
-    rake (12.3.1)
+    rake (12.3.2)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -94,7 +104,7 @@ GEM
     timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    unicode-display_width (1.4.0)
+    unicode-display_width (1.4.1)
     yard (0.9.16)
 
 PLATFORMS
@@ -102,18 +112,16 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 5.0.0)
-  activerecord-jdbcsqlite3-adapter
-  appraisal (~> 2.1.0)
+  appraisal
   aruba
-  cucumber (~> 1.3.15)
+  cucumber
   factory_bot!
-  jdbc-sqlite3
   rake
-  rspec (~> 3.0)
-  rspec-its (~> 1.0)
+  rspec
+  rspec-its
   rubocop (= 0.54)
   simplecov
-  sqlite3 (~> 1.3.10)
+  sqlite3
   timecop
   yard
 

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -2,11 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord-jdbcsqlite3-adapter", :platforms => :jruby
-gem "jdbc-sqlite3", :platforms => :jruby
-gem "sqlite3", "~> 1.3.10", :platforms => :ruby
-gem "rake"
-gem "rubocop", "0.54", :require => false
 gem "activerecord", "~> 5.1.0"
 
-gemspec :name => "factory_bot", :path => "../"
+gemspec name: "factory_bot", path: "../"

--- a/gemfiles/5.1.gemfile.lock
+++ b/gemfiles/5.1.gemfile.lock
@@ -7,18 +7,18 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.1.6)
-      activesupport (= 5.1.6)
-    activerecord (5.1.6)
-      activemodel (= 5.1.6)
-      activesupport (= 5.1.6)
+    activemodel (5.1.6.1)
+      activesupport (= 5.1.6.1)
+    activerecord (5.1.6.1)
+      activemodel (= 5.1.6.1)
+      activesupport (= 5.1.6.1)
       arel (~> 8.0)
-    activesupport (5.1.6)
+    activesupport (5.1.6.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    appraisal (2.1.0)
+    appraisal (2.2.0)
       bundler
       rake
       thor (>= 0.14.0)
@@ -31,23 +31,33 @@ GEM
       rspec-expectations (>= 2.99)
       thor (~> 0.19)
     ast (2.4.0)
+    backports (3.11.4)
     builder (3.2.3)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.4)
     contracts (0.16.0)
-    cucumber (1.3.20)
+    cucumber (3.1.2)
       builder (>= 2.1.2)
-      diff-lcs (>= 1.1.3)
-      gherkin (~> 2.12)
+      cucumber-core (~> 3.2.0)
+      cucumber-expressions (~> 6.0.1)
+      cucumber-wire (~> 0.0.1)
+      diff-lcs (~> 1.3)
+      gherkin (~> 5.1.0)
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.1.2)
+    cucumber-core (3.2.1)
+      backports (>= 3.8.0)
+      cucumber-tag_expressions (~> 1.1.0)
+      gherkin (~> 5.0)
+    cucumber-expressions (6.0.1)
+    cucumber-tag_expressions (1.1.1)
+    cucumber-wire (0.0.1)
     diff-lcs (1.3)
     docile (1.3.1)
     ffi (1.9.25)
-    gherkin (2.12.2)
-      multi_json (~> 1.3)
-    i18n (1.1.1)
+    gherkin (5.1.0)
+    i18n (1.4.0)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     minitest (5.11.3)
@@ -58,7 +68,7 @@ GEM
       ast (~> 2.4.0)
     powerpack (0.1.2)
     rainbow (3.0.0)
-    rake (12.3.1)
+    rake (12.3.2)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -94,7 +104,7 @@ GEM
     timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    unicode-display_width (1.4.0)
+    unicode-display_width (1.4.1)
     yard (0.9.16)
 
 PLATFORMS
@@ -102,18 +112,16 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 5.1.0)
-  activerecord-jdbcsqlite3-adapter
-  appraisal (~> 2.1.0)
+  appraisal
   aruba
-  cucumber (~> 1.3.15)
+  cucumber
   factory_bot!
-  jdbc-sqlite3
   rake
-  rspec (~> 3.0)
-  rspec-its (~> 1.0)
+  rspec
+  rspec-its
   rubocop (= 0.54)
   simplecov
-  sqlite3 (~> 1.3.10)
+  sqlite3
   timecop
   yard
 

--- a/gemfiles/5.2.gemfile
+++ b/gemfiles/5.2.gemfile
@@ -2,11 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord-jdbcsqlite3-adapter", :platforms => :jruby
-gem "jdbc-sqlite3", :platforms => :jruby
-gem "sqlite3", "~> 1.3.10", :platforms => :ruby
-gem "rake"
-gem "rubocop", "0.54", :require => false
 gem "activerecord", "~> 5.2.0"
 
-gemspec :name => "factory_bot", :path => "../"
+gemspec name: "factory_bot", path: "../"

--- a/gemfiles/5.2.gemfile.lock
+++ b/gemfiles/5.2.gemfile.lock
@@ -7,18 +7,18 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.1)
-      activesupport (= 5.2.1)
-    activerecord (5.2.1)
-      activemodel (= 5.2.1)
-      activesupport (= 5.2.1)
+    activemodel (5.2.2)
+      activesupport (= 5.2.2)
+    activerecord (5.2.2)
+      activemodel (= 5.2.2)
+      activesupport (= 5.2.2)
       arel (>= 9.0)
-    activesupport (5.2.1)
+    activesupport (5.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    appraisal (2.1.0)
+    appraisal (2.2.0)
       bundler
       rake
       thor (>= 0.14.0)
@@ -31,23 +31,33 @@ GEM
       rspec-expectations (>= 2.99)
       thor (~> 0.19)
     ast (2.4.0)
+    backports (3.11.4)
     builder (3.2.3)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.4)
     contracts (0.16.0)
-    cucumber (1.3.20)
+    cucumber (3.1.2)
       builder (>= 2.1.2)
-      diff-lcs (>= 1.1.3)
-      gherkin (~> 2.12)
+      cucumber-core (~> 3.2.0)
+      cucumber-expressions (~> 6.0.1)
+      cucumber-wire (~> 0.0.1)
+      diff-lcs (~> 1.3)
+      gherkin (~> 5.1.0)
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.1.2)
+    cucumber-core (3.2.1)
+      backports (>= 3.8.0)
+      cucumber-tag_expressions (~> 1.1.0)
+      gherkin (~> 5.0)
+    cucumber-expressions (6.0.1)
+    cucumber-tag_expressions (1.1.1)
+    cucumber-wire (0.0.1)
     diff-lcs (1.3)
     docile (1.3.1)
     ffi (1.9.25)
-    gherkin (2.12.2)
-      multi_json (~> 1.3)
-    i18n (1.1.1)
+    gherkin (5.1.0)
+    i18n (1.4.0)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     minitest (5.11.3)
@@ -58,7 +68,7 @@ GEM
       ast (~> 2.4.0)
     powerpack (0.1.2)
     rainbow (3.0.0)
-    rake (12.3.1)
+    rake (12.3.2)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -94,7 +104,7 @@ GEM
     timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    unicode-display_width (1.4.0)
+    unicode-display_width (1.4.1)
     yard (0.9.16)
 
 PLATFORMS
@@ -102,18 +112,16 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 5.2.0)
-  activerecord-jdbcsqlite3-adapter
-  appraisal (~> 2.1.0)
+  appraisal
   aruba
-  cucumber (~> 1.3.15)
+  cucumber
   factory_bot!
-  jdbc-sqlite3
   rake
-  rspec (~> 3.0)
-  rspec-its (~> 1.0)
+  rspec
+  rspec-its
   rubocop (= 0.54)
   simplecov
-  sqlite3 (~> 1.3.10)
+  sqlite3
   timecop
   yard
 


### PR DESCRIPTION
I consolidated all the development dependencies in the gemspec,
then ran `bundle update` and `appraisal install`.

I also got rid of unnecessary version constraints (I would rather just
the latest versions of things in development, and we can always add
constraints later if necessary), and removed the jruby-specific gems
since we aren't testing on jruby anymore.