### PR TITLE
Improve error for static attribute attempts

### DIFF
--- a/lib/factory_bot/definition_proxy.rb
+++ b/lib/factory_bot/definition_proxy.rb
@@ -89,14 +89,16 @@ module FactoryBot
     #
     # are equivalent.
     def method_missing(name, *args, &block) # rubocop:disable Style/MethodMissing
-      if args.empty?
+      association_options = args.first
+
+      if association_options.nil?
         __declare_attribute__(name, block)
-      elsif args.first.respond_to?(:has_key?) && args.first.has_key?(:factory)
-        association(name, *args)
+      elsif __valid_association_options?(association_options)
+        association(name, association_options)
       else
         raise NoMethodError.new(<<~MSG)
           undefined method '#{name}' in '#{@definition.name}' factory
-          Did you mean? '#{name} { #{args.first.inspect} }'
+          Did you mean? '#{name} { #{association_options.inspect} }'
         MSG
       end
     end
@@ -187,6 +189,10 @@ module FactoryBot
       else
         add_attribute(name, &block)
       end
+    end
+
+    def __valid_association_options?(options)
+      options.respond_to?(:has_key?) && options.has_key?(:factory)
     end
   end
 end

--- a/lib/factory_bot/definition_proxy.rb
+++ b/lib/factory_bot/definition_proxy.rb
@@ -94,9 +94,10 @@ module FactoryBot
       elsif args.first.respond_to?(:has_key?) && args.first.has_key?(:factory)
         association(name, *args)
       else
-        raise NoMethodError.new(
-          "undefined method '#{name}' in '#{@definition.name}' factory",
-        )
+        raise NoMethodError.new(<<~MSG)
+          undefined method '#{name}' in '#{@definition.name}' factory
+          Did you mean? '#{name} { #{args.first.inspect} }'
+        MSG
       end
     end
 

--- a/spec/factory_bot/definition_proxy_spec.rb
+++ b/spec/factory_bot/definition_proxy_spec.rb
@@ -72,23 +72,11 @@ describe FactoryBot::DefinitionProxy, "#method_missing" do
       definition = FactoryBot::Definition.new(:broken)
       proxy = FactoryBot::DefinitionProxy.new(definition)
 
-      invalid_call = -> { proxy.static_attributes_are_gone true }
+      invalid_call = -> { proxy.static_attributes_are_gone "true" }
       expect(invalid_call).to raise_error(
         NoMethodError,
-        "undefined method 'static_attributes_are_gone' in 'broken' factory",
-      )
-    end
-  end
-
-  context "when called with a setter method" do
-    it "raises a NoMethodError" do
-      definition = FactoryBot::Definition.new(:broken)
-      proxy = FactoryBot::DefinitionProxy.new(definition)
-
-      invalid_call = -> { proxy.setter_method = true }
-      expect(invalid_call).to raise_error(
-        NoMethodError,
-        "undefined method 'setter_method=' in 'broken' factory",
+        "undefined method 'static_attributes_are_gone' in 'broken' factory\n" \
+        "Did you mean? 'static_attributes_are_gone { \"true\" }'\n",
       )
     end
   end


### PR DESCRIPTION
Some people upgrade straight from factory_bot < 4.11 to factory_bot >=
5.0 and miss the deprecation cycle for static attributes. I have gotten
some feedback that the NoMethodError is confusing. Since we know that in
most cases people are seeing the NoMethodError when trying to define
static attributes, we offer them a "Did you mean?"-style suggestion for
how they might update to dynamic attributes.

I removed the extra test for setter methods. It was a remnant of
something I had removed in #1200. I see no reason to have special
treatment for setters at this point.

Closes https://github.com/thoughtbot/factory_bot/issues/1272