### PR TITLE
Update yard from 0.9.19 to 0.9.20

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
-    yard (0.9.19)
+    yard (0.9.20)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Why:
A security vulnerability has been identified with the 0.9.19 version of
the yard gem. More details
[here](https://github.com/lsegal/yard/security/advisories/GHSA-xfhh-rx56-rxcr)

This PR:
Updates the yard gem version.