### PR TITLE
Support JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - jruby-9.2.8.0
   - ruby-head
 before_install:
   - gem update --system

--- a/Appraisals
+++ b/Appraisals
@@ -33,7 +33,7 @@ end
 appraise "6.0" do
   gem "activerecord", "~> 6.0.0"
   group :development do
-    gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+    gem "activerecord-jdbcsqlite3-adapter", "~> 60.0.rc1", platforms: [:jruby]
     gem "sqlite3", platforms: [:ruby]
   end
 end

--- a/Appraisals
+++ b/Appraisals
@@ -1,21 +1,39 @@
 appraise "4.2" do
   gem "activerecord", "~> 4.2.11"
-  gem "sqlite3", "~> 1.3.6"
+  group :development do
+    gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+    gem "sqlite3", "~> 1.3.6", platforms: [:ruby]
+  end
 end
 
 appraise "5.0" do
   gem "activerecord", "~> 5.0.7"
-  gem "sqlite3", "~> 1.3.6"
+  group :development do
+    gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+    gem "sqlite3", "~> 1.3.6", platforms: [:ruby]
+  end
 end
 
 appraise "5.1" do
   gem "activerecord", "~> 5.1.7"
+  group :development do
+    gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+    gem "sqlite3", platforms: [:ruby]
+  end
 end
 
 appraise "5.2" do
   gem "activerecord", "~> 5.2.3"
+  group :development do
+    gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+    gem "sqlite3", platforms: [:ruby]
+  end
 end
 
 appraise "6.0" do
   gem "activerecord", "~> 6.0.0"
+  group :development do
+    gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+    gem "sqlite3", platforms: [:ruby]
+  end
 end

--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,7 @@
 appraise "4.2" do
   gem "activerecord", "~> 4.2.11"
   group :development do
-    gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+    gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.25", platforms: [:jruby]
     gem "sqlite3", "~> 1.3.6", platforms: [:ruby]
   end
 end

--- a/Appraisals
+++ b/Appraisals
@@ -1,39 +1,29 @@
 appraise "4.2" do
   gem "activerecord", "~> 4.2.11"
-  group :development do
-    gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.25", platforms: [:jruby]
-    gem "sqlite3", "~> 1.3.6", platforms: [:ruby]
-  end
+  gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.25", platforms: [:jruby]
+  gem "sqlite3", "~> 1.3.6", platforms: [:ruby]
 end
 
 appraise "5.0" do
   gem "activerecord", "~> 5.0.7"
-  group :development do
-    gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
-    gem "sqlite3", "~> 1.3.6", platforms: [:ruby]
-  end
+  gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+  gem "sqlite3", "~> 1.3.6", platforms: [:ruby]
 end
 
 appraise "5.1" do
   gem "activerecord", "~> 5.1.7"
-  group :development do
-    gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
-    gem "sqlite3", platforms: [:ruby]
-  end
+  gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+  gem "sqlite3", platforms: [:ruby]
 end
 
 appraise "5.2" do
   gem "activerecord", "~> 5.2.3"
-  group :development do
-    gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
-    gem "sqlite3", platforms: [:ruby]
-  end
+  gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+  gem "sqlite3", platforms: [:ruby]
 end
 
 appraise "6.0" do
   gem "activerecord", "~> 6.0.0"
-  group :development do
-    gem "activerecord-jdbcsqlite3-adapter", "~> 60.0.rc1", platforms: [:jruby]
-    gem "sqlite3", platforms: [:ruby]
-  end
+  gem "activerecord-jdbcsqlite3-adapter", "~> 60.0.rc1", platforms: [:jruby]
+  gem "sqlite3", platforms: [:ruby]
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source "https://rubygems.org"
 
-group :development do
-  gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
-  gem "sqlite3", platforms: [:ruby]
-end
+gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+gem "sqlite3", platforms: [:ruby]
 
 gemspec name: "factory_bot"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,9 @@
 source "https://rubygems.org"
 
+# Development dependencies
+group :development do
+  gem "sqlite3", :platforms => [:ruby]
+  gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
+end
+
 gemspec name: "factory_bot"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-# Development dependencies
 group :development do
   gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
   gem "sqlite3", platforms: [:ruby]

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source "https://rubygems.org"
 
 # Development dependencies
 group :development do
-  gem "sqlite3", :platforms => [:ruby]
-  gem "activerecord-jdbcsqlite3-adapter", :platforms => [:jruby]
+  gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+  gem "sqlite3", platforms: [:ruby]
 end
 
 gemspec name: "factory_bot"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,10 +56,12 @@ GEM
     diff-lcs (1.3)
     docile (1.3.2)
     ffi (1.11.1)
+    ffi (1.11.1-java)
     gherkin (5.1.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     json (2.2.0)
+    json (2.2.0-java)
     minitest (5.11.3)
     multi_json (1.13.1)
     multi_test (0.1.2)
@@ -107,6 +109,7 @@ GEM
     yard (0.9.20)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,11 @@ GEM
       activemodel (= 5.2.3)
       activesupport (= 5.2.3)
       arel (>= 9.0)
+    activerecord-jdbc-adapter (52.3-java)
+      activerecord (~> 5.2.0)
+    activerecord-jdbcsqlite3-adapter (52.3-java)
+      activerecord-jdbc-adapter (= 52.3)
+      jdbc-sqlite3 (~> 3.8, < 3.30)
     activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -60,6 +65,7 @@ GEM
     gherkin (5.1.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    jdbc-sqlite3 (3.28.0)
     json (2.2.0)
     json (2.2.0-java)
     minitest (5.11.3)
@@ -103,6 +109,7 @@ GEM
     sqlite3 (1.4.1)
     thor (0.20.3)
     thread_safe (0.3.6)
+    thread_safe (0.3.6-java)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
@@ -114,6 +121,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord
+  activerecord-jdbcsqlite3-adapter
   appraisal
   aruba
   cucumber

--- a/factory_bot.gemspec
+++ b/factory_bot.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rspec-its")
   s.add_development_dependency("rubocop", "0.54")
   s.add_development_dependency("simplecov")
-  s.add_development_dependency("sqlite3")
   s.add_development_dependency("yard")
 
   s.license = "MIT"

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "activerecord", "~> 4.2.11"
 
 group :development do
-  gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+  gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.25", platforms: [:jruby]
   gem "sqlite3", "~> 1.3.6", platforms: [:ruby]
 end
 

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -3,6 +3,10 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 4.2.11"
-gem "sqlite3", "~> 1.3.6"
+
+group :development do
+  gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+  gem "sqlite3", "~> 1.3.6", platforms: [:ruby]
+end
 
 gemspec name: "factory_bot", path: "../"

--- a/gemfiles/4.2.gemfile.lock
+++ b/gemfiles/4.2.gemfile.lock
@@ -14,6 +14,11 @@ GEM
       activemodel (= 4.2.11.1)
       activesupport (= 4.2.11.1)
       arel (~> 6.0)
+    activerecord-jdbc-adapter (50.0)
+      activerecord (>= 2.2)
+    activerecord-jdbcsqlite3-adapter (50.0)
+      activerecord-jdbc-adapter (~> 50.0)
+      jdbc-sqlite3 (~> 3.8, < 3.30)
     activesupport (4.2.11.1)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -57,10 +62,13 @@ GEM
     diff-lcs (1.3)
     docile (1.3.2)
     ffi (1.11.1)
+    ffi (1.11.1-java)
     gherkin (5.1.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    jdbc-sqlite3 (3.28.0)
     json (2.2.0)
+    json (2.2.0-java)
     minitest (5.11.3)
     multi_json (1.13.1)
     multi_test (0.1.2)
@@ -102,12 +110,14 @@ GEM
     sqlite3 (1.3.13)
     thor (0.20.3)
     thread_safe (0.3.6)
+    thread_safe (0.3.6-java)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
     yard (0.9.19)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES

--- a/gemfiles/4.2.gemfile.lock
+++ b/gemfiles/4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    factory_bot (5.0.2)
+    factory_bot (5.1.0)
       activesupport (>= 4.2.0)
 
 GEM
@@ -112,6 +112,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 4.2.11)
+  activerecord-jdbcsqlite3-adapter
   appraisal
   aruba
   cucumber

--- a/gemfiles/4.2.gemfile.lock
+++ b/gemfiles/4.2.gemfile.lock
@@ -14,11 +14,11 @@ GEM
       activemodel (= 4.2.11.1)
       activesupport (= 4.2.11.1)
       arel (~> 6.0)
-    activerecord-jdbc-adapter (50.0)
-      activerecord (>= 2.2)
-    activerecord-jdbcsqlite3-adapter (50.0)
-      activerecord-jdbc-adapter (~> 50.0)
-      jdbc-sqlite3 (~> 3.8, < 3.30)
+    activerecord-jdbc-adapter (1.3.25)
+      activerecord (>= 2.2, < 5.0)
+    activerecord-jdbcsqlite3-adapter (1.3.25)
+      activerecord-jdbc-adapter (~> 1.3.25)
+      jdbc-sqlite3 (>= 3.7.2, < 3.9)
     activesupport (4.2.11.1)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -66,7 +66,7 @@ GEM
     gherkin (5.1.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jdbc-sqlite3 (3.28.0)
+    jdbc-sqlite3 (3.8.11.2)
     json (2.2.0)
     json (2.2.0-java)
     minitest (5.11.3)
@@ -122,7 +122,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 4.2.11)
-  activerecord-jdbcsqlite3-adapter
+  activerecord-jdbcsqlite3-adapter (~> 1.3.25)
   appraisal
   aruba
   cucumber

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -3,6 +3,10 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 5.0.7"
-gem "sqlite3", "~> 1.3.6"
+
+group :development do
+  gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+  gem "sqlite3", "~> 1.3.6", platforms: [:ruby]
+end
 
 gemspec name: "factory_bot", path: "../"

--- a/gemfiles/5.0.gemfile.lock
+++ b/gemfiles/5.0.gemfile.lock
@@ -13,6 +13,11 @@ GEM
       activemodel (= 5.0.7.2)
       activesupport (= 5.0.7.2)
       arel (~> 7.0)
+    activerecord-jdbc-adapter (50.4-java)
+      activerecord (~> 5.0.0, >= 5.0.3)
+    activerecord-jdbcsqlite3-adapter (50.4-java)
+      activerecord-jdbc-adapter (= 50.4)
+      jdbc-sqlite3 (~> 3.8, < 3.30)
     activesupport (5.0.7.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -56,10 +61,13 @@ GEM
     diff-lcs (1.3)
     docile (1.3.2)
     ffi (1.11.1)
+    ffi (1.11.1-java)
     gherkin (5.1.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    jdbc-sqlite3 (3.28.0)
     json (2.2.0)
+    json (2.2.0-java)
     minitest (5.11.3)
     multi_json (1.13.1)
     multi_test (0.1.2)
@@ -101,12 +109,14 @@ GEM
     sqlite3 (1.3.13)
     thor (0.20.3)
     thread_safe (0.3.6)
+    thread_safe (0.3.6-java)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
     yard (0.9.19)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES

--- a/gemfiles/5.0.gemfile.lock
+++ b/gemfiles/5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    factory_bot (5.0.2)
+    factory_bot (5.1.0)
       activesupport (>= 4.2.0)
 
 GEM
@@ -111,6 +111,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 5.0.7)
+  activerecord-jdbcsqlite3-adapter
   appraisal
   aruba
   cucumber

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -4,4 +4,9 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 5.1.7"
 
+group :development do
+  gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+  gem "sqlite3", platforms: [:ruby]
+end
+
 gemspec name: "factory_bot", path: "../"

--- a/gemfiles/5.1.gemfile.lock
+++ b/gemfiles/5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    factory_bot (5.0.2)
+    factory_bot (5.1.0)
       activesupport (>= 4.2.0)
 
 GEM
@@ -111,6 +111,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 5.1.7)
+  activerecord-jdbcsqlite3-adapter
   appraisal
   aruba
   cucumber

--- a/gemfiles/5.1.gemfile.lock
+++ b/gemfiles/5.1.gemfile.lock
@@ -13,6 +13,11 @@ GEM
       activemodel (= 5.1.7)
       activesupport (= 5.1.7)
       arel (~> 8.0)
+    activerecord-jdbc-adapter (51.4-java)
+      activerecord (~> 5.1.0)
+    activerecord-jdbcsqlite3-adapter (51.4-java)
+      activerecord-jdbc-adapter (= 51.4)
+      jdbc-sqlite3 (~> 3.8, < 3.30)
     activesupport (5.1.7)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -56,10 +61,13 @@ GEM
     diff-lcs (1.3)
     docile (1.3.2)
     ffi (1.11.1)
+    ffi (1.11.1-java)
     gherkin (5.1.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    jdbc-sqlite3 (3.28.0)
     json (2.2.0)
+    json (2.2.0-java)
     minitest (5.11.3)
     multi_json (1.13.1)
     multi_test (0.1.2)
@@ -101,12 +109,14 @@ GEM
     sqlite3 (1.4.1)
     thor (0.20.3)
     thread_safe (0.3.6)
+    thread_safe (0.3.6-java)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
     yard (0.9.19)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES

--- a/gemfiles/5.2.gemfile
+++ b/gemfiles/5.2.gemfile
@@ -4,4 +4,9 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 5.2.3"
 
+group :development do
+  gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+  gem "sqlite3", platforms: [:ruby]
+end
+
 gemspec name: "factory_bot", path: "../"

--- a/gemfiles/5.2.gemfile.lock
+++ b/gemfiles/5.2.gemfile.lock
@@ -13,6 +13,11 @@ GEM
       activemodel (= 5.2.3)
       activesupport (= 5.2.3)
       arel (>= 9.0)
+    activerecord-jdbc-adapter (52.3-java)
+      activerecord (~> 5.2.0)
+    activerecord-jdbcsqlite3-adapter (52.3-java)
+      activerecord-jdbc-adapter (= 52.3)
+      jdbc-sqlite3 (~> 3.8, < 3.30)
     activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -56,10 +61,13 @@ GEM
     diff-lcs (1.3)
     docile (1.3.2)
     ffi (1.11.1)
+    ffi (1.11.1-java)
     gherkin (5.1.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    jdbc-sqlite3 (3.28.0)
     json (2.2.0)
+    json (2.2.0-java)
     minitest (5.11.3)
     multi_json (1.13.1)
     multi_test (0.1.2)
@@ -101,12 +109,14 @@ GEM
     sqlite3 (1.4.1)
     thor (0.20.3)
     thread_safe (0.3.6)
+    thread_safe (0.3.6-java)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
     yard (0.9.19)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES

--- a/gemfiles/5.2.gemfile.lock
+++ b/gemfiles/5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    factory_bot (5.0.2)
+    factory_bot (5.1.0)
       activesupport (>= 4.2.0)
 
 GEM
@@ -111,6 +111,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 5.2.3)
+  activerecord-jdbcsqlite3-adapter
   appraisal
   aruba
   cucumber

--- a/gemfiles/6.0.gemfile
+++ b/gemfiles/6.0.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "activerecord", "~> 6.0.0"
 
 group :development do
-  gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+  gem "activerecord-jdbcsqlite3-adapter", "~> 60.0.rc1", platforms: [:jruby]
   gem "sqlite3", platforms: [:ruby]
 end
 

--- a/gemfiles/6.0.gemfile
+++ b/gemfiles/6.0.gemfile
@@ -4,4 +4,9 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 6.0.0"
 
+group :development do
+  gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+  gem "sqlite3", platforms: [:ruby]
+end
+
 gemspec name: "factory_bot", path: "../"

--- a/gemfiles/6.0.gemfile.lock
+++ b/gemfiles/6.0.gemfile.lock
@@ -12,10 +12,10 @@ GEM
     activerecord (6.0.0)
       activemodel (= 6.0.0)
       activesupport (= 6.0.0)
-    activerecord-jdbc-adapter (50.0)
-      activerecord (>= 2.2)
-    activerecord-jdbcsqlite3-adapter (50.0)
-      activerecord-jdbc-adapter (~> 50.0)
+    activerecord-jdbc-adapter (60.0.rc1-java)
+      activerecord (~> 6.0.0.rc1)
+    activerecord-jdbcsqlite3-adapter (60.0.rc1-java)
+      activerecord-jdbc-adapter (= 60.0.rc1)
       jdbc-sqlite3 (~> 3.8, < 3.30)
     activesupport (6.0.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -121,7 +121,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 6.0.0)
-  activerecord-jdbcsqlite3-adapter
+  activerecord-jdbcsqlite3-adapter (~> 60.0.rc1)
   appraisal
   aruba
   cucumber

--- a/gemfiles/6.0.gemfile.lock
+++ b/gemfiles/6.0.gemfile.lock
@@ -12,6 +12,11 @@ GEM
     activerecord (6.0.0)
       activemodel (= 6.0.0)
       activesupport (= 6.0.0)
+    activerecord-jdbc-adapter (50.0)
+      activerecord (>= 2.2)
+    activerecord-jdbcsqlite3-adapter (50.0)
+      activerecord-jdbc-adapter (~> 50.0)
+      jdbc-sqlite3 (~> 3.8, < 3.30)
     activesupport (6.0.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -55,10 +60,13 @@ GEM
     diff-lcs (1.3)
     docile (1.3.2)
     ffi (1.11.1)
+    ffi (1.11.1-java)
     gherkin (5.1.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    jdbc-sqlite3 (3.28.0)
     json (2.2.0)
+    json (2.2.0-java)
     minitest (5.11.3)
     multi_json (1.13.1)
     multi_test (0.1.2)
@@ -100,6 +108,7 @@ GEM
     sqlite3 (1.4.1)
     thor (0.20.3)
     thread_safe (0.3.6)
+    thread_safe (0.3.6-java)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
@@ -107,6 +116,7 @@ GEM
     zeitwerk (2.1.9)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES

--- a/gemfiles/6.0.gemfile.lock
+++ b/gemfiles/6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    factory_bot (5.0.2)
+    factory_bot (5.1.0)
       activesupport (>= 4.2.0)
 
 GEM
@@ -111,6 +111,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 6.0.0)
+  activerecord-jdbcsqlite3-adapter
   appraisal
   aruba
   cucumber

--- a/lib/factory_bot/internal.rb
+++ b/lib/factory_bot/internal.rb
@@ -86,7 +86,7 @@ module FactoryBot
       end
 
       def register_default_strategies
-        DEFAULT_STRATEGIES.each(&method(:register_strategy))
+        DEFAULT_STRATEGIES.each { |name, klass| register_strategy(name, klass) }
       end
 
       def register_default_callbacks

--- a/spec/acceptance/keyed_by_class_spec.rb
+++ b/spec/acceptance/keyed_by_class_spec.rb
@@ -11,7 +11,7 @@ describe "finding factories keyed by class instead of symbol" do
 
   it "doesn't find the factory" do
     expect { FactoryBot.create(User) }.to(
-      raise_error(KeyError, "Factory not registered: #{User.inspect}"),
+      raise_error(KeyError, /Factory not registered: User/),
     )
   end
 end


### PR DESCRIPTION
This fixes #1331. 

Details:
* Build with JRuby on Travis.
* Use different sqlite3 driver for tests on JRuby, both in the main Gemfile and in the Appraisals, requiring compatible versions for Rails 4.2 and 6.0.
* Change `register_default_strategies` to use a regular block.
* Loosen a spec that checks for KeyError message, which is slightly different on JRuby.