### PR TITLE
Refactor factory_bot_spec.rb to conform to Let's Not style

### DIFF
--- a/spec/factory_bot_spec.rb
+++ b/spec/factory_bot_spec.rb
@@ -1,19 +1,19 @@
 describe FactoryBot do
-  let(:factory)  { FactoryBot::Factory.new(:object) }
-  let(:sequence) { FactoryBot::Sequence.new(:email) }
-  let(:trait)    { FactoryBot::Trait.new(:admin) }
-
   it "finds a registered factory", :silence_deprecation do
+    factory = FactoryBot::Factory.new(:object)
     FactoryBot.register_factory(factory)
+
     expect(FactoryBot.factory_by_name(factory.name)).to eq factory
   end
 
   it "finds a registered sequence", :silence_deprecation do
+    sequence = FactoryBot::Sequence.new(:email)
     FactoryBot.register_sequence(sequence)
     expect(FactoryBot.sequence_by_name(sequence.name)).to eq sequence
   end
 
   it "finds a registered trait", :silence_deprecation do
+    trait = FactoryBot::Trait.new(:admin)
     FactoryBot.register_trait(trait)
     expect(FactoryBot.trait_by_name(trait.name)).to eq trait
   end


### PR DESCRIPTION
For reference:

https://thoughtbot.com/blog/lets-not

TL;DR- there is consensus within thoughtbot that RSpec's subject, before, and let features are over-used in the Ruby community, and result in relatively hard-to-read tests.

This is one of several PRs which in-lines many of the declarations previously made using the above idioms.