### PR TITLE
Code style consistency for Polymorphic association

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -519,11 +519,11 @@ FactoryBot.define do
     for_photo
 
     trait :for_video do
-      association(:commentable, factory: :video)
+      association :commentable, factory: :video
     end
 
     trait :for_photo do
-      association(:commentable, factory: :photo)
+      association :commentable, factory: :photo
     end
   end
 end
@@ -532,7 +532,8 @@ end
 This allows us to do:
 
 ```
-create(:comment)
+# Would be created for :photo by default since we have `for_photo` after :comment factory definition
+create(:comment) 
 create(:comment, :for_video)
 create(:comment, :for_photo)
 ```

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -532,7 +532,7 @@ end
 This allows us to do:
 
 ```
-create(:comment) 
+create(:comment)
 create(:comment, :for_video)
 create(:comment, :for_photo)
 ```

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -516,7 +516,7 @@ FactoryBot.define do
   factory :photo
 
   factory :comment do
-    for_photo
+    for_photo # default to the :for_photo trait if none is specified
 
     trait :for_video do
       association :commentable, factory: :video
@@ -532,7 +532,6 @@ end
 This allows us to do:
 
 ```
-# Would be created for :photo by default since we have `for_photo` after :comment factory definition
 create(:comment) 
 create(:comment, :for_video)
 create(:comment, :for_photo)


### PR DESCRIPTION
We have explicit association written as `association :author, factory: :user` everywhere 
except for polymorphic `association(:commentable, factory: :video)`

This PR aims to keep it consistent 