### PR TITLE
Deprecate and move to Internal sequence methods

### DIFF
--- a/lib/factory_bot.rb
+++ b/lib/factory_bot.rb
@@ -87,8 +87,11 @@ module FactoryBot
              :constructor,
              to: :configuration
 
-    delegate :trait_by_name,
+    delegate :register_sequence,
              :register_trait,
+             :rewind_sequences,
+             :sequence_by_name,
+             :trait_by_name,
              to: Internal
 
     attr_accessor :allow_class_lookup
@@ -96,6 +99,8 @@ module FactoryBot
     deprecate :allow_class_lookup,
               :allow_class_lookup=,
               :register_trait,
+              :sequence_by_name,
+              :sequences,
               :trait_by_name,
               :traits,
               deprecator: Deprecation
@@ -110,22 +115,6 @@ module FactoryBot
 
   def self.factory_by_name(name)
     factories.find(name)
-  end
-
-  def self.register_sequence(sequence)
-    sequence.names.each do |name|
-      sequences.register(name, sequence)
-    end
-    sequence
-  end
-
-  def self.sequence_by_name(name)
-    sequences.find(name)
-  end
-
-  def self.rewind_sequences
-    sequences.each(&:rewind)
-    Internal.rewind_inline_sequences
   end
 
   def self.register_strategy(strategy_name, strategy_class)

--- a/lib/factory_bot/declaration/implicit.rb
+++ b/lib/factory_bot/declaration/implicit.rb
@@ -23,7 +23,7 @@ module FactoryBot
       def build
         if FactoryBot.factories.registered?(name)
           [Attribute::Association.new(name, name, {})]
-        elsif FactoryBot.sequences.registered?(name)
+        elsif FactoryBot::Internal.sequences.registered?(name)
           [Attribute::Sequence.new(name, name, @ignored)]
         else
           @factory.inherit_traits([name])

--- a/lib/factory_bot/internal.rb
+++ b/lib/factory_bot/internal.rb
@@ -2,7 +2,7 @@ module FactoryBot
   # @api private
   module Internal
     class << self
-      delegate :inline_sequences, :traits, to: :configuration
+      delegate :inline_sequences, :sequences, :traits, to: :configuration
 
       def configuration
         @configuration ||= Configuration.new
@@ -29,6 +29,22 @@ module FactoryBot
 
       def trait_by_name(name)
         traits.find(name)
+      end
+
+      def register_sequence(sequence)
+        sequence.names.each do |name|
+          sequences.register(name, sequence)
+        end
+        sequence
+      end
+
+      def sequence_by_name(name)
+        sequences.find(name)
+      end
+
+      def rewind_sequences
+        sequences.each(&:rewind)
+        rewind_inline_sequences
       end
     end
   end

--- a/lib/factory_bot/syntax/default.rb
+++ b/lib/factory_bot/syntax/default.rb
@@ -26,7 +26,7 @@ module FactoryBot
         end
 
         def sequence(name, *args, &block)
-          FactoryBot.register_sequence(Sequence.new(name, *args, &block))
+          Internal.register_sequence(Sequence.new(name, *args, &block))
         end
 
         def trait(name, &block)
@@ -54,7 +54,7 @@ module FactoryBot
         private
 
         def configuration
-          FactoryBot::Internal.configuration
+          Internal.configuration
         end
       end
 

--- a/lib/factory_bot/syntax/methods.rb
+++ b/lib/factory_bot/syntax/methods.rb
@@ -111,7 +111,7 @@ module FactoryBot
       # Returns:
       #   The next value in the sequence. (Object)
       def generate(name)
-        FactoryBot.sequence_by_name(name).next
+        Internal.sequence_by_name(name).next
       end
 
       # Generates and returns the list of values in a sequence.
@@ -126,7 +126,7 @@ module FactoryBot
       #   The next value in the sequence. (Object)
       def generate_list(name, count)
         (1..count).map do
-          FactoryBot.sequence_by_name(name).next
+          Internal.sequence_by_name(name).next
         end
       end
     end

--- a/spec/factory_bot/attribute/dynamic_spec.rb
+++ b/spec/factory_bot/attribute/dynamic_spec.rb
@@ -45,7 +45,13 @@ describe FactoryBot::Attribute::Dynamic do
   end
 
   context "with a block returning a sequence" do
-    let(:block) { -> { FactoryBot.register_sequence(FactoryBot::Sequence.new(:email, 1) { |n| "foo#{n}" }) } }
+    let(:block) do
+      -> do
+        FactoryBot::Internal.register_sequence(
+          FactoryBot::Sequence.new(:email, 1) { |n| "foo#{n}" },
+        )
+      end
+    end
 
     it "raises a sequence abuse error" do
       expect { subject.to_proc.call }.to raise_error(FactoryBot::SequenceAbuseError)

--- a/spec/factory_bot/attribute/sequence_spec.rb
+++ b/spec/factory_bot/attribute/sequence_spec.rb
@@ -4,7 +4,7 @@ describe FactoryBot::Attribute::Sequence do
   let(:sequence)      { FactoryBot::Sequence.new(sequence_name, 5) { |n| "Name #{n}" } }
 
   subject { FactoryBot::Attribute::Sequence.new(name, sequence_name, false) }
-  before  { FactoryBot.register_sequence(sequence) }
+  before  { FactoryBot::Internal.register_sequence(sequence) }
 
   its(:name) { should eq name }
 

--- a/spec/factory_bot/declaration/implicit_spec.rb
+++ b/spec/factory_bot/declaration/implicit_spec.rb
@@ -22,7 +22,7 @@ describe FactoryBot::Declaration::Implicit do
 
   context "with a known sequence" do
     it "does not create an assocition attribute" do
-      allow(FactoryBot.sequences).to receive(:registered?).and_return true
+      allow(FactoryBot::Internal.sequences).to receive(:registered?).and_return true
 
       declaration = FactoryBot::Declaration::Implicit.new(:name)
       attribute = declaration.to_attributes.first
@@ -31,7 +31,7 @@ describe FactoryBot::Declaration::Implicit do
     end
 
     it "creates a sequence attribute" do
-      allow(FactoryBot.sequences).to receive(:registered?).and_return true
+      allow(FactoryBot::Internal.sequences).to receive(:registered?).and_return true
 
       declaration = FactoryBot::Declaration::Implicit.new(:name)
       attribute = declaration.to_attributes.first

--- a/spec/factory_bot/internal_spec.rb
+++ b/spec/factory_bot/internal_spec.rb
@@ -17,4 +17,40 @@ describe FactoryBot::Internal do
       expect(FactoryBot::Internal.trait_by_name(trait.name)).to eq trait
     end
   end
+
+  describe ".register_sequence" do
+    it "registers the provided sequence" do
+      sequence = FactoryBot::Sequence.new(:email)
+      configuration = FactoryBot::Internal.configuration
+      expect { FactoryBot::Internal.register_sequence(sequence) }.
+        to change { configuration.sequences.count }.
+        from(0).
+        to(1)
+    end
+  end
+
+  describe ".sequence_by_name" do
+    it "finds a registered sequence" do
+      sequence = FactoryBot::Sequence.new(:email)
+      FactoryBot::Internal.register_sequence(sequence)
+      expect(FactoryBot::Internal.sequence_by_name(sequence.name)).to eq sequence
+    end
+  end
+
+  describe ".rewind_sequences" do
+    it "rewinds the sequences and the internal sequences" do
+      sequence = instance_double(FactoryBot::Sequence, names: ["email"])
+      allow(sequence).to receive(:rewind)
+      FactoryBot::Internal.register_sequence(sequence)
+
+      inline_sequence = instance_double(FactoryBot::Sequence)
+      allow(inline_sequence).to receive(:rewind)
+      FactoryBot::Internal.register_inline_sequence(inline_sequence)
+
+      FactoryBot::Internal.rewind_sequences
+
+      expect(sequence).to have_received(:rewind).exactly(:once)
+      expect(inline_sequence).to have_received(:rewind).exactly(:once)
+    end
+  end
 end

--- a/spec/factory_bot_spec.rb
+++ b/spec/factory_bot_spec.rb
@@ -8,7 +8,7 @@ describe FactoryBot do
     expect(FactoryBot.factory_by_name(factory.name)).to eq factory
   end
 
-  it "finds a registered sequence" do
+  it "finds a registered sequence", :silence_deprecation do
     FactoryBot.register_sequence(sequence)
     expect(FactoryBot.sequence_by_name(sequence.name)).to eq sequence
   end


### PR DESCRIPTION
Why:
Another run of internal methods that should not be publicly
available from the base namespace.
This time the sequence involving methods were moved. It's worth noticing
that the ```Internal``` class is getting crowded. Maybe we can start
name-spacing the internal groups into modules under
```internal/sequence.rb``` ```internal/trait.rb``` and so on. Thoughts?

This PR:

- Moves the ```register_sequence```, ```sequence_by_name```,
```sequences``` and ```rewind_sequences``` to the
```FactoryBot::Internal``` module.
- Deprecates uses of ```register_sequence```, ```sequence_by_name```,
```sequences``` and ```rewind_sequences``` from the ```FactoryBot``` module.

This is one of the steps towards fixing [this issue](https://github.com/thoughtbot/factory_bot/pull/1285#1281)