### PR TITLE
Fix issue where build_stubbed would load associations persisted in the database 

### DIFF
--- a/spec/acceptance/stub_spec.rb
+++ b/spec/acceptance/stub_spec.rb
@@ -99,3 +99,36 @@ describe "a stubbed instance with no primary key" do
     end
   end
 end
+
+describe "a stubbed instance with association persisted in the database" do
+  include FactoryBot::Syntax::Methods
+
+  before do
+    define_model("User") do
+      has_many :posts
+    end
+    define_model("Post", user_id: :integer) do
+      belongs_to :user
+    end
+
+    FactoryBot.define do
+      factory :user
+
+      factory :post do
+        association(:user)
+      end
+    end
+  end
+
+  let(:persisted_post) { create(:post) }
+
+  subject { build_stubbed(:user, id: persisted_post.user.id)}
+
+  it "does not assign associations in the database" do
+    expect(subject.posts).to be_empty
+  end
+
+  it "is a collection proxy" do
+    expect(subject.posts).to be_kind_of ActiveRecord::Associations::CollectionProxy
+  end
+end

--- a/spec/acceptance/stub_spec.rb
+++ b/spec/acceptance/stub_spec.rb
@@ -122,7 +122,7 @@ describe "a stubbed instance with association persisted in the database" do
 
   let(:persisted_post) { create(:post) }
 
-  subject { build_stubbed(:user, id: persisted_post.user.id)}
+  subject { build_stubbed(:user, id: persisted_post.user.id) }
 
   it "does not assign associations in the database" do
     expect(subject.posts).to be_empty


### PR DESCRIPTION
Hi!
This PR is a fix for: https://github.com/thoughtbot/factory_bot/issues/1117

The approach for this PR is to stub the association's proxy objects to make it look like an attempt has already been made to load the results from the database and has returned with an empty result. An empty array is the default value for `find_target`, whose results get returned by `load_target`

https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/association.rb#L220:L220

I decided to stub `load_target` instead of `find_target` since `find_target` is a private method.

`loaded?` also had to be stubbed because CollectionAssociation uses it to determine if the collection is empty:

https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/collection_association.rb#L234:L234