### PR TITLE
Refactor definition_proxy_spec.rb to conform to Let's Not style

### DIFF
--- a/lib/factory_bot/definition.rb
+++ b/lib/factory_bot/definition.rb
@@ -49,7 +49,7 @@ module FactoryBot
 
         defined_traits.each do |defined_trait|
           base_traits.each       { |bt| bt.define_trait defined_trait }
-          additional_traits.each { |bt| bt.define_trait defined_trait }
+          additional_traits.each { |at| at.define_trait defined_trait }
         end
 
         @compiled = true


### PR DESCRIPTION
For reference:

https://thoughtbot.com/blog/lets-not

TL;DR- there is consensus within thoughtbot that RSpec's subject, before, and let features are over-used in the Ruby community, and result in relatively hard-to-read tests.

This is one of several PRs which in-lines many of the declarations previously made using the above idioms.