### PR TITLE
Refactor declaration_list_spec.rb to conform to Let's Not style

### DIFF
--- a/spec/factory_bot/declaration_list_spec.rb
+++ b/spec/factory_bot/declaration_list_spec.rb
@@ -1,30 +1,25 @@
 describe FactoryBot::DeclarationList, "#attributes" do
-  let(:attribute_1) { double("attribute 1") }
-  let(:attribute_2) { double("attribute 2") }
-  let(:attribute_3) { double("attribute 3") }
-  let(:declaration_1) do
-    double(
-      "declaration 1",
-      to_attributes: [attribute_1, attribute_2],
-    )
-  end
-  let(:declaration_2) do
-    double("declaration_2", to_attributes: [attribute_3])
-  end
-
   it "returns an AttributeList" do
-    expect(subject.attributes).to be_a(FactoryBot::AttributeList)
-  end
+    declaration_list = FactoryBot::DeclarationList.new
 
-  let(:attribute_list) { double("attribute list", define_attribute: true) }
+    expect(declaration_list.attributes).to be_a(FactoryBot::AttributeList)
+  end
 
   it "defines each attribute on the attribute list" do
+    attribute_1 = double("attribute 1")
+    attribute_2 = double("attribute 2")
+    attribute_3 = double("attribute 3")
+    declaration_1 = double("declaration 1", to_attributes: [attribute_1, attribute_2])
+    declaration_2 = double("declaration_2", to_attributes: [attribute_3])
+    attribute_list = double("attribute list", define_attribute: true)
+    declaration_list = FactoryBot::DeclarationList.new
+
     allow(FactoryBot::AttributeList).to receive(:new).and_return attribute_list
 
-    subject.declare_attribute(declaration_1)
-    subject.declare_attribute(declaration_2)
+    declaration_list.declare_attribute(declaration_1)
+    declaration_list.declare_attribute(declaration_2)
 
-    subject.attributes
+    declaration_list.attributes
 
     expect(attribute_list).to have_received(:define_attribute).with(attribute_1)
     expect(attribute_list).to have_received(:define_attribute).with(attribute_2)
@@ -33,42 +28,45 @@ describe FactoryBot::DeclarationList, "#attributes" do
 end
 
 describe FactoryBot::DeclarationList, "#declare_attribute" do
-  let(:declaration_1) { double("declaration", name: "declaration 1") }
-  let(:declaration_2) { double("declaration", name: "declaration 2") }
-  let(:declaration_with_same_name) do
-    double("declaration", name: "declaration 1")
+  it "adds the declaration to the list when not overridable" do
+    declaration_1 = double("declaration", name: "declaration 1")
+    declaration_2 = double("declaration", name: "declaration 2")
+    declaration_list = FactoryBot::DeclarationList.new
+
+    declaration_list.declare_attribute(declaration_1)
+    expect(declaration_list.to_a).to eq [declaration_1]
+
+    declaration_list.declare_attribute(declaration_2)
+    expect(declaration_list.to_a).to eq [declaration_1, declaration_2]
   end
 
-  context "when not overridable" do
-    it "adds the declaration to the list" do
-      subject.declare_attribute(declaration_1)
-      expect(subject.to_a).to eq [declaration_1]
+  it "adds the declaration to the list when overridable" do
+    declaration_1 = double("declaration", name: "declaration 1")
+    declaration_2 = double("declaration", name: "declaration 2")
+    declaration_list = FactoryBot::DeclarationList.new
+    declaration_list.overridable
 
-      subject.declare_attribute(declaration_2)
-      expect(subject.to_a).to eq [declaration_1, declaration_2]
-    end
+    declaration_list.declare_attribute(declaration_1)
+    expect(declaration_list.to_a).to eq [declaration_1]
+
+    declaration_list.declare_attribute(declaration_2)
+    expect(declaration_list.to_a).to eq [declaration_1, declaration_2]
   end
 
-  context "when overridable" do
-    before { subject.overridable }
+  it "deletes declarations with the same name when overridable" do
+    declaration_1 = double("declaration", name: "declaration 1")
+    declaration_2 = double("declaration", name: "declaration 2")
+    declaration_with_same_name = double("declaration", name: "declaration 1")
+    declaration_list = FactoryBot::DeclarationList.new
+    declaration_list.overridable
 
-    it "adds the declaration to the list" do
-      subject.declare_attribute(declaration_1)
-      expect(subject.to_a).to eq [declaration_1]
+    declaration_list.declare_attribute(declaration_1)
+    expect(declaration_list.to_a).to eq [declaration_1]
 
-      subject.declare_attribute(declaration_2)
-      expect(subject.to_a).to eq [declaration_1, declaration_2]
-    end
+    declaration_list.declare_attribute(declaration_2)
+    expect(declaration_list.to_a).to eq [declaration_1, declaration_2]
 
-    it "deletes declarations with the same name" do
-      subject.declare_attribute(declaration_1)
-      expect(subject.to_a).to eq [declaration_1]
-
-      subject.declare_attribute(declaration_2)
-      expect(subject.to_a).to eq [declaration_1, declaration_2]
-
-      subject.declare_attribute(declaration_with_same_name)
-      expect(subject.to_a).to eq [declaration_2, declaration_with_same_name]
-    end
+    declaration_list.declare_attribute(declaration_with_same_name)
+    expect(declaration_list.to_a).to eq [declaration_2, declaration_with_same_name]
   end
 end

--- a/spec/factory_bot/declaration_list_spec.rb
+++ b/spec/factory_bot/declaration_list_spec.rb
@@ -6,67 +6,85 @@ describe FactoryBot::DeclarationList, "#attributes" do
   end
 
   it "defines each attribute on the attribute list" do
-    attribute_1 = double("attribute 1")
-    attribute_2 = double("attribute 2")
-    attribute_3 = double("attribute 3")
-    declaration_1 = double("declaration 1", to_attributes: [attribute_1, attribute_2])
-    declaration_2 = double("declaration_2", to_attributes: [attribute_3])
+    attribute1 = double("attribute 1")
+    attribute2 = double("attribute 2")
+    attribute3 = double("attribute 3")
+    declaration1 = double("declaration 1", to_attributes: [attribute1, attribute2])
+    declaration2 = double("declaration2", to_attributes: [attribute3])
     attribute_list = double("attribute list", define_attribute: true)
     declaration_list = FactoryBot::DeclarationList.new
 
     allow(FactoryBot::AttributeList).to receive(:new).and_return attribute_list
 
-    declaration_list.declare_attribute(declaration_1)
-    declaration_list.declare_attribute(declaration_2)
+    declaration_list.declare_attribute(declaration1)
+    declaration_list.declare_attribute(declaration2)
 
     declaration_list.attributes
 
-    expect(attribute_list).to have_received(:define_attribute).with(attribute_1)
-    expect(attribute_list).to have_received(:define_attribute).with(attribute_2)
-    expect(attribute_list).to have_received(:define_attribute).with(attribute_3)
+    expect(attribute_list).to have_received(:define_attribute).with(attribute1)
+    expect(attribute_list).to have_received(:define_attribute).with(attribute2)
+    expect(attribute_list).to have_received(:define_attribute).with(attribute3)
   end
 end
 
 describe FactoryBot::DeclarationList, "#declare_attribute" do
   it "adds the declaration to the list when not overridable" do
-    declaration_1 = double("declaration", name: "declaration 1")
-    declaration_2 = double("declaration", name: "declaration 2")
+    declaration1 = double("declaration", name: "declaration 1")
+    declaration2 = double("declaration", name: "declaration 2")
     declaration_list = FactoryBot::DeclarationList.new
 
-    declaration_list.declare_attribute(declaration_1)
-    expect(declaration_list.to_a).to eq [declaration_1]
+    declaration_list.declare_attribute(declaration1)
+    expect(declaration_list.to_a).to eq [declaration1]
 
-    declaration_list.declare_attribute(declaration_2)
-    expect(declaration_list.to_a).to eq [declaration_1, declaration_2]
+    declaration_list.declare_attribute(declaration2)
+    expect(declaration_list.to_a).to eq [declaration1, declaration2]
   end
 
   it "adds the declaration to the list when overridable" do
-    declaration_1 = double("declaration", name: "declaration 1")
-    declaration_2 = double("declaration", name: "declaration 2")
+    declaration1 = double("declaration", name: "declaration 1")
+    declaration2 = double("declaration", name: "declaration 2")
     declaration_list = FactoryBot::DeclarationList.new
     declaration_list.overridable
 
-    declaration_list.declare_attribute(declaration_1)
-    expect(declaration_list.to_a).to eq [declaration_1]
+    declaration_list.declare_attribute(declaration1)
+    expect(declaration_list.to_a).to eq [declaration1]
 
-    declaration_list.declare_attribute(declaration_2)
-    expect(declaration_list.to_a).to eq [declaration_1, declaration_2]
+    declaration_list.declare_attribute(declaration2)
+    expect(declaration_list.to_a).to eq [declaration1, declaration2]
   end
 
   it "deletes declarations with the same name when overridable" do
-    declaration_1 = double("declaration", name: "declaration 1")
-    declaration_2 = double("declaration", name: "declaration 2")
+    declaration1 = double("declaration", name: "declaration 1")
+    declaration2 = double("declaration", name: "declaration 2")
     declaration_with_same_name = double("declaration", name: "declaration 1")
     declaration_list = FactoryBot::DeclarationList.new
     declaration_list.overridable
 
-    declaration_list.declare_attribute(declaration_1)
-    expect(declaration_list.to_a).to eq [declaration_1]
+    declaration_list.declare_attribute(declaration1)
+    expect(declaration_list.to_a).to eq [declaration1]
 
-    declaration_list.declare_attribute(declaration_2)
-    expect(declaration_list.to_a).to eq [declaration_1, declaration_2]
+    declaration_list.declare_attribute(declaration2)
+    expect(declaration_list.to_a).to eq [declaration1, declaration2]
 
     declaration_list.declare_attribute(declaration_with_same_name)
-    expect(declaration_list.to_a).to eq [declaration_2, declaration_with_same_name]
+    expect(declaration_list.to_a).to eq [declaration2, declaration_with_same_name]
+  end
+
+  it "appends declarations with the same name when NOT overridable" do
+    declaration1 = double("declaration", name: "declaration 1")
+    declaration2 = double("declaration", name: "declaration 2")
+    declaration_with_same_name = double("declaration", name: "declaration 1")
+
+    # DeclarationList's `@overridable` attr is set to false by default
+    declaration_list = FactoryBot::DeclarationList.new
+
+    declaration_list.declare_attribute(declaration1)
+    expect(declaration_list.to_a).to eq [declaration1]
+
+    declaration_list.declare_attribute(declaration2)
+    expect(declaration_list.to_a).to eq [declaration1, declaration2]
+
+    declaration_list.declare_attribute(declaration_with_same_name)
+    expect(declaration_list.to_a).to eq [declaration1, declaration2, declaration_with_same_name]
   end
 end


### PR DESCRIPTION
For reference:

https://thoughtbot.com/blog/lets-not

TL;DR- there is consensus within thoughtbot that RSpec's subject, before, and let features are over-used in the Ruby community, and result in relatively hard-to-read tests.

This is one of several PRs which in-lines many of the declarations previously made using the above idioms.