### PR TITLE
Add changelog to gemspec

### DIFF
--- a/factory_bot.gemspec
+++ b/factory_bot.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.email   = ["jclayton@thoughtbot.com", "jferris@thoughtbot.com"]
 
   s.homepage = "https://github.com/thoughtbot/factory_bot"
+  s.metadata["changelog_uri"] = "https://github.com/thoughtbot/factory_bot/blob/master/NEWS.md"
 
   s.add_dependency("activesupport", ">= 4.2.0")
 


### PR DESCRIPTION
For a nice “Changelog” link in the https://rubygems.org/gems/factory_bot sidebar.