### PR TITLE
Update README.md: remove StackOverflow old tag mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ More Information
 * [Issues](https://github.com/thoughtbot/factory_bot/issues)
 * [GIANT ROBOTS SMASHING INTO OTHER GIANT ROBOTS](https://robots.thoughtbot.com/)
 
-You may also find useful information under the [factory_girl tag on Stack Overflow](https://stackoverflow.com/questions/tagged/factory-girl).
-
 [GETTING_STARTED]: https://www.rubydoc.info/gems/factory_bot/file/GETTING_STARTED.md
 
 Contributing


### PR DESCRIPTION
Stackoverflow redirect to the new tag name: "factory-girl" gets redirected to "factory-bot"
No needs to mention the old tag name. The existing tag is line 58 (4 lines above).