### PR TITLE
Deprecate allow_class_lookup

### DIFF
--- a/lib/factory_bot.rb
+++ b/lib/factory_bot.rb
@@ -47,6 +47,8 @@ require "factory_bot/linter"
 require "factory_bot/version"
 
 module FactoryBot
+  DEPRECATOR = ActiveSupport::Deprecation.new("6.0", "factory_bot")
+
   def self.configuration
     @configuration ||= Configuration.new
   end
@@ -82,6 +84,9 @@ module FactoryBot
              :initialize_with,
              :constructor,
              to: :configuration
+
+    attr_accessor :allow_class_lookup
+    deprecate :allow_class_lookup, :allow_class_lookup=, deprecator: DEPRECATOR
   end
 
   def self.register_factory(factory)


### PR DESCRIPTION
I removed allow_class_lookup entirely in 2e0b476 when removing the
deprecated ability to lookup factories by class. But the upgrade to
fb 5 will be a bit more smooth if we deprecate the method first.