### PR TITLE
Refactor attribute_list_spec.rb to conform to Let's Not style

### DIFF
--- a/spec/factory_bot/attribute_list_spec.rb
+++ b/spec/factory_bot/attribute_list_spec.rb
@@ -2,25 +2,28 @@ describe FactoryBot::AttributeList, "#define_attribute" do
   it "maintains a list of attributes" do
     attribute = double(:attribute, name: :attribute_name)
     another_attribute = double(:attribute, name: :another_attribute_name)
+    list = FactoryBot::AttributeList.new
 
-    subject.define_attribute(attribute)
-    expect(subject.to_a).to eq [attribute]
+    list.define_attribute(attribute)
+    expect(list.to_a).to eq [attribute]
 
-    subject.define_attribute(another_attribute)
-    expect(subject.to_a).to eq [attribute, another_attribute]
+    list.define_attribute(another_attribute)
+    expect(list.to_a).to eq [attribute, another_attribute]
   end
 
   it "returns the attribute" do
     attribute = double(:attribute, name: :attribute_name)
+    list = FactoryBot::AttributeList.new
 
-    expect(subject.define_attribute(attribute)).to eq attribute
+    expect(list.define_attribute(attribute)).to eq attribute
   end
 
   it "raises if an attribute has already been defined" do
     attribute = double(:attribute, name: :attribute_name)
+    list = FactoryBot::AttributeList.new
 
     expect do
-      2.times { subject.define_attribute(attribute) }
+      2.times { list.define_attribute(attribute) }
     end.to raise_error(
       FactoryBot::AttributeDefinitionError,
       "Attribute already defined: attribute_name",
@@ -29,14 +32,12 @@ describe FactoryBot::AttributeList, "#define_attribute" do
 end
 
 describe FactoryBot::AttributeList, "#define_attribute with a named attribute list" do
-  subject { FactoryBot::AttributeList.new(:author) }
-
-  let(:association_with_same_name)      { FactoryBot::Attribute::Association.new(:author, :author, {}) }
-  let(:association_with_different_name) { FactoryBot::Attribute::Association.new(:author, :post, {}) }
-
   it "raises when the attribute is a self-referencing association" do
+    association_with_same_name = FactoryBot::Attribute::Association.new(:author, :author, {})
+    list = FactoryBot::AttributeList.new(:author)
+
     expect do
-      subject.define_attribute(association_with_same_name)
+      list.define_attribute(association_with_same_name)
     end.to raise_error(
       FactoryBot::AssociationDefinitionError,
       "Self-referencing association 'author' in 'author'",
@@ -44,7 +45,10 @@ describe FactoryBot::AttributeList, "#define_attribute with a named attribute li
   end
 
   it "does not raise when the attribute is not a self-referencing association" do
-    expect { subject.define_attribute(association_with_different_name) }.to_not raise_error
+    association_with_different_name = FactoryBot::Attribute::Association.new(:author, :post, {})
+    list = FactoryBot::AttributeList.new
+
+    expect { list.define_attribute(association_with_different_name) }.to_not raise_error
   end
 end
 
@@ -59,28 +63,30 @@ describe FactoryBot::AttributeList, "#apply_attributes" do
     attribute1 = double(:attribute1, name: :attribute1)
     attribute2 = double(:attribute2, name: :attribute2)
     attribute3 = double(:attribute3, name: :attribute3)
+    list = FactoryBot::AttributeList.new
 
-    subject.define_attribute(attribute1)
-    subject.apply_attributes(list(attribute2, attribute3))
-    expect(subject.to_a).to eq [attribute1, attribute2, attribute3]
+    list.define_attribute(attribute1)
+    list.apply_attributes(list(attribute2, attribute3))
+    expect(list.to_a).to eq [attribute1, attribute2, attribute3]
   end
 end
 
 describe FactoryBot::AttributeList, "#associations" do
-  let(:email_attribute) do
-    FactoryBot::Attribute::Dynamic.new(:email, false, ->(u) { "#{u.full_name}@example.com" })
-  end
-  let(:author_attribute)    { FactoryBot::Attribute::Association.new(:author, :user, {}) }
-  let(:profile_attribute)   { FactoryBot::Attribute::Association.new(:profile, :profile, {}) }
-
-  before do
-    subject.define_attribute(email_attribute)
-    subject.define_attribute(author_attribute)
-    subject.define_attribute(profile_attribute)
-  end
-
   it "returns associations" do
-    expect(subject.associations.to_a).to eq [author_attribute, profile_attribute]
+    email_attribute = FactoryBot::Attribute::Dynamic.new(
+      :email,
+      false,
+      ->(u) { "#{u.full_name}@example.com" },
+    )
+    author_attribute = FactoryBot::Attribute::Association.new(:author, :user, {})
+    profile_attribute = FactoryBot::Attribute::Association.new(:profile, :profile, {})
+    list = FactoryBot::AttributeList.new
+
+    list.define_attribute(email_attribute)
+    list.define_attribute(author_attribute)
+    list.define_attribute(profile_attribute)
+
+    expect(list.associations.to_a).to eq [author_attribute, profile_attribute]
   end
 end
 
@@ -93,20 +99,26 @@ describe FactoryBot::AttributeList, "filter based on ignored attributes" do
     FactoryBot::Attribute::Dynamic.new(name, false, -> { "value" })
   end
 
-  before do
-    subject.define_attribute(build_ignored_attribute(:comments_count))
-    subject.define_attribute(build_ignored_attribute(:posts_count))
-    subject.define_attribute(build_non_ignored_attribute(:email))
-    subject.define_attribute(build_non_ignored_attribute(:first_name))
-    subject.define_attribute(build_non_ignored_attribute(:last_name))
-  end
-
   it "filters #ignored attributes" do
-    expect(subject.ignored.map(&:name)).to eq [:comments_count, :posts_count]
+    list = FactoryBot::AttributeList.new
+    list.define_attribute(build_ignored_attribute(:comments_count))
+    list.define_attribute(build_ignored_attribute(:posts_count))
+    list.define_attribute(build_non_ignored_attribute(:email))
+    list.define_attribute(build_non_ignored_attribute(:first_name))
+    list.define_attribute(build_non_ignored_attribute(:last_name))
+
+    expect(list.ignored.map(&:name)).to eq [:comments_count, :posts_count]
   end
 
   it "filters #non_ignored attributes" do
-    expect(subject.non_ignored.map(&:name)).to eq [:email, :first_name, :last_name]
+    list = FactoryBot::AttributeList.new
+    list.define_attribute(build_ignored_attribute(:comments_count))
+    list.define_attribute(build_ignored_attribute(:posts_count))
+    list.define_attribute(build_non_ignored_attribute(:email))
+    list.define_attribute(build_non_ignored_attribute(:first_name))
+    list.define_attribute(build_non_ignored_attribute(:last_name))
+
+    expect(list.non_ignored.map(&:name)).to eq [:email, :first_name, :last_name]
   end
 end
 
@@ -123,28 +135,51 @@ describe FactoryBot::AttributeList, "generating names" do
     FactoryBot::Attribute::Association.new(name, :user, {})
   end
 
-  before do
-    subject.define_attribute(build_ignored_attribute(:comments_count))
-    subject.define_attribute(build_ignored_attribute(:posts_count))
-    subject.define_attribute(build_non_ignored_attribute(:email))
-    subject.define_attribute(build_non_ignored_attribute(:first_name))
-    subject.define_attribute(build_non_ignored_attribute(:last_name))
-    subject.define_attribute(build_association(:avatar))
-  end
-
   it "knows all its #names" do
-    expect(subject.names).to eq [:comments_count, :posts_count, :email, :first_name, :last_name, :avatar]
+    list = FactoryBot::AttributeList.new
+    list.define_attribute(build_ignored_attribute(:comments_count))
+    list.define_attribute(build_ignored_attribute(:posts_count))
+    list.define_attribute(build_non_ignored_attribute(:email))
+    list.define_attribute(build_non_ignored_attribute(:first_name))
+    list.define_attribute(build_non_ignored_attribute(:last_name))
+    list.define_attribute(build_association(:avatar))
+
+    expect(list.names).to eq [:comments_count, :posts_count, :email, :first_name, :last_name, :avatar]
   end
 
   it "knows all its #names for #ignored attributes" do
-    expect(subject.ignored.names).to eq [:comments_count, :posts_count]
+    list = FactoryBot::AttributeList.new
+    list.define_attribute(build_ignored_attribute(:comments_count))
+    list.define_attribute(build_ignored_attribute(:posts_count))
+    list.define_attribute(build_non_ignored_attribute(:email))
+    list.define_attribute(build_non_ignored_attribute(:first_name))
+    list.define_attribute(build_non_ignored_attribute(:last_name))
+    list.define_attribute(build_association(:avatar))
+
+    expect(list.ignored.names).to eq [:comments_count, :posts_count]
   end
 
   it "knows all its #names for #non_ignored attributes" do
-    expect(subject.non_ignored.names).to eq [:email, :first_name, :last_name, :avatar]
+    list = FactoryBot::AttributeList.new
+    list.define_attribute(build_ignored_attribute(:comments_count))
+    list.define_attribute(build_ignored_attribute(:posts_count))
+    list.define_attribute(build_non_ignored_attribute(:email))
+    list.define_attribute(build_non_ignored_attribute(:first_name))
+    list.define_attribute(build_non_ignored_attribute(:last_name))
+    list.define_attribute(build_association(:avatar))
+
+    expect(list.non_ignored.names).to eq [:email, :first_name, :last_name, :avatar]
   end
 
   it "knows all its #names for #associations" do
-    expect(subject.associations.names).to eq [:avatar]
+    list = FactoryBot::AttributeList.new
+    list.define_attribute(build_ignored_attribute(:comments_count))
+    list.define_attribute(build_ignored_attribute(:posts_count))
+    list.define_attribute(build_non_ignored_attribute(:email))
+    list.define_attribute(build_non_ignored_attribute(:first_name))
+    list.define_attribute(build_non_ignored_attribute(:last_name))
+    list.define_attribute(build_association(:avatar))
+
+    expect(list.associations.names).to eq [:avatar]
   end
 end

--- a/spec/factory_bot/attribute_list_spec.rb
+++ b/spec/factory_bot/attribute_list_spec.rb
@@ -62,12 +62,11 @@ describe FactoryBot::AttributeList, "#apply_attributes" do
   it "adds attributes in the order defined" do
     attribute1 = double(:attribute1, name: :attribute1)
     attribute2 = double(:attribute2, name: :attribute2)
-    attribute3 = double(:attribute3, name: :attribute3)
     list = FactoryBot::AttributeList.new
 
     list.define_attribute(attribute1)
-    list.apply_attributes(build_attribute_list(attribute2, attribute3))
-    expect(list.to_a).to eq [attribute1, attribute2, attribute3]
+    list.apply_attributes(build_attribute_list(attribute2))
+    expect(list.to_a).to eq [attribute1, attribute2]
   end
 end
 
@@ -98,25 +97,19 @@ describe FactoryBot::AttributeList, "filter based on ignored attributes" do
   it "filters #ignored attributes" do
     list = build_attribute_list(
       build_ignored_attribute(:comments_count),
-      build_ignored_attribute(:posts_count),
       build_non_ignored_attribute(:email),
-      build_non_ignored_attribute(:first_name),
-      build_non_ignored_attribute(:last_name),
     )
 
-    expect(list.ignored.names).to eq [:comments_count, :posts_count]
+    expect(list.ignored.names).to eq [:comments_count]
   end
 
   it "filters #non_ignored attributes" do
     list = build_attribute_list(
       build_ignored_attribute(:comments_count),
-      build_ignored_attribute(:posts_count),
       build_non_ignored_attribute(:email),
-      build_non_ignored_attribute(:first_name),
-      build_non_ignored_attribute(:last_name),
     )
 
-    expect(list.non_ignored.names).to eq [:email, :first_name, :last_name]
+    expect(list.non_ignored.names).to eq [:email]
   end
 end
 
@@ -136,48 +129,36 @@ describe FactoryBot::AttributeList, "generating names" do
   it "knows all its #names" do
     list = build_attribute_list(
       build_ignored_attribute(:comments_count),
-      build_ignored_attribute(:posts_count),
-      build_non_ignored_attribute(:email),
-      build_non_ignored_attribute(:first_name),
       build_non_ignored_attribute(:last_name),
       build_association(:avatar),
     )
 
-    expect(list.names).to eq [:comments_count, :posts_count, :email, :first_name, :last_name, :avatar]
+    expect(list.names).to eq [:comments_count, :last_name, :avatar]
   end
 
   it "knows all its #names for #ignored attributes" do
     list = build_attribute_list(
-      build_ignored_attribute(:comments_count),
       build_ignored_attribute(:posts_count),
-      build_non_ignored_attribute(:email),
-      build_non_ignored_attribute(:first_name),
       build_non_ignored_attribute(:last_name),
       build_association(:avatar),
     )
 
-    expect(list.ignored.names).to eq [:comments_count, :posts_count]
+    expect(list.ignored.names).to eq [:posts_count]
   end
 
   it "knows all its #names for #non_ignored attributes" do
     list = build_attribute_list(
-      build_ignored_attribute(:comments_count),
       build_ignored_attribute(:posts_count),
-      build_non_ignored_attribute(:email),
-      build_non_ignored_attribute(:first_name),
       build_non_ignored_attribute(:last_name),
       build_association(:avatar),
     )
 
-    expect(list.non_ignored.names).to eq [:email, :first_name, :last_name, :avatar]
+    expect(list.non_ignored.names).to eq [:last_name, :avatar]
   end
 
   it "knows all its #names for #associations" do
     list = build_attribute_list(
-      build_ignored_attribute(:comments_count),
       build_ignored_attribute(:posts_count),
-      build_non_ignored_attribute(:email),
-      build_non_ignored_attribute(:first_name),
       build_non_ignored_attribute(:last_name),
       build_association(:avatar),
     )

--- a/spec/factory_bot/attribute_list_spec.rb
+++ b/spec/factory_bot/attribute_list_spec.rb
@@ -1,3 +1,9 @@
+def build_attribute_list(*attributes)
+  FactoryBot::AttributeList.new.tap do |list|
+    attributes.each { |attribute| list.define_attribute(attribute) }
+  end
+end
+
 describe FactoryBot::AttributeList, "#define_attribute" do
   it "maintains a list of attributes" do
     attribute = double(:attribute, name: :attribute_name)
@@ -53,12 +59,6 @@ describe FactoryBot::AttributeList, "#define_attribute with a named attribute li
 end
 
 describe FactoryBot::AttributeList, "#apply_attributes" do
-  def list(*attributes)
-    FactoryBot::AttributeList.new.tap do |list|
-      attributes.each { |attribute| list.define_attribute(attribute) }
-    end
-  end
-
   it "adds attributes in the order defined" do
     attribute1 = double(:attribute1, name: :attribute1)
     attribute2 = double(:attribute2, name: :attribute2)
@@ -66,7 +66,7 @@ describe FactoryBot::AttributeList, "#apply_attributes" do
     list = FactoryBot::AttributeList.new
 
     list.define_attribute(attribute1)
-    list.apply_attributes(list(attribute2, attribute3))
+    list.apply_attributes(build_attribute_list(attribute2, attribute3))
     expect(list.to_a).to eq [attribute1, attribute2, attribute3]
   end
 end
@@ -80,11 +80,7 @@ describe FactoryBot::AttributeList, "#associations" do
     )
     author_attribute = FactoryBot::Attribute::Association.new(:author, :user, {})
     profile_attribute = FactoryBot::Attribute::Association.new(:profile, :profile, {})
-    list = FactoryBot::AttributeList.new
-
-    list.define_attribute(email_attribute)
-    list.define_attribute(author_attribute)
-    list.define_attribute(profile_attribute)
+    list = build_attribute_list(email_attribute, author_attribute, profile_attribute)
 
     expect(list.associations.to_a).to eq [author_attribute, profile_attribute]
   end
@@ -100,23 +96,25 @@ describe FactoryBot::AttributeList, "filter based on ignored attributes" do
   end
 
   it "filters #ignored attributes" do
-    list = FactoryBot::AttributeList.new
-    list.define_attribute(build_ignored_attribute(:comments_count))
-    list.define_attribute(build_ignored_attribute(:posts_count))
-    list.define_attribute(build_non_ignored_attribute(:email))
-    list.define_attribute(build_non_ignored_attribute(:first_name))
-    list.define_attribute(build_non_ignored_attribute(:last_name))
+    list = build_attribute_list(
+      build_ignored_attribute(:comments_count),
+      build_ignored_attribute(:posts_count),
+      build_non_ignored_attribute(:email),
+      build_non_ignored_attribute(:first_name),
+      build_non_ignored_attribute(:last_name),
+    )
 
     expect(list.ignored.names).to eq [:comments_count, :posts_count]
   end
 
   it "filters #non_ignored attributes" do
-    list = FactoryBot::AttributeList.new
-    list.define_attribute(build_ignored_attribute(:comments_count))
-    list.define_attribute(build_ignored_attribute(:posts_count))
-    list.define_attribute(build_non_ignored_attribute(:email))
-    list.define_attribute(build_non_ignored_attribute(:first_name))
-    list.define_attribute(build_non_ignored_attribute(:last_name))
+    list = build_attribute_list(
+      build_ignored_attribute(:comments_count),
+      build_ignored_attribute(:posts_count),
+      build_non_ignored_attribute(:email),
+      build_non_ignored_attribute(:first_name),
+      build_non_ignored_attribute(:last_name),
+    )
 
     expect(list.non_ignored.names).to eq [:email, :first_name, :last_name]
   end
@@ -136,49 +134,53 @@ describe FactoryBot::AttributeList, "generating names" do
   end
 
   it "knows all its #names" do
-    list = FactoryBot::AttributeList.new
-    list.define_attribute(build_ignored_attribute(:comments_count))
-    list.define_attribute(build_ignored_attribute(:posts_count))
-    list.define_attribute(build_non_ignored_attribute(:email))
-    list.define_attribute(build_non_ignored_attribute(:first_name))
-    list.define_attribute(build_non_ignored_attribute(:last_name))
-    list.define_attribute(build_association(:avatar))
+    list = build_attribute_list(
+      build_ignored_attribute(:comments_count),
+      build_ignored_attribute(:posts_count),
+      build_non_ignored_attribute(:email),
+      build_non_ignored_attribute(:first_name),
+      build_non_ignored_attribute(:last_name),
+      build_association(:avatar),
+    )
 
     expect(list.names).to eq [:comments_count, :posts_count, :email, :first_name, :last_name, :avatar]
   end
 
   it "knows all its #names for #ignored attributes" do
-    list = FactoryBot::AttributeList.new
-    list.define_attribute(build_ignored_attribute(:comments_count))
-    list.define_attribute(build_ignored_attribute(:posts_count))
-    list.define_attribute(build_non_ignored_attribute(:email))
-    list.define_attribute(build_non_ignored_attribute(:first_name))
-    list.define_attribute(build_non_ignored_attribute(:last_name))
-    list.define_attribute(build_association(:avatar))
+    list = build_attribute_list(
+      build_ignored_attribute(:comments_count),
+      build_ignored_attribute(:posts_count),
+      build_non_ignored_attribute(:email),
+      build_non_ignored_attribute(:first_name),
+      build_non_ignored_attribute(:last_name),
+      build_association(:avatar),
+    )
 
     expect(list.ignored.names).to eq [:comments_count, :posts_count]
   end
 
   it "knows all its #names for #non_ignored attributes" do
-    list = FactoryBot::AttributeList.new
-    list.define_attribute(build_ignored_attribute(:comments_count))
-    list.define_attribute(build_ignored_attribute(:posts_count))
-    list.define_attribute(build_non_ignored_attribute(:email))
-    list.define_attribute(build_non_ignored_attribute(:first_name))
-    list.define_attribute(build_non_ignored_attribute(:last_name))
-    list.define_attribute(build_association(:avatar))
+    list = build_attribute_list(
+      build_ignored_attribute(:comments_count),
+      build_ignored_attribute(:posts_count),
+      build_non_ignored_attribute(:email),
+      build_non_ignored_attribute(:first_name),
+      build_non_ignored_attribute(:last_name),
+      build_association(:avatar),
+    )
 
     expect(list.non_ignored.names).to eq [:email, :first_name, :last_name, :avatar]
   end
 
   it "knows all its #names for #associations" do
-    list = FactoryBot::AttributeList.new
-    list.define_attribute(build_ignored_attribute(:comments_count))
-    list.define_attribute(build_ignored_attribute(:posts_count))
-    list.define_attribute(build_non_ignored_attribute(:email))
-    list.define_attribute(build_non_ignored_attribute(:first_name))
-    list.define_attribute(build_non_ignored_attribute(:last_name))
-    list.define_attribute(build_association(:avatar))
+    list = build_attribute_list(
+      build_ignored_attribute(:comments_count),
+      build_ignored_attribute(:posts_count),
+      build_non_ignored_attribute(:email),
+      build_non_ignored_attribute(:first_name),
+      build_non_ignored_attribute(:last_name),
+      build_association(:avatar),
+    )
 
     expect(list.associations.names).to eq [:avatar]
   end

--- a/spec/factory_bot/attribute_list_spec.rb
+++ b/spec/factory_bot/attribute_list_spec.rb
@@ -107,7 +107,7 @@ describe FactoryBot::AttributeList, "filter based on ignored attributes" do
     list.define_attribute(build_non_ignored_attribute(:first_name))
     list.define_attribute(build_non_ignored_attribute(:last_name))
 
-    expect(list.ignored.map(&:name)).to eq [:comments_count, :posts_count]
+    expect(list.ignored.names).to eq [:comments_count, :posts_count]
   end
 
   it "filters #non_ignored attributes" do
@@ -118,7 +118,7 @@ describe FactoryBot::AttributeList, "filter based on ignored attributes" do
     list.define_attribute(build_non_ignored_attribute(:first_name))
     list.define_attribute(build_non_ignored_attribute(:last_name))
 
-    expect(list.non_ignored.map(&:name)).to eq [:email, :first_name, :last_name]
+    expect(list.non_ignored.names).to eq [:email, :first_name, :last_name]
   end
 end
 

--- a/spec/factory_bot/attribute_list_spec.rb
+++ b/spec/factory_bot/attribute_list_spec.rb
@@ -1,6 +1,8 @@
-def build_attribute_list(*attributes)
-  FactoryBot::AttributeList.new.tap do |list|
-    attributes.each { |attribute| list.define_attribute(attribute) }
+module AttributeList
+  def build_attribute_list(*attributes)
+    FactoryBot::AttributeList.new.tap do |list|
+      attributes.each { |attribute| list.define_attribute(attribute) }
+    end
   end
 end
 
@@ -59,6 +61,8 @@ describe FactoryBot::AttributeList, "#define_attribute with a named attribute li
 end
 
 describe FactoryBot::AttributeList, "#apply_attributes" do
+  include AttributeList
+
   it "adds attributes in the order defined" do
     attribute1 = double(:attribute1, name: :attribute1)
     attribute2 = double(:attribute2, name: :attribute2)
@@ -71,6 +75,8 @@ describe FactoryBot::AttributeList, "#apply_attributes" do
 end
 
 describe FactoryBot::AttributeList, "#associations" do
+  include AttributeList
+
   it "returns associations" do
     email_attribute = FactoryBot::Attribute::Dynamic.new(
       :email,
@@ -86,6 +92,8 @@ describe FactoryBot::AttributeList, "#associations" do
 end
 
 describe FactoryBot::AttributeList, "filter based on ignored attributes" do
+  include AttributeList
+
   def build_ignored_attribute(name)
     FactoryBot::Attribute::Dynamic.new(name, true, -> { "value" })
   end
@@ -114,6 +122,8 @@ describe FactoryBot::AttributeList, "filter based on ignored attributes" do
 end
 
 describe FactoryBot::AttributeList, "generating names" do
+  include AttributeList
+
   def build_ignored_attribute(name)
     FactoryBot::Attribute::Dynamic.new(name, true, -> { "value" })
   end


### PR DESCRIPTION
For reference:

https://thoughtbot.com/blog/lets-not

TL;DR- there is consensus within thoughtbot that RSpec's subject, before, and let features are over-used in the Ruby community, and result in relatively hard-to-read tests.

This is one of several PRs which in-lines many of the declarations previously made using the above idioms.