### PR TITLE
Raise error when a trait is self-referencing

### DIFF
--- a/lib/factory_bot/declaration/implicit.rb
+++ b/lib/factory_bot/declaration/implicit.rb
@@ -25,6 +25,9 @@ module FactoryBot
           [Attribute::Association.new(name, name, {})]
         elsif FactoryBot::Internal.sequences.registered?(name)
           [Attribute::Sequence.new(name, name, @ignored)]
+        elsif @factory.name.to_s == name.to_s
+          message = "Self-referencing trait '#{@name}'"
+          raise TraitDefinitionError, message
         else
           @factory.inherit_traits([name])
           []

--- a/lib/factory_bot/errors.rb
+++ b/lib/factory_bot/errors.rb
@@ -2,6 +2,9 @@ module FactoryBot
   # Raised when a factory is defined that attempts to instantiate itself.
   class AssociationDefinitionError < RuntimeError; end
 
+  # Raised when a trait is defined that references itself.
+  class TraitDefinitionError < RuntimeError; end
+
   # Raised when a callback is defined that has an invalid name
   class InvalidCallbackNameError < RuntimeError; end
 

--- a/lib/factory_bot/trait.rb
+++ b/lib/factory_bot/trait.rb
@@ -7,9 +7,11 @@ module FactoryBot
       @name = name.to_s
       @block = block
       @definition = Definition.new(@name)
-
       proxy = FactoryBot::DefinitionProxy.new(@definition)
-      proxy.instance_eval(&@block) if block_given?
+
+      if block_given?
+        proxy.instance_eval(&@block)
+      end
     end
 
     delegate :add_callback, :declare_attribute, :to_create, :define_trait, :constructor,

--- a/spec/acceptance/traits_spec.rb
+++ b/spec/acceptance/traits_spec.rb
@@ -798,3 +798,38 @@ describe "traits used in associations" do
     expect(creator.name).to eq "Joe Creator"
   end
 end
+
+describe "when a self-referential trait is defined" do
+  it "raises a TraitDefinitionError" do
+    define_model("User", name: :string)
+    FactoryBot.define do
+      factory :user do
+        trait :admin do
+          admin
+        end
+      end
+    end
+
+    expect { FactoryBot.build(:user, :admin) }.to raise_error(
+      FactoryBot::TraitDefinitionError,
+      "Self-referencing trait 'admin'",
+    )
+  end
+
+  it "raises a TraitDefinitionError" do
+    define_model("User", name: :string)
+    FactoryBot.define do
+      factory :user do
+        trait :admin do
+          admin
+          name { "name" }
+        end
+      end
+    end
+
+    expect { FactoryBot.build(:user, :admin) }.to raise_error(
+      FactoryBot::TraitDefinitionError,
+      "Self-referencing trait 'admin'",
+    )
+  end
+end


### PR DESCRIPTION
We want to check if any attributes of a new trait definition matches the name of
the trait. Raise an error if so, to avoid a recursive call to the trait. A fix to:
https://github.com/thoughtbot/factory_bot/issues/1238