### PR TITLE
Add setup comment

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -30,7 +30,7 @@ Configure your test suite
 
 ### RSpec
 
-If you're using Rails:
+If you're using Rails, add the following configuration to `spec/support/factory_bot.rb` and be sure to require that file in `rails_helper.rb`:
 
 ```ruby
 RSpec.configure do |config|


### PR DESCRIPTION
For new users who may trip over setup

I (was moving too fast and) put this in spec_helper and got an error. I ended up on [stackoverflow](https://stackoverflow.com/questions/48091582/ruby-gem-uninitialized-constant-factorybot) to fix the problem. Suggesting this line to help future users. 