### PR TITLE
Refactor aliases_spec.rb to more closely adhere to the Let's Not school of RSpec

### DIFF
--- a/spec/factory_bot/aliases_spec.rb
+++ b/spec/factory_bot/aliases_spec.rb
@@ -1,19 +1,19 @@
 describe FactoryBot, "aliases" do
-  it "aliases for an attribute should include the original attribute and a version suffixed with '_id'" do
+  it "for an attribute should include the original attribute and a version suffixed with '_id'" do
     aliases = FactoryBot.aliases_for(:test)
 
     expect(aliases).to include(:test)
     expect(aliases).to include(:test_id)
   end
 
-  it "aliases for a foreign key should include both the suffixed and un-suffixed variants" do
+  it "for a foreign key should include both the suffixed and un-suffixed variants" do
     aliases = FactoryBot.aliases_for(:test_id)
 
     expect(aliases).to include(:test)
     expect(aliases).to include(:test_id)
   end
 
-  it "aliases for an attribute which starts with an underscore should not include a non-underscored version" do
+  it "for an attribute which starts with an underscore should not include a non-underscored version" do
     aliases = FactoryBot.aliases_for(:_id)
 
     expect(aliases).not_to include(:id)

--- a/spec/factory_bot/aliases_spec.rb
+++ b/spec/factory_bot/aliases_spec.rb
@@ -1,29 +1,42 @@
 describe FactoryBot, "aliases" do
-  context "aliases for an attribute" do
-    subject { FactoryBot.aliases_for(:test) }
-    it      { should include(:test) }
-    it      { should include(:test_id) }
+  it "aliases for an attribute should include the original attribute and a version suffixed with '_id'" do
+    aliases = FactoryBot.aliases_for(:test)
+
+    expect(aliases).to include(:test)
+    expect(aliases).to include(:test_id)
   end
 
-  context "aliases for a foreign key" do
-    subject { FactoryBot.aliases_for(:test_id) }
-    it      { should include(:test) }
-    it      { should include(:test_id) }
+  it "aliases for a foreign key should include the un-suffixed attribute name" do
+    aliases = FactoryBot.aliases_for(:test_id)
+
+    expect(aliases).to include(:test)
   end
 
-  context "aliases for an attribute starting with an underscore" do
-    subject { FactoryBot.aliases_for(:_id) }
-    it      { should_not include(:id) }
+  it "aliases for a foreign key should include the original attribute name" do
+    aliases = FactoryBot.aliases_for(:test_id)
+
+    expect(aliases).to include(:test_id)
+  end
+
+  it "aliases for an attribute starting with an underscore should not include a non-underscored version" do
+    aliases = FactoryBot.aliases_for(:_id)
+
+    expect(aliases).not_to include(:id)
   end
 end
 
 describe FactoryBot, "after defining an alias" do
-  before do
+  it "the list of aliases should include an un-suffixed equivalent" do
     FactoryBot.aliases << [/(.*)_suffix/, '\1']
+    aliases = FactoryBot.aliases_for(:test_suffix)
+
+    expect(aliases).to include(:test)
   end
 
-  subject { FactoryBot.aliases_for(:test_suffix) }
+  it "the list of aliases should include the original name plus an '_id' suffix" do
+    FactoryBot.aliases << [/(.*)_suffix/, '\1']
+    aliases = FactoryBot.aliases_for(:test_suffix)
 
-  it { should include(:test) }
-  it { should include(:test_suffix_id) }
+    expect(aliases).to include(:test_suffix_id)
+  end
 end

--- a/spec/factory_bot/aliases_spec.rb
+++ b/spec/factory_bot/aliases_spec.rb
@@ -6,19 +6,14 @@ describe FactoryBot, "aliases" do
     expect(aliases).to include(:test_id)
   end
 
-  it "aliases for a foreign key should include the un-suffixed attribute name" do
+  it "aliases for a foreign key should include both the suffixed and un-suffixed variants" do
     aliases = FactoryBot.aliases_for(:test_id)
 
     expect(aliases).to include(:test)
-  end
-
-  it "aliases for a foreign key should include the original attribute name" do
-    aliases = FactoryBot.aliases_for(:test_id)
-
     expect(aliases).to include(:test_id)
   end
 
-  it "aliases for an attribute starting with an underscore should not include a non-underscored version" do
+  it "aliases for an attribute which starts with an underscore should not include a non-underscored version" do
     aliases = FactoryBot.aliases_for(:_id)
 
     expect(aliases).not_to include(:id)
@@ -26,17 +21,11 @@ describe FactoryBot, "aliases" do
 end
 
 describe FactoryBot, "after defining an alias" do
-  it "the list of aliases should include an un-suffixed equivalent" do
+  it "the list of aliases should include a variant with no suffix at all, and one with an '_id' suffix" do
     FactoryBot.aliases << [/(.*)_suffix/, '\1']
     aliases = FactoryBot.aliases_for(:test_suffix)
 
     expect(aliases).to include(:test)
-  end
-
-  it "the list of aliases should include the original name plus an '_id' suffix" do
-    FactoryBot.aliases << [/(.*)_suffix/, '\1']
-    aliases = FactoryBot.aliases_for(:test_suffix)
-
     expect(aliases).to include(:test_suffix_id)
   end
 end

--- a/spec/factory_bot/aliases_spec.rb
+++ b/spec/factory_bot/aliases_spec.rb
@@ -2,15 +2,13 @@ describe FactoryBot, "aliases" do
   it "for an attribute should include the original attribute and a version suffixed with '_id'" do
     aliases = FactoryBot.aliases_for(:test)
 
-    expect(aliases).to include(:test)
-    expect(aliases).to include(:test_id)
+    expect(aliases).to include(:test, :test_id)
   end
 
   it "for a foreign key should include both the suffixed and un-suffixed variants" do
     aliases = FactoryBot.aliases_for(:test_id)
 
-    expect(aliases).to include(:test)
-    expect(aliases).to include(:test_id)
+    expect(aliases).to include(:test, :test_id)
   end
 
   it "for an attribute which starts with an underscore should not include a non-underscored version" do
@@ -25,7 +23,6 @@ describe FactoryBot, "after defining an alias" do
     FactoryBot.aliases << [/(.*)_suffix/, '\1']
     aliases = FactoryBot.aliases_for(:test_suffix)
 
-    expect(aliases).to include(:test)
-    expect(aliases).to include(:test_suffix_id)
+    expect(aliases).to include(:test, :test_suffix_id)
   end
 end


### PR DESCRIPTION
For reference:

https://thoughtbot.com/blog/lets-not

TL;DR- there is consensus within thoughtbot that RSpec's `subject`, `before`, and `let` features are over-used in the Ruby community, and result in relatively hard-to-read tests.

This is the first of several PRs which will in-line many of the declarations previously made using these idioms.