### PR TITLE
Change the evaluator association syntax to allow :factory option.

### DIFF
--- a/lib/factory_bot/evaluator.rb
+++ b/lib/factory_bot/evaluator.rb
@@ -21,13 +21,15 @@ module FactoryBot
       end
     end
 
-    def association(factory_name, *traits_and_overrides)
+    # If `factory` option is not provided, `association_name` will be used
+    def association(association_name, *traits_and_overrides)
       overrides = traits_and_overrides.extract_options!
       strategy_override = overrides.fetch(:strategy) do
         FactoryBot.use_parent_strategy ? @build_strategy.class : :create
       end
+      factory_name = overrides[:factory] || association_name
 
-      traits_and_overrides += [overrides.except(:strategy)]
+      traits_and_overrides += [overrides.except(:strategy, :factory)]
 
       runner = FactoryRunner.new(factory_name, strategy_override, traits_and_overrides)
       @build_strategy.association(runner)

--- a/spec/acceptance/associations_spec.rb
+++ b/spec/acceptance/associations_spec.rb
@@ -16,4 +16,86 @@ describe "associations" do
       )
     end
   end
+
+  context "when building an association through the evaluator" do
+    before do
+      define_model("User", name: :string)
+
+      define_model("Thumbnail", user_id: :integer) do
+        belongs_to :user
+      end
+
+      FactoryBot.define do
+        factory :user do
+          name { "John Doe" }
+        end
+
+        factory :thumbnail do
+          user
+        end
+      end
+    end
+
+    context "when the association and factory name match" do
+      before do
+        define_model("Post", user_id: :integer, thumbnail_id: :integer) do
+          belongs_to :user
+          belongs_to :thumbnail
+        end
+
+        FactoryBot.define do
+          factory :post do
+            association(:user, name: "Joe Poster")
+            thumbnail { association(:thumbnail, user: user) }
+          end
+        end
+      end
+
+      it "uses the referenced association's object" do
+        post = FactoryBot.create(:post)
+        expect(post.thumbnail.user).to eq(post.user)
+      end
+    end
+
+    context "when the association and factory do not match" do
+      before do
+        define_model("Comment", user_id: :integer, avatar_id: :integer) do
+          belongs_to :user
+          belongs_to :avatar, class_name: "Thumbnail"
+        end
+      end
+
+      context "when using the factory name directly" do
+        before do
+          FactoryBot.define do
+            factory :comment do
+              association(:user, name: "Joe Commmenter")
+              avatar { association(:thumbnail, user: user) }
+            end
+          end
+        end
+
+        it "uses the referenced association's object" do
+          comment = FactoryBot.create(:comment)
+          expect(comment.avatar.user).to eq(comment.user)
+        end
+      end
+
+      context "when supplying the factory option" do
+        before do
+          FactoryBot.define do
+            factory :comment do
+              association(:user, name: "Joe Commmenter")
+              avatar { association(:avatar, factory: :thumbnail, user: user) }
+            end
+          end
+        end
+
+        it "uses the referenced association's object" do
+          comment = FactoryBot.create(:comment)
+          expect(comment.avatar.user).to eq(comment.user)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This addresses the discussion of #1268 (though it does not create documentation).

This supports the syntax I had initially expected, with the :factory option:
```ruby
association_name { association(:association_name, factory: :factory_name) }
```

It continues to support the original syntax:
```ruby
association_name { association(:factory_name) }
```

It also adds specs for both usages.

This seems like the least impactful change that still works the way I had expected it to. I have some alternative thoughts which I'll address in comments.