### PR TITLE
Set use_parent_strategy default to true explicitly

### DIFF
--- a/lib/factory_bot.rb
+++ b/lib/factory_bot.rb
@@ -57,7 +57,8 @@ module FactoryBot
     @configuration = nil
   end
 
-  mattr_accessor :use_parent_strategy, instance_accessor: false, default: true
+  mattr_accessor :use_parent_strategy, instance_accessor: false
+  self.use_parent_strategy = true
 
   # Look for errors in factories and (optionally) their traits.
   # Parameters:

--- a/spec/factory_bot_spec.rb
+++ b/spec/factory_bot_spec.rb
@@ -17,4 +17,10 @@ describe FactoryBot do
     FactoryBot.register_trait(trait)
     expect(FactoryBot.trait_by_name(trait.name)).to eq trait
   end
+
+  describe ".use_parent_strategy" do
+    it "is true by default" do
+      expect(FactoryBot.use_parent_strategy).to be true
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,11 +20,19 @@ RSpec.configure do |config|
 
   config.before do
     FactoryBot.reload
-    FactoryBot.use_parent_strategy = true
   end
 
   config.after do
     Timecop.return
+  end
+
+  config.around do |example|
+    begin
+      previous_use_parent_strategy = FactoryBot.use_parent_strategy
+      example.run
+    ensure
+      FactoryBot.use_parent_strategy = previous_use_parent_strategy
+    end
   end
 
   config.order = :random


### PR DESCRIPTION
Followup to https://github.com/thoughtbot/factory_bot/commit/d0208eda9c65cbc476a02d2f7503234195610005.

The `default:` option of `mattr_accessor` wasn't added until Rails 5.2, which means it has no effect on older versions and the default value of `FactoryBot.use_parent_strategy` in 5.0.0.rc1 is nil on those versions.