### PR TITLE
Introduce FactoryBot::Internal module

### DIFF
--- a/lib/factory_bot.rb
+++ b/lib/factory_bot.rb
@@ -45,16 +45,17 @@ require "factory_bot/decorator/invocation_tracker"
 require "factory_bot/decorator/new_constructor"
 require "factory_bot/linter"
 require "factory_bot/version"
+require "factory_bot/internal"
 
 module FactoryBot
   DEPRECATOR = ActiveSupport::Deprecation.new("6.0", "factory_bot")
 
   def self.configuration
-    @configuration ||= Configuration.new
+    Internal.configuration
   end
 
   def self.reset_configuration
-    @configuration = nil
+    Internal.reset_configuration
   end
 
   mattr_accessor :use_parent_strategy, instance_accessor: false

--- a/lib/factory_bot/internal.rb
+++ b/lib/factory_bot/internal.rb
@@ -1,0 +1,14 @@
+module FactoryBot
+  # @api private
+  module Internal
+    class << self
+      def configuration
+        @configuration ||= Configuration.new
+      end
+
+      def reset_configuration
+        @configuration = nil
+      end
+    end
+  end
+end

--- a/lib/factory_bot/reload.rb
+++ b/lib/factory_bot/reload.rb
@@ -1,6 +1,6 @@
 module FactoryBot
   def self.reload
-    reset_configuration
+    Internal.reset_configuration
     register_default_strategies
     register_default_callbacks
     find_definitions

--- a/lib/factory_bot/syntax/default.rb
+++ b/lib/factory_bot/syntax/default.rb
@@ -54,7 +54,7 @@ module FactoryBot
         private
 
         def configuration
-          FactoryBot.configuration
+          FactoryBot::Internal.configuration
         end
       end
 


### PR DESCRIPTION
The `FactoryBot` module has a mixture of methods that are meant for
public use, and methods that are meant only for internal use.
The methods meant for internal use are cluttering the
documentation, and may be confusing to people using the library.

This PR was prompted by [#1258]. Rather than introduce yet another
public method on `FactoryBot` meant only for internal use,
we can introduce a `FactoryBot::Internal` module,
and avoid generating documentation for the internal module.

The `FactoryBot::Internal.register_inline_sequence` method in [#1258]
will need access to the configuration instance, so this PR moves that
into `FactoryBot::Internal`. Eventually I plan to deprecate
`FactoryBot.configuration` and `FactoryBot.reset_configuration`, and to
move more of the `FactoryBot` methods into `FactoryBot::Internal`, but I
would rather hold off on all that until the dust settles on the 5.0
release.

[#1258]: https://github.com/thoughtbot/factory_bot/pull/1258