### PR TITLE
Refactor disallows_duplicates_registry_spec.rb to conform to Let's Not style

### DIFF
--- a/spec/factory_bot/disallows_duplicates_registry_spec.rb
+++ b/spec/factory_bot/disallows_duplicates_registry_spec.rb
@@ -1,7 +1,7 @@
 describe FactoryBot::Decorator::DisallowsDuplicatesRegistry do
   it "delegates #register to the registry when not registered" do
     registry = double("registry", name: "Great thing", register: true)
-    decorator = described_class.new(registry)
+    decorator = FactoryBot::Decorator::DisallowsDuplicatesRegistry.new(registry)
     allow(registry).to receive(:registered?).and_return false
     decorator.register(:awesome, {})
 
@@ -10,7 +10,7 @@ describe FactoryBot::Decorator::DisallowsDuplicatesRegistry do
 
   it "raises when attempting to #register a previously registered strategy" do
     registry = double("registry", name: "Great thing", register: true)
-    decorator = described_class.new(registry)
+    decorator = FactoryBot::Decorator::DisallowsDuplicatesRegistry.new(registry)
     allow(registry).to receive(:registered?).and_return true
 
     expect { decorator.register(:same_name, {}) }.

--- a/spec/factory_bot/disallows_duplicates_registry_spec.rb
+++ b/spec/factory_bot/disallows_duplicates_registry_spec.rb
@@ -1,17 +1,19 @@
 describe FactoryBot::Decorator::DisallowsDuplicatesRegistry do
-  let(:registry) { double("registry", name: "Great thing", register: true) }
-
-  subject { described_class.new(registry) }
-
   it "delegates #register to the registry when not registered" do
+    registry = double("registry", name: "Great thing", register: true)
+    decorator = described_class.new(registry)
     allow(registry).to receive(:registered?).and_return false
-    subject.register(:awesome, {})
+    decorator.register(:awesome, {})
+
     expect(registry).to have_received(:register).with(:awesome, {})
   end
 
   it "raises when attempting to #register a previously registered strategy" do
+    registry = double("registry", name: "Great thing", register: true)
+    decorator = described_class.new(registry)
     allow(registry).to receive(:registered?).and_return true
-    expect { subject.register(:same_name, {}) }.
+
+    expect { decorator.register(:same_name, {}) }.
       to raise_error(FactoryBot::DuplicateDefinitionError, "Great thing already registered: same_name")
   end
 end


### PR DESCRIPTION
For reference:

https://thoughtbot.com/blog/lets-not

TL;DR- there is consensus within thoughtbot that RSpec's subject, before, and let features are over-used in the Ruby community, and result in relatively hard-to-read tests.

This is one of several PRs which in-lines many of the declarations previously made using the above idioms.