### PR TITLE
Refactor null_object_spec.rb to conform to Let's Not style

### DIFF
--- a/spec/factory_bot/null_object_spec.rb
+++ b/spec/factory_bot/null_object_spec.rb
@@ -1,20 +1,22 @@
 describe FactoryBot::NullObject do
-  let(:methods_to_respond_to)     { %w[id age name admin?] }
-  let(:methods_to_not_respond_to) { %w[email date_of_birth title] }
-
-  subject { FactoryBot::NullObject.new(methods_to_respond_to) }
-
   it "responds to the given methods" do
+    methods_to_respond_to = %w[id age name admin?]
+    null_object = FactoryBot::NullObject.new(methods_to_respond_to)
+
     methods_to_respond_to.each do |method_name|
-      expect(subject.__send__(method_name)).to be_nil
-      expect(subject).to respond_to(method_name)
+      expect(null_object.__send__(method_name)).to be_nil
+      expect(null_object).to respond_to(method_name)
     end
   end
 
   it "does not respond to other methods" do
+    methods_to_respond_to = %w[id age name admin?]
+    methods_to_not_respond_to = %w[email date_of_birth title]
+    null_object = FactoryBot::NullObject.new(methods_to_respond_to)
+
     methods_to_not_respond_to.each do |method_name|
-      expect { subject.__send__(method_name) }.to raise_error(NoMethodError)
-      expect(subject).not_to respond_to(method_name)
+      expect { null_object.__send__(method_name) }.to raise_error(NoMethodError)
+      expect(null_object).not_to respond_to(method_name)
     end
   end
 end


### PR DESCRIPTION
For reference:

https://thoughtbot.com/blog/lets-not

TL;DR- there is consensus within thoughtbot that RSpec's subject, before, and let features are over-used in the Ruby community, and result in relatively hard-to-read tests.

This is one of several PRs which in-lines many of the declarations previously made using the above idioms.