### PR TITLE
Deprecate/Move strategies and callback methods

### DIFF
--- a/lib/factory_bot.rb
+++ b/lib/factory_bot.rb
@@ -88,11 +88,16 @@ module FactoryBot
              to: :configuration
 
     delegate :factory_by_name,
+             :register_callback,
+             :register_default_callbacks,
+             :register_default_strategies,
              :register_factory,
              :register_sequence,
+             :register_strategy,
              :register_trait,
              :rewind_sequences,
              :sequence_by_name,
+             :strategy_by_name,
              :trait_by_name,
              to: Internal
 
@@ -100,45 +105,21 @@ module FactoryBot
 
     deprecate :allow_class_lookup,
               :allow_class_lookup=,
+              :callback_names,
               :factory_by_name,
+              :register_callback,
+              :register_default_callbacks,
+              :register_default_strategies,
               :register_factory,
               :register_trait,
               :sequence_by_name,
               :sequences,
+              :strategies,
               :trait_by_name,
               :traits,
               deprecator: Deprecation
   end
-
-  def self.register_strategy(strategy_name, strategy_class)
-    strategies.register(strategy_name, strategy_class)
-    StrategySyntaxMethodRegistrar.new(strategy_name).define_strategy_methods
-  end
-
-  def self.strategy_by_name(name)
-    strategies.find(name)
-  end
-
-  def self.register_default_strategies
-    register_strategy(:build,          FactoryBot::Strategy::Build)
-    register_strategy(:create,         FactoryBot::Strategy::Create)
-    register_strategy(:attributes_for, FactoryBot::Strategy::AttributesFor)
-    register_strategy(:build_stubbed,  FactoryBot::Strategy::Stub)
-    register_strategy(:null,           FactoryBot::Strategy::Null)
-  end
-
-  def self.register_default_callbacks
-    register_callback(:after_build)
-    register_callback(:after_create)
-    register_callback(:after_stub)
-    register_callback(:before_create)
-  end
-
-  def self.register_callback(name)
-    name = name.to_sym
-    callback_names << name
-  end
 end
 
-FactoryBot.register_default_strategies
-FactoryBot.register_default_callbacks
+FactoryBot::Internal.register_default_strategies
+FactoryBot::Internal.register_default_callbacks

--- a/lib/factory_bot/callback.rb
+++ b/lib/factory_bot/callback.rb
@@ -28,9 +28,9 @@ module FactoryBot
     private
 
     def ensure_valid_callback_name!
-      unless FactoryBot.callback_names.include?(name)
+      unless FactoryBot::Internal.callback_names.include?(name)
         raise InvalidCallbackNameError, "#{name} is not a valid callback name. " +
-          "Valid callback names are #{FactoryBot.callback_names.inspect}"
+          "Valid callback names are #{FactoryBot::Internal.callback_names.inspect}"
       end
     end
 

--- a/lib/factory_bot/definition.rb
+++ b/lib/factory_bot/definition.rb
@@ -95,7 +95,7 @@ module FactoryBot
 
     def callback(*names, &block)
       names.each do |name|
-        FactoryBot.register_callback(name)
+        FactoryBot::Internal.register_callback(name)
         add_callback(Callback.new(name, block))
       end
     end

--- a/lib/factory_bot/reload.rb
+++ b/lib/factory_bot/reload.rb
@@ -1,8 +1,8 @@
 module FactoryBot
   def self.reload
     Internal.reset_configuration
-    register_default_strategies
-    register_default_callbacks
+    Internal.register_default_strategies
+    Internal.register_default_callbacks
     find_definitions
   end
 end

--- a/lib/factory_bot/strategy_calculator.rb
+++ b/lib/factory_bot/strategy_calculator.rb
@@ -20,7 +20,7 @@ module FactoryBot
     end
 
     def strategy_name_to_object
-      FactoryBot.strategy_by_name(@name_or_object)
+      FactoryBot::Internal.strategy_by_name(@name_or_object)
     end
   end
 end

--- a/lib/factory_bot/syntax/methods.rb
+++ b/lib/factory_bot/syntax/methods.rb
@@ -30,7 +30,7 @@ module FactoryBot
     ##   # factory with traits and attribute override
     ##   build_stubbed_list(:user, 15, :admin, :male, name: "John Doe")
     module Methods
-      # @!parse FactoryBot.register_default_strategies
+      # @!parse FactoryBot::Internal.register_default_strategies
       # @!method build(name, *traits_and_overrides, &block)
       # (see #strategy_method)
       # Builds a registered factory by name.

--- a/spec/factory_bot/callback_spec.rb
+++ b/spec/factory_bot/callback_spec.rb
@@ -26,7 +26,7 @@ describe FactoryBot::Callback do
   end
 
   it "allows valid callback names to be assigned" do
-    FactoryBot.callback_names.each do |callback_name|
+    FactoryBot::Internal.callback_names.each do |callback_name|
       expect { FactoryBot::Callback.new(callback_name, -> {}) }.
         to_not raise_error
     end

--- a/spec/factory_bot/internal_spec.rb
+++ b/spec/factory_bot/internal_spec.rb
@@ -96,4 +96,65 @@ describe FactoryBot::Internal do
       expect(FactoryBot::Internal.factory_by_name(factory.name)).to eq factory
     end
   end
+
+  describe ".register_factory" do
+    it "registers the provided factory" do
+      factory = FactoryBot::Factory.new(:object)
+      configuration = FactoryBot::Internal.configuration
+      expect { FactoryBot::Internal.register_factory(factory) }.
+        to change { configuration.factories.count }.
+        from(0).
+        to(1)
+    end
+
+    it "returns the registered factory" do
+      factory = FactoryBot::Factory.new(:object)
+      expect(FactoryBot::Internal.register_factory(factory)).to eq factory
+    end
+  end
+
+  describe ".factory_by_name" do
+    it "finds a registered factory" do
+      factory = FactoryBot::Factory.new(:object)
+      FactoryBot::Internal.register_factory(factory)
+      expect(FactoryBot::Internal.factory_by_name(factory.name)).to eq factory
+    end
+  end
+
+  describe ".register_strategy" do
+    it "register the provided strategy name with the class" do
+      configuration = FactoryBot::Internal.configuration
+      initial_strategies_count = configuration.strategies.count
+      expect do
+        FactoryBot::Internal.register_strategy(:strategy_name, :strategy_class)
+      end.to change { configuration.strategies.count }.
+        from(initial_strategies_count).
+        to(initial_strategies_count + 1)
+    end
+  end
+
+  describe ".strategy_by_name" do
+    it "finds a registered strategy" do
+      FactoryBot::Internal.register_strategy(:strategy_name, :strategy_class)
+      expect(FactoryBot::Internal.strategy_by_name(:strategy_name)).
+        to eq :strategy_class
+    end
+  end
+
+  describe "default strategies and callbacks" do
+    FactoryBot::Internal::DEFAULT_STRATEGIES.
+      each do |strategy_name, strategy_class|
+      it "registers the #{strategy_name} strategy by default" do
+        expect(FactoryBot::Internal.strategy_by_name(strategy_name)).
+          to eq strategy_class
+      end
+    end
+
+    FactoryBot::Internal::DEFAULT_CALLBACKS.each do |callback_name|
+      it "registers the #{callback_name} by default" do
+        expect(FactoryBot::Internal.callback_names.include?(callback_name)).
+          to be_truthy
+      end
+    end
+  end
 end

--- a/spec/factory_bot/strategy_calculator_spec.rb
+++ b/spec/factory_bot/strategy_calculator_spec.rb
@@ -13,14 +13,14 @@ describe FactoryBot::StrategyCalculator do
 
   context "when a symbol" do
     before do
-      allow(FactoryBot).to receive(:strategy_by_name).and_return(strategy)
+      allow(FactoryBot::Internal).to receive(:strategy_by_name).and_return(strategy)
     end
 
     subject { FactoryBot::StrategyCalculator.new(:build).strategy }
 
     it "finds the strategy by name" do
       subject
-      expect(FactoryBot).to have_received(:strategy_by_name).with(:build)
+      expect(FactoryBot::Internal).to have_received(:strategy_by_name).with(:build)
     end
 
     it "returns the strategy found" do

--- a/spec/factory_bot_spec.rb
+++ b/spec/factory_bot_spec.rb
@@ -18,6 +18,12 @@ describe FactoryBot do
     expect(FactoryBot.trait_by_name(trait.name)).to eq trait
   end
 
+  it "finds a registered strategy" do
+    FactoryBot.register_strategy(:strategy_name, :strategy_class)
+    expect(FactoryBot.strategy_by_name(:strategy_name)).
+      to eq :strategy_class
+  end
+
   describe ".use_parent_strategy" do
     it "is true by default" do
       expect(FactoryBot.use_parent_strategy).to be true


### PR DESCRIPTION
Why:
These methods are used internally for the functionality of the library
and are subject to change. Therefore shouldn't be part of the public
interface.

This PR:
- Moves the ```register_strategy```, ```register_callback```,
```register_default_factories```, ```register_default_callbacks```
and ```strategy_by_name``` methods to the ```FactoryBot::Internal```
class.
- Deprecates the use of ```register_callback``` from the ```FactoryBot```
module.