### PR TITLE
Use sqlite in-memory DB in specs

### DIFF
--- a/features/support/factories.rb
+++ b/features/support/factories.rb
@@ -1,6 +1,6 @@
 ActiveRecord::Base.establish_connection(
   adapter: "sqlite3",
-  database: File.join(File.dirname(__FILE__), "test.db"),
+  database: ":memory:",
 )
 
 migration_class =

--- a/spec/support/macros/define_constant.rb
+++ b/spec/support/macros/define_constant.rb
@@ -57,7 +57,7 @@ RSpec.configure do |config|
   config.before(:all) do
     ActiveRecord::Base.establish_connection(
       adapter:  "sqlite3",
-      database: File.join(File.dirname(__FILE__), "test.db"),
+      database: ":memory:",
     )
   end
 


### PR DESCRIPTION
This PR is partly out of curiousity 📚  (I've always read about this mode but not used it), but it also makes specs faster (on my machine at least).

## Benchmark

| Iteration | Before | After    |
|-----------|--------|----------|
| 1         | 7.974  | 6.294    |
| 2         | 7.727  | 6.292    |
| 3         | 7.684  | 6.320    |
| 4         | 7.813  | 6.345    |
| 5         | 8.207  | 6.278    |
| 6         | 7.918  | 6.229    |
| 7         | 7.785  | 6.249    |
| 8         | 7.856  | 6.281    |
| 9         | 7.894  | 6.273    |
| 10        | 7.767  | 6.287    |
| Avg       | 7.863  | 6.285    |
| Diff      |        | -20.066% |

Test command:

```
repeat 10 { time bundle exec rake 2>/dev/null } | grep total
```

## Reference

https://www.sqlite.org/inmemorydb.html