### PR TITLE
Use already installed version of bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ rvm:
   - jruby-9.2.8.0
   - ruby-head
 before_install:
-  - gem update --system
-  - gem update bundler
-  - gem cleanup bundler
+  which bundle || gem install bundler
 install: "bundle install --jobs 8"
 script: "bundle exec rake"
 gemfile:


### PR DESCRIPTION
These before install steps were introduced quite a while back in
850116da, 3c0547fa, and b3509f81. It looks like they were introduced as
workarounds to no-longer-relevant issues. Now that bundler is included
in Ruby by default, this is causing builds to fail while waiting on a
prompt about where it is OK to overwrite the "bundle" executable.