### PR TITLE
Refactor attribute_spec.rb to conform with Let's Not style

### DIFF
--- a/spec/factory_bot/attribute_spec.rb
+++ b/spec/factory_bot/attribute_spec.rb
@@ -1,7 +1,15 @@
 describe FactoryBot::Attribute do
-  let(:name)  { "user" }
-  subject     { FactoryBot::Attribute.new(name, false) }
+  it "converts the name attribute to a symbol" do
+    name = "user"
+    attribute = FactoryBot::Attribute.new(name, false)
 
-  its(:name) { should eq name.to_sym }
-  it { should_not be_association }
+    expect(attribute.name).to eq name.to_sym
+  end
+
+  it "is not an association" do
+    name = "user"
+    attribute = FactoryBot::Attribute.new(name, false)
+
+    expect(attribute).not_to be_association
+  end
 end


### PR DESCRIPTION
For reference:

https://thoughtbot.com/blog/lets-not

TL;DR- there is consensus within thoughtbot that RSpec's subject, before, and let features are over-used in the Ruby community, and result in relatively hard-to-read tests.

This is one of several PRs which in-lines many of the declarations previously made using the above idioms.