### PR TITLE
Move and deprecate trait methods from FactoryBot

### DIFF
--- a/lib/factory_bot.rb
+++ b/lib/factory_bot.rb
@@ -48,7 +48,7 @@ require "factory_bot/version"
 require "factory_bot/internal"
 
 module FactoryBot
-  DEPRECATOR = ActiveSupport::Deprecation.new("6.0", "factory_bot")
+  Deprecation = ActiveSupport::Deprecation.new("6.0", "factory_bot")
 
   def self.configuration
     Internal.configuration
@@ -87,8 +87,18 @@ module FactoryBot
              :constructor,
              to: :configuration
 
+    delegate :trait_by_name,
+             :register_trait,
+             to: Internal
+
     attr_accessor :allow_class_lookup
-    deprecate :allow_class_lookup, :allow_class_lookup=, deprecator: DEPRECATOR
+
+    deprecate :allow_class_lookup,
+              :allow_class_lookup=,
+              :register_trait,
+              :trait_by_name,
+              :traits,
+              deprecator: Deprecation
   end
 
   def self.register_factory(factory)
@@ -116,17 +126,6 @@ module FactoryBot
   def self.rewind_sequences
     sequences.each(&:rewind)
     Internal.rewind_inline_sequences
-  end
-
-  def self.register_trait(trait)
-    trait.names.each do |name|
-      traits.register(name, trait)
-    end
-    trait
-  end
-
-  def self.trait_by_name(name)
-    traits.find(name)
   end
 
   def self.register_strategy(strategy_name, strategy_class)

--- a/lib/factory_bot/definition.rb
+++ b/lib/factory_bot/definition.rb
@@ -111,7 +111,7 @@ module FactoryBot
     end
 
     def trait_by_name(name)
-      trait_for(name) || FactoryBot.trait_by_name(name)
+      trait_for(name) || Internal.trait_by_name(name)
     end
 
     def trait_for(name)

--- a/lib/factory_bot/internal.rb
+++ b/lib/factory_bot/internal.rb
@@ -2,7 +2,7 @@ module FactoryBot
   # @api private
   module Internal
     class << self
-      delegate :inline_sequences, to: :configuration
+      delegate :inline_sequences, :traits, to: :configuration
 
       def configuration
         @configuration ||= Configuration.new
@@ -18,6 +18,17 @@ module FactoryBot
 
       def rewind_inline_sequences
         inline_sequences.each(&:rewind)
+      end
+
+      def register_trait(trait)
+        trait.names.each do |name|
+          traits.register(name, trait)
+        end
+        trait
+      end
+
+      def trait_by_name(name)
+        traits.find(name)
       end
     end
   end

--- a/lib/factory_bot/syntax/default.rb
+++ b/lib/factory_bot/syntax/default.rb
@@ -30,7 +30,7 @@ module FactoryBot
         end
 
         def trait(name, &block)
-          FactoryBot.register_trait(Trait.new(name, &block))
+          Internal.register_trait(Trait.new(name, &block))
         end
 
         def to_create(&block)

--- a/spec/factory_bot/internal_spec.rb
+++ b/spec/factory_bot/internal_spec.rb
@@ -1,0 +1,20 @@
+describe FactoryBot::Internal do
+  describe ".register_trait" do
+    it "registers the provided trait" do
+      trait = FactoryBot::Trait.new(:admin)
+      configuration = FactoryBot::Internal.configuration
+      expect { FactoryBot::Internal.register_trait(trait) }.
+        to change { configuration.traits.count }.
+        from(0).
+        to(1)
+    end
+  end
+
+  describe ".trait_by_name" do
+    it "finds a previously registered trait" do
+      trait = FactoryBot::Trait.new(:admin)
+      FactoryBot::Internal.register_trait(trait)
+      expect(FactoryBot::Internal.trait_by_name(trait.name)).to eq trait
+    end
+  end
+end

--- a/spec/factory_bot_spec.rb
+++ b/spec/factory_bot_spec.rb
@@ -13,7 +13,7 @@ describe FactoryBot do
     expect(FactoryBot.sequence_by_name(sequence.name)).to eq sequence
   end
 
-  it "finds a registered trait" do
+  it "finds a registered trait", :silence_deprecation do
     FactoryBot.register_trait(trait)
     expect(FactoryBot.trait_by_name(trait.name)).to eq trait
   end

--- a/spec/support/macros/deprecation.rb
+++ b/spec/support/macros/deprecation.rb
@@ -2,10 +2,10 @@ require "active_support"
 
 module SilenceDeprecation
   def silence_deprecation(example)
-    cached_silenced = ActiveSupport::Deprecation.silenced
-    ActiveSupport::Deprecation.silenced = true
+    cached_silenced = FactoryBot::Deprecation.silenced
+    FactoryBot::Deprecation.silenced = true
     example.run
-    ActiveSupport::Deprecation.silenced = cached_silenced
+    FactoryBot::Deprecation.silenced = cached_silenced
   end
 end
 


### PR DESCRIPTION
Why:
These are essentially internal methods that should not be publicly
available from the base namespace.
One thing worth noticing is that the use of these methods internally was
almost exclusively in the `syntax/default` except for one use on the
`factory_bot/definition`.
Also, the deprecation silencing module was referring to the singleton
an instance of the ```ActiveRecord:: Deprecation``` class and not to the new
deprecation instance that was being used in the ```FactoryBot``` module.

This PR:
- Moves the `trait_by_name` and `register_trait` into the
`FactoryBot::Internal` module
- Deprecates uses of `trait_by_name`, `register_trait` and `traits` from
the `FactoryBot` module.
- Rename DEPRECATOR => Deprecation

This is one of the steps towards fixing [this
issue](#1281)