### PR TITLE
Pass the index of the object to a block when using *_list methods

### DIFF
--- a/lib/factory_bot/strategy_syntax_method_registrar.rb
+++ b/lib/factory_bot/strategy_syntax_method_registrar.rb
@@ -29,10 +29,10 @@ module FactoryBot
           raise ArgumentError, "count missing for #{strategy_name}_list"
         end
 
-        Array.new(amount) { |i|
-          curried_block = block.nil? ? block : ->(*args) { block.call(*args<<i) }
+        Array.new(amount) do |i|
+          curried_block = block.nil? ? block : ->(*args) { block.call(*args << i) }
           send(strategy_name, name, *traits_and_overrides, &curried_block)
-        }
+        end
       end
     end
 

--- a/lib/factory_bot/strategy_syntax_method_registrar.rb
+++ b/lib/factory_bot/strategy_syntax_method_registrar.rb
@@ -29,7 +29,10 @@ module FactoryBot
           raise ArgumentError, "count missing for #{strategy_name}_list"
         end
 
-        Array.new(amount) { send(strategy_name, name, *traits_and_overrides, &block) }
+        Array.new(amount) { |i|
+          curried_block = block.nil? ? block : ->(*args) { block.call(*args<<i) }
+          send(strategy_name, name, *traits_and_overrides, &curried_block)
+        }
       end
     end
 

--- a/spec/acceptance/build_list_spec.rb
+++ b/spec/acceptance/build_list_spec.rb
@@ -51,4 +51,18 @@ describe "build multiple instances" do
       end
     end
   end
+
+  context "with a block that receives both the object and an index" do
+    subject do
+      FactoryBot.build_list(:post, 20, title: "The Listing of the Indexed Block") do |post, index|
+        post.position = index
+      end
+    end
+
+    it "correctly uses the set value" do
+      subject.each_with_index do |record, index|
+        expect(record.position).to eq index
+      end
+    end
+  end
 end

--- a/spec/acceptance/create_list_spec.rb
+++ b/spec/acceptance/create_list_spec.rb
@@ -52,6 +52,20 @@ describe "create multiple instances" do
     end
   end
 
+  context "with a block that receives both the object and an index" do
+    subject do
+      FactoryBot.create_list(:post, 20, title: "The Listing of the Indexed Block") do |post, index|
+        post.position = index
+      end
+    end
+
+    it "uses the new values" do
+      subject.each_with_index do |record, index|
+        expect(record.position).to eq index
+      end
+    end
+  end
+
   context "without the count" do
     subject { FactoryBot.create_list(:post, title: "The Hunting of the Bear") }
 


### PR DESCRIPTION
When using one of the `*_list` methods, allow the block to receive the object's index.

```ruby
posts = build_list(:post, 10, title: 'Post number') do |post, i|
  post.title = "#{post.title} #{i + 1}"
end

posts.first.title # => "Post number 1"
# ...
posts.last.title  # => "Post number 10"
```