### PR TITLE
Remove Timecop / time travel

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,6 @@ GEM
     sqlite3 (1.4.1)
     thor (0.20.3)
     thread_safe (0.3.6)
-    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
@@ -122,8 +121,7 @@ DEPENDENCIES
   rubocop (= 0.54)
   simplecov
   sqlite3
-  timecop
   yard
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/factory_bot.gemspec
+++ b/factory_bot.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rubocop", "0.54")
   s.add_development_dependency("simplecov")
   s.add_development_dependency("sqlite3")
-  s.add_development_dependency("timecop")
   s.add_development_dependency("yard")
 
   s.license = "MIT"

--- a/gemfiles/4.2.gemfile.lock
+++ b/gemfiles/4.2.gemfile.lock
@@ -102,7 +102,6 @@ GEM
     sqlite3 (1.3.13)
     thor (0.20.3)
     thread_safe (0.3.6)
-    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
@@ -123,8 +122,7 @@ DEPENDENCIES
   rubocop (= 0.54)
   simplecov
   sqlite3 (~> 1.3.6)
-  timecop
   yard
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/gemfiles/5.0.gemfile.lock
+++ b/gemfiles/5.0.gemfile.lock
@@ -101,7 +101,6 @@ GEM
     sqlite3 (1.3.13)
     thor (0.20.3)
     thread_safe (0.3.6)
-    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
@@ -122,8 +121,7 @@ DEPENDENCIES
   rubocop (= 0.54)
   simplecov
   sqlite3 (~> 1.3.6)
-  timecop
   yard
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/gemfiles/5.1.gemfile.lock
+++ b/gemfiles/5.1.gemfile.lock
@@ -101,7 +101,6 @@ GEM
     sqlite3 (1.4.1)
     thor (0.20.3)
     thread_safe (0.3.6)
-    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
@@ -122,8 +121,7 @@ DEPENDENCIES
   rubocop (= 0.54)
   simplecov
   sqlite3
-  timecop
   yard
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/gemfiles/5.2.gemfile.lock
+++ b/gemfiles/5.2.gemfile.lock
@@ -101,7 +101,6 @@ GEM
     sqlite3 (1.4.1)
     thor (0.20.3)
     thread_safe (0.3.6)
-    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
@@ -122,8 +121,7 @@ DEPENDENCIES
   rubocop (= 0.54)
   simplecov
   sqlite3
-  timecop
   yard
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/gemfiles/6.0.gemfile.lock
+++ b/gemfiles/6.0.gemfile.lock
@@ -100,7 +100,6 @@ GEM
     sqlite3 (1.4.1)
     thor (0.20.3)
     thread_safe (0.3.6)
-    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
@@ -122,8 +121,7 @@ DEPENDENCIES
   rubocop (= 0.54)
   simplecov
   sqlite3
-  timecop
   yard
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/spec/acceptance/build_stubbed_spec.rb
+++ b/spec/acceptance/build_stubbed_spec.rb
@@ -148,12 +148,10 @@ describe "defaulting `created_at`" do
       factory :thing_with_timestamp
       factory :thing_without_timestamp
     end
-
-    travel_to(Time.now)
   end
 
   it "defaults created_at for objects with created_at" do
-    expect(build_stubbed(:thing_with_timestamp).created_at).to eq Time.now
+    expect(build_stubbed(:thing_with_timestamp).created_at).to be_about_now
   end
 
   it "is doesn't mark the object as changed" do
@@ -179,9 +177,10 @@ describe "defaulting `created_at`" do
 
   it "allows assignment of created_at" do
     stub = build_stubbed(:thing_with_timestamp)
-    expect(stub.created_at).to eq Time.now
-    stub.created_at = 3.days.ago
-    expect(stub.created_at).to eq 3.days.ago
+    expect(stub.created_at).to be_about_now
+    past_time = 3.days.ago
+    stub.created_at = past_time
+    expect(stub.created_at).to eq past_time
   end
 
   it "behaves the same as a non-stubbed created_at" do
@@ -213,12 +212,10 @@ describe "defaulting `updated_at`" do
       factory :thing_with_timestamp
       factory :thing_without_timestamp
     end
-
-    travel_to(Time.now)
   end
 
   it "defaults updated_at for objects with updated_at" do
-    expect(build_stubbed(:thing_with_timestamp).updated_at).to eq Time.current
+    expect(build_stubbed(:thing_with_timestamp).updated_at).to be_about_now
   end
 
   it "is doesn't mark the object as changed" do
@@ -232,8 +229,9 @@ describe "defaulting `updated_at`" do
   end
 
   it "allows overriding updated_at for objects with updated_at" do
-    stubbed = build_stubbed(:thing_with_timestamp, updated_at: 3.days.ago)
-    expect(stubbed.updated_at).to eq 3.days.ago
+    past_time = 3.days.ago
+    stubbed = build_stubbed(:thing_with_timestamp, updated_at: past_time)
+    expect(stubbed.updated_at).to eq past_time
   end
 
   it "doesn't allow setting updated_at on an object that doesn't define it" do
@@ -244,9 +242,10 @@ describe "defaulting `updated_at`" do
 
   it "allows assignment of updated_at" do
     stub = build_stubbed(:thing_with_timestamp)
-    expect(stub.updated_at).to eq Time.now
-    stub.updated_at = 3.days.ago
-    expect(stub.updated_at).to eq 3.days.ago
+    expect(stub.updated_at).to be_about_now
+    past_time = 3.days.ago
+    stub.updated_at = past_time
+    expect(stub.updated_at).to eq past_time
   end
 
   it "behaves the same as a non-stubbed updated_at" do

--- a/spec/acceptance/build_stubbed_spec.rb
+++ b/spec/acceptance/build_stubbed_spec.rb
@@ -149,7 +149,7 @@ describe "defaulting `created_at`" do
       factory :thing_without_timestamp
     end
 
-    Timecop.freeze 2012, 1, 1
+    travel_to(Time.now)
   end
 
   it "defaults created_at for objects with created_at" do
@@ -214,7 +214,7 @@ describe "defaulting `updated_at`" do
       factory :thing_without_timestamp
     end
 
-    Timecop.freeze 2012, 1, 1
+    travel_to(Time.now)
   end
 
   it "defaults updated_at for objects with updated_at" do

--- a/spec/factory_bot/strategy/stub_spec.rb
+++ b/spec/factory_bot/strategy/stub_spec.rb
@@ -23,7 +23,7 @@ describe FactoryBot::Strategy::Stub do
   it_should_behave_like "strategy with strategy: :build", :build_stubbed
 
   context "asking for a result" do
-    before { Timecop.freeze(Time.now) }
+    before { travel_to(Time.now) }
     let(:result_instance) do
       define_class("ResultInstance") do
         attr_accessor :id, :created_at
@@ -42,7 +42,7 @@ describe FactoryBot::Strategy::Stub do
       created_at = subject.result(evaluation).created_at
       expect(created_at).to eq Time.now
 
-      Timecop.travel(150000)
+      travel_to(2.days.from_now)
 
       expect(subject.result(evaluation).created_at).to eq created_at
     end

--- a/spec/factory_bot/strategy/stub_spec.rb
+++ b/spec/factory_bot/strategy/stub_spec.rb
@@ -23,7 +23,6 @@ describe FactoryBot::Strategy::Stub do
   it_should_behave_like "strategy with strategy: :build", :build_stubbed
 
   context "asking for a result" do
-    before { travel_to(Time.now) }
     let(:result_instance) do
       define_class("ResultInstance") do
         attr_accessor :id, :created_at
@@ -39,12 +38,10 @@ describe FactoryBot::Strategy::Stub do
     it { expect(subject.result(evaluation)).not_to be_destroyed }
 
     it "assigns created_at" do
-      created_at = subject.result(evaluation).created_at
-      expect(created_at).to eq Time.now
+      created_at1 = subject.result(evaluation).created_at
+      created_at2 = subject.result(evaluation).created_at
 
-      travel_to(2.days.from_now)
-
-      expect(subject.result(evaluation).created_at).to eq created_at
+      expect(created_at1).to equal created_at2
     end
 
     include_examples "disabled persistence method", :connection

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ require "rspec/its"
 require "simplecov"
 
 require "factory_bot"
-require "active_support/testing/time_helpers"
 
 Dir["spec/support/**/*.rb"].each { |f| require File.expand_path(f) }
 
@@ -17,14 +16,9 @@ RSpec.configure do |config|
   end
 
   config.include DeclarationMatchers
-  config.include ActiveSupport::Testing::TimeHelpers
 
   config.before do
     FactoryBot.reload
-  end
-
-  config.after do
-    travel_back
   end
 
   config.around do |example|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require "rspec/its"
 require "simplecov"
 
 require "factory_bot"
-require "timecop"
+require "active_support/testing/time_helpers"
 
 Dir["spec/support/**/*.rb"].each { |f| require File.expand_path(f) }
 
@@ -17,13 +17,14 @@ RSpec.configure do |config|
   end
 
   config.include DeclarationMatchers
+  config.include ActiveSupport::Testing::TimeHelpers
 
   config.before do
     FactoryBot.reload
   end
 
   config.after do
-    Timecop.return
+    travel_back
   end
 
   config.around do |example|

--- a/spec/support/matchers/be_about_now.rb
+++ b/spec/support/matchers/be_about_now.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define :be_about_now do
+  match do |actual|
+    expect(actual).to be_within(2.seconds).of(Time.now)
+  end
+end


### PR DESCRIPTION
This PR is made up of two commits, which may make more sense reviewed invidiually:

1. Removes `TimeCop` in favour of `ActiveSupport::Testing::TimeHelpers` (removes a dev dependency from the project)
2. (Optional) Avoids freezing / travelling through time altogether

Happy to remove the second change from the PR if it's a step too far.