### PR TITLE
Refactors strategy_calculator_spec.rb to conform to Let's Not style

### DIFF
--- a/spec/factory_bot/strategy_calculator_spec.rb
+++ b/spec/factory_bot/strategy_calculator_spec.rb
@@ -1,30 +1,24 @@
 describe FactoryBot::StrategyCalculator do
-  let(:strategy) do
-    define_class("MyAwesomeClass")
+  it "returns the class passed when it is instantiated with a class" do
+    strategy = define_class("MyAwesomeClass")
+    calculator = FactoryBot::StrategyCalculator.new(strategy).strategy
+
+    expect(calculator).to eq strategy
   end
 
-  context "when a class" do
-    subject { FactoryBot::StrategyCalculator.new(strategy).strategy }
+  it "finds the strategy by name when instantiated with a symbol" do
+    strategy = define_class("MyAwesomeClass")
+    allow(FactoryBot::Internal).to receive(:strategy_by_name).and_return(strategy)
+    FactoryBot::StrategyCalculator.new(:build).strategy
 
-    it "returns the class passed" do
-      expect(subject).to eq strategy
-    end
+    expect(FactoryBot::Internal).to have_received(:strategy_by_name).with(:build)
   end
 
-  context "when a symbol" do
-    before do
-      allow(FactoryBot::Internal).to receive(:strategy_by_name).and_return(strategy)
-    end
+  it "returns the strategy found when instantiated with a symbol" do
+    strategy = define_class("MyAwesomeClass")
+    allow(FactoryBot::Internal).to receive(:strategy_by_name).and_return(strategy)
+    calculator = FactoryBot::StrategyCalculator.new(:build).strategy
 
-    subject { FactoryBot::StrategyCalculator.new(:build).strategy }
-
-    it "finds the strategy by name" do
-      subject
-      expect(FactoryBot::Internal).to have_received(:strategy_by_name).with(:build)
-    end
-
-    it "returns the strategy found" do
-      expect(subject).to eq strategy
-    end
+    expect(calculator).to eq strategy
   end
 end


### PR DESCRIPTION
For reference:

https://thoughtbot.com/blog/lets-not

TL;DR- there is consensus within thoughtbot that RSpec's subject, before, and let features are over-used in the Ruby community, and result in relatively hard-to-read tests.

This is one of several PRs which in-lines many of the declarations previously made using the above idioms.