### PR TITLE
[Tests] Adjust global state in blocks

### DIFF
--- a/spec/acceptance/build_spec.rb
+++ b/spec/acceptance/build_spec.rb
@@ -22,20 +22,20 @@ describe "a built instance" do
   it { should be_new_record }
 
   context "when the :use_parent_strategy config option is set to false" do
-    before { FactoryBot.use_parent_strategy = false }
-
     it "assigns and saves associations" do
-      expect(subject.user).to be_kind_of(User)
-      expect(subject.user).not_to be_new_record
+      with_temporary_assignment(FactoryBot, :use_parent_strategy, false) do
+        expect(subject.user).to be_kind_of(User)
+        expect(subject.user).not_to be_new_record
+      end
     end
   end
 
   context "when the :use_parent_strategy config option is set to true" do
-    before { FactoryBot.use_parent_strategy = true }
-
     it "assigns but does not save associations" do
-      expect(subject.user).to be_kind_of(User)
-      expect(subject.user).to be_new_record
+      with_temporary_assignment(FactoryBot, :use_parent_strategy, true) do
+        expect(subject.user).to be_kind_of(User)
+        expect(subject.user).to be_new_record
+      end
     end
   end
 end

--- a/spec/acceptance/register_strategies_spec.rb
+++ b/spec/acceptance/register_strategies_spec.rb
@@ -99,24 +99,24 @@ describe "associations without overriding :strategy" do
   end
 
   context "when the :use_parent_strategy config option is set to false" do
-    before { FactoryBot.use_parent_strategy = false }
-
     it "uses the overridden strategy on the association" do
       FactoryBot.register_strategy(:create, custom_strategy)
 
-      post = FactoryBot.build(:post)
-      expect(post.user.name).to eq "Custom strategy"
+      with_temporary_assignment(FactoryBot, :use_parent_strategy, false) do
+        post = FactoryBot.build(:post)
+        expect(post.user.name).to eq "Custom strategy"
+      end
     end
   end
 
   context "when the :use_parent_strategy config option is set to true" do
-    before { FactoryBot.use_parent_strategy = true }
-
     it "uses the parent strategy on the association" do
       FactoryBot.register_strategy(:create, custom_strategy)
 
-      post = FactoryBot.build(:post)
-      expect(post.user.name).to eq "John Doe"
+      with_temporary_assignment(FactoryBot, :use_parent_strategy, true) do
+        post = FactoryBot.build(:post)
+        expect(post.user.name).to eq "John Doe"
+      end
     end
   end
 end

--- a/spec/acceptance/reload_spec.rb
+++ b/spec/acceptance/reload_spec.rb
@@ -1,10 +1,10 @@
 describe "reload" do
   it "does not reset the value of use_parent_strategy" do
-    use_parent_strategy = :custom_use_parent_strategy_value
-    FactoryBot.use_parent_strategy = use_parent_strategy
+    custom_strategy = :custom_use_parent_strategy_value
 
-    FactoryBot.reload
-
-    expect(FactoryBot.use_parent_strategy).to eq use_parent_strategy
+    with_temporary_assignment(FactoryBot, :use_parent_strategy, custom_strategy) do
+      FactoryBot.reload
+      expect(FactoryBot.use_parent_strategy).to eq custom_strategy
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,15 +21,6 @@ RSpec.configure do |config|
     FactoryBot.reload
   end
 
-  config.around do |example|
-    begin
-      previous_use_parent_strategy = FactoryBot.use_parent_strategy
-      example.run
-    ensure
-      FactoryBot.use_parent_strategy = previous_use_parent_strategy
-    end
-  end
-
   config.order = :random
   Kernel.srand config.seed
 

--- a/spec/support/macros/deprecation.rb
+++ b/spec/support/macros/deprecation.rb
@@ -1,18 +1,9 @@
 require "active_support"
 
-module SilenceDeprecation
-  def silence_deprecation(example)
-    cached_silenced = FactoryBot::Deprecation.silenced
-    FactoryBot::Deprecation.silenced = true
-    example.run
-    FactoryBot::Deprecation.silenced = cached_silenced
-  end
-end
-
 RSpec.configure do |config|
-  config.include SilenceDeprecation
-
   config.around :example, silence_deprecation: true do |example|
-    silence_deprecation(example)
+    with_temporary_assignment(FactoryBot::Deprecation, :silenced, true) do
+      example.run
+    end
   end
 end

--- a/spec/support/macros/temporary_assignment.rb
+++ b/spec/support/macros/temporary_assignment.rb
@@ -1,0 +1,14 @@
+module TemporaryAssignment
+  def with_temporary_assignment(assignee, attribute, temporary_value)
+    original_value = assignee.public_send(attribute)
+    attribute_setter = "#{attribute}="
+    assignee.public_send(attribute_setter, temporary_value)
+    yield
+  ensure
+    assignee.public_send(attribute_setter, original_value)
+  end
+end
+
+RSpec.configure do |config|
+  config.include TemporaryAssignment
+end


### PR DESCRIPTION
I noticed in `spec_helper.rb` there's a global `around` to reset some state:

https://github.com/thoughtbot/factory_bot/blob/eb6bccb3e3cdeef6948cfb7b187e084982318075/spec/spec_helper.rb#L24-L31

This PR proposes switching to a block-based helper to safely adjust global state in the specs which need to do so. When the block is completed, the value is reset.