### PR TITLE
fixes deprecation warning on linter.rb

### DIFF
--- a/lib/factory_bot.rb
+++ b/lib/factory_bot.rb
@@ -71,7 +71,7 @@ module FactoryBot
   def self.lint(*args)
     options = args.extract_options!
     factories_to_lint = args[0] || FactoryBot.factories
-    Linter.new(factories_to_lint, options).lint!
+    Linter.new(factories_to_lint, **options).lint!
   end
 
   class << self


### PR DESCRIPTION
With ruby 2.7 we start seeing the following warnings when running tests
```
/factory_bot/lib/factory_bot.rb:74: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/factory_bot/lib/factory_bot/linter.rb:3: warning: The called method `initialize' is defined here
```
I'm proposing the following changes so that the message is supressed.