### PR TITLE
Implement transient associations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,4 +25,4 @@ Style/FormatStringToken:
 # Let's not open a big PR to fix all of these at once - 
 # we can fix gradually if we happen to be editing a file that has a violation
 Metrics/LineLength:
-  Max: 110
+  Max: 115

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,4 +25,4 @@ Style/FormatStringToken:
 # Let's not open a big PR to fix all of these at once - 
 # we can fix gradually if we happen to be editing a file that has a violation
 Metrics/LineLength:
-  Max: 115
+  Max: 110

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gemspec name: "factory_bot"
+gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,7 @@ GEM
     ast (2.4.0)
     backports (3.11.4)
     builder (3.2.3)
+    byebug (11.0.1)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     concurrent-ruby (1.1.4)
@@ -114,6 +115,7 @@ DEPENDENCIES
   activerecord
   appraisal
   aruba
+  byebug
   cucumber
   factory_bot!
   rake

--- a/lib/factory_bot/attribute/association.rb
+++ b/lib/factory_bot/attribute/association.rb
@@ -4,8 +4,8 @@ module FactoryBot
     class Association < Attribute
       attr_reader :factory
 
-      def initialize(name, factory, overrides)
-        super(name, false)
+      def initialize(name, ignored, factory, overrides)
+        super(name, ignored)
         @factory   = factory
         @overrides = overrides
       end

--- a/lib/factory_bot/declaration/association.rb
+++ b/lib/factory_bot/declaration/association.rb
@@ -2,8 +2,8 @@ module FactoryBot
   class Declaration
     # @api private
     class Association < Declaration
-      def initialize(name, *options)
-        super(name, false)
+      def initialize(name, ignored, *options)
+        super(name, ignored)
         @options = options.dup
         @overrides = options.extract_options!
         @traits = options
@@ -23,7 +23,7 @@ module FactoryBot
 
       def build
         factory_name = @overrides[:factory] || name
-        [Attribute::Association.new(name, factory_name, [@traits, @overrides.except(:factory)].flatten)]
+        [Attribute::Association.new(name, @ignored, factory_name, [@traits, @overrides.except(:factory)].flatten)]
       end
     end
   end

--- a/lib/factory_bot/declaration/association.rb
+++ b/lib/factory_bot/declaration/association.rb
@@ -23,7 +23,8 @@ module FactoryBot
 
       def build
         factory_name = @overrides[:factory] || name
-        [Attribute::Association.new(name, @ignored, factory_name, [@traits, @overrides.except(:factory)].flatten)]
+        overrides = [@traits, @overrides.except(:factory)].flatten
+        [Attribute::Association.new(name, @ignored, factory_name, overrides)]
       end
     end
   end

--- a/lib/factory_bot/declaration/implicit.rb
+++ b/lib/factory_bot/declaration/implicit.rb
@@ -22,7 +22,7 @@ module FactoryBot
 
       def build
         if FactoryBot.factories.registered?(name)
-          [Attribute::Association.new(name, name, {})]
+          [Attribute::Association.new(name, @ignored, name, {})]
         elsif FactoryBot.sequences.registered?(name)
           [Attribute::Sequence.new(name, name, @ignored)]
         else

--- a/lib/factory_bot/definition_proxy.rb
+++ b/lib/factory_bot/definition_proxy.rb
@@ -152,7 +152,7 @@ module FactoryBot
           "in '#{@definition.name}' factory",
         )
       else
-        declaration = Declaration::Association.new(name, *options)
+        declaration = Declaration::Association.new(name, false, *options)
         @definition.declare_attribute(declaration)
       end
     end

--- a/spec/acceptance/transient_attributes_spec.rb
+++ b/spec/acceptance/transient_attributes_spec.rb
@@ -1,6 +1,6 @@
 describe "transient attributes" do
   before do
-    define_model('Country')
+    define_model("Country")
     define_model("User", name: :string, email: :string)
 
     FactoryBot.define do

--- a/spec/acceptance/transient_attributes_spec.rb
+++ b/spec/acceptance/transient_attributes_spec.rb
@@ -1,15 +1,19 @@
 describe "transient attributes" do
   before do
+    define_model('Country')
     define_model("User", name: :string, email: :string)
 
     FactoryBot.define do
       sequence(:name) { |n| "John #{n}" }
+
+      factory :country
 
       factory :user do
         transient do
           four     { 2 + 2 }
           rockstar { true }
           upcased  { false }
+          country
         end
 
         name  { "#{FactoryBot.generate(:name)}#{' - Rockstar' if rockstar}" }

--- a/spec/acceptance/transient_attributes_spec.rb
+++ b/spec/acceptance/transient_attributes_spec.rb
@@ -1,12 +1,19 @@
 describe "transient attributes" do
   before do
-    define_model("Country")
-    define_model("User", name: :string, email: :string)
+    define_model("Country", country_code: :string)
+    # define_model("Account", account_number: :string)
+    define_model("User", name: :string, email: :string, country_code: :string)
 
     FactoryBot.define do
       sequence(:name) { |n| "John #{n}" }
 
-      factory :country
+      factory :country do
+        country_code { 'US' }
+      end
+
+      # factory :account do
+      #   sequence(:account_number)
+      # end
 
       factory :user do
         transient do
@@ -18,6 +25,7 @@ describe "transient attributes" do
 
         name  { "#{FactoryBot.generate(:name)}#{' - Rockstar' if rockstar}" }
         email { "#{name.downcase}#{four}@example.com" }
+        country_code { country.country_code }
 
         after(:create) do |user, evaluator|
           user.name.upcase! if evaluator.upcased
@@ -28,11 +36,15 @@ describe "transient attributes" do
 
   context "returning attributes for a factory" do
     subject { FactoryBot.attributes_for(:user, rockstar: true) }
+
     it { should_not have_key(:four) }
     it { should_not have_key(:rockstar) }
     it { should_not have_key(:upcased) }
+    it { should_not have_key(:country) }
+    # it { should_not have_key(:account) }
     it { should     have_key(:name) }
     it { should     have_key(:email) }
+    it { should     have_key(:country_code) }
   end
 
   context "with a transient variable assigned" do

--- a/spec/factory_bot/attribute/association_spec.rb
+++ b/spec/factory_bot/attribute/association_spec.rb
@@ -4,7 +4,7 @@ describe FactoryBot::Attribute::Association do
   let(:overrides)   { { first_name: "John" } }
   let(:association) { double("association") }
 
-  subject { FactoryBot::Attribute::Association.new(name, factory, overrides) }
+  subject { FactoryBot::Attribute::Association.new(name, false, factory, overrides) }
 
   module MissingMethods
     def association(*args); end
@@ -33,6 +33,6 @@ describe FactoryBot::Attribute::Association do
 end
 
 describe FactoryBot::Attribute::Association, "with a string name" do
-  subject    { FactoryBot::Attribute::Association.new("name", :user, {}) }
+  subject    { FactoryBot::Attribute::Association.new("name", false, :user, {}) }
   its(:name) { should eq :name }
 end

--- a/spec/factory_bot/attribute_list_spec.rb
+++ b/spec/factory_bot/attribute_list_spec.rb
@@ -31,8 +31,8 @@ end
 describe FactoryBot::AttributeList, "#define_attribute with a named attribute list" do
   subject { FactoryBot::AttributeList.new(:author) }
 
-  let(:association_with_same_name)      { FactoryBot::Attribute::Association.new(:author, :author, {}) }
-  let(:association_with_different_name) { FactoryBot::Attribute::Association.new(:author, :post, {}) }
+  let(:association_with_same_name)      { FactoryBot::Attribute::Association.new(:author, false, :author, {}) }
+  let(:association_with_different_name) { FactoryBot::Attribute::Association.new(:author, false, :post, {}) }
 
   it "raises when the attribute is a self-referencing association" do
     expect do
@@ -70,8 +70,8 @@ describe FactoryBot::AttributeList, "#associations" do
   let(:email_attribute) do
     FactoryBot::Attribute::Dynamic.new(:email, false, ->(u) { "#{u.full_name}@example.com" })
   end
-  let(:author_attribute)    { FactoryBot::Attribute::Association.new(:author, :user, {}) }
-  let(:profile_attribute)   { FactoryBot::Attribute::Association.new(:profile, :profile, {}) }
+  let(:author_attribute)    { FactoryBot::Attribute::Association.new(:author, false, :user, {}) }
+  let(:profile_attribute)   { FactoryBot::Attribute::Association.new(:profile, false, :profile, {}) }
 
   before do
     subject.define_attribute(email_attribute)
@@ -120,7 +120,7 @@ describe FactoryBot::AttributeList, "generating names" do
   end
 
   def build_association(name)
-    FactoryBot::Attribute::Association.new(name, :user, {})
+    FactoryBot::Attribute::Association.new(name, false, :user, {})
   end
 
   before do

--- a/spec/factory_bot/attribute_list_spec.rb
+++ b/spec/factory_bot/attribute_list_spec.rb
@@ -31,8 +31,12 @@ end
 describe FactoryBot::AttributeList, "#define_attribute with a named attribute list" do
   subject { FactoryBot::AttributeList.new(:author) }
 
-  let(:association_with_same_name)      { FactoryBot::Attribute::Association.new(:author, false, :author, {}) }
-  let(:association_with_different_name) { FactoryBot::Attribute::Association.new(:author, false, :post, {}) }
+  let(:association_with_same_name) do
+    FactoryBot::Attribute::Association.new(:author, false, :author, {})
+  end
+  let(:association_with_different_name) do
+    FactoryBot::Attribute::Association.new(:author, false, :post, {})
+  end
 
   it "raises when the attribute is a self-referencing association" do
     expect do

--- a/spec/factory_bot/declaration/association_spec.rb
+++ b/spec/factory_bot/declaration/association_spec.rb
@@ -2,8 +2,8 @@ describe FactoryBot::Declaration::Association do
   describe "#==" do
     context "when the attributes are equal" do
       it "the objects are equal" do
-        declaration = described_class.new(:name, options: true)
-        other_declaration = described_class.new(:name, options: true)
+        declaration = described_class.new(:name, false, options: true)
+        other_declaration = described_class.new(:name, false, options: true)
 
         expect(declaration).to eq(other_declaration)
       end
@@ -11,8 +11,8 @@ describe FactoryBot::Declaration::Association do
 
     context "when the names are different" do
       it "the objects are NOT equal" do
-        declaration = described_class.new(:name, options: true)
-        other_declaration = described_class.new(:other_name, options: true)
+        declaration = described_class.new(:name, false, options: true)
+        other_declaration = described_class.new(:other_name, false, options: true)
 
         expect(declaration).not_to eq(other_declaration)
       end
@@ -20,8 +20,8 @@ describe FactoryBot::Declaration::Association do
 
     context "when the options are different" do
       it "the objects are NOT equal" do
-        declaration = described_class.new(:name, options: true)
-        other_declaration = described_class.new(:name, other_options: true)
+        declaration = described_class.new(:name, false, options: true)
+        other_declaration = described_class.new(:name, false, other_options: true)
 
         expect(declaration).not_to eq(other_declaration)
       end
@@ -29,7 +29,7 @@ describe FactoryBot::Declaration::Association do
 
     context "when comparing against another type of object" do
       it "the objects are NOT equal" do
-        declaration = described_class.new(:name)
+        declaration = described_class.new(:name, false)
 
         expect(declaration).not_to eq(:not_a_declaration)
       end

--- a/spec/support/matchers/declaration.rb
+++ b/spec/support/matchers/declaration.rb
@@ -60,9 +60,9 @@ module DeclarationMatchers
       when :implicit    then FactoryBot::Declaration::Implicit.new(@name, @factory, ignored?)
       when :association
         if @options
-          FactoryBot::Declaration::Association.new(@name, options)
+          FactoryBot::Declaration::Association.new(@name, ignored?, options)
         else
-          FactoryBot::Declaration::Association.new(@name)
+          FactoryBot::Declaration::Association.new(@name, ignored?)
         end
       end
     end


### PR DESCRIPTION
Co-authored-by: Jon Eisenstein <jon@zype.com>

(Revision of PR #1288 to maintain proper credit to original author)

From https://github.com/faucct/factory_girl/tree/feature/transient_associations. I claim no credit for the work except to update the code.

I ran into the same problems (Issue #1024) as were addressed in the existing open PR #1027, and made it compatible with current master. If there is a more supported way to do this, I'd be happy to delete this PR and do it the other way.

My use case:
I am using FactoryBot to generate nested Hash structures for use as mock responses from the AWS API. These structures sometimes fully contain other fully-defined structures within them, and sometimes simply echo data that would be well-formed values in those other structures. My strategy has been to do things like this:

```
factory :base_aws_object, :class => Hash do
  initialize_with { attributes.stringify_keys }
  skip_create

  factory :ebs_volume do
    sequence(:volume_id) { |n| "vol-#{n}" }
    size { 8 }
    ....
  end

  factory :ebs_snapshot do
    transient do
      ebs_volume
    end

    sequence(:snapshot_id) { |n| "snap-#{n}" }
    description { "Test Snapshot" }
    volume_id { ebs_volume['volume_id'] }
    volume_size { ebs_volume['size'] }
    ....
  end
end
```

Without this PR, the transient associations are still added to the final Hash when doing build(:ebs_snapshot), and thus are rejected by the AWS API gem as invalid.