### PR TITLE
Raise error on undefined callback

### DIFF
--- a/lib/factory_bot/definition.rb
+++ b/lib/factory_bot/definition.rb
@@ -95,7 +95,6 @@ module FactoryBot
 
     def callback(*names, &block)
       names.each do |name|
-        FactoryBot::Internal.register_callback(name)
         add_callback(Callback.new(name, block))
       end
     end

--- a/lib/factory_bot/internal.rb
+++ b/lib/factory_bot/internal.rb
@@ -10,7 +10,7 @@ module FactoryBot
     }.freeze
 
     DEFAULT_CALLBACKS = [
-      :after_create, :after_build, :after_stub, :after_create
+      :after_create, :after_build, :after_stub, :before_create
     ].freeze
 
     class << self

--- a/spec/acceptance/callbacks_spec.rb
+++ b/spec/acceptance/callbacks_spec.rb
@@ -142,6 +142,10 @@ describe "custom callbacks" do
     FactoryBot.register_strategy(:custom_after, custom_after)
     FactoryBot.register_strategy(:totally_custom, totally_custom)
 
+    FactoryBot.register_callback(:before_custom)
+    FactoryBot.register_callback(:after_custom)
+    FactoryBot.register_callback(:totally_custom)
+
     FactoryBot.define do
       factory :user do
         first_name { "John" }
@@ -247,5 +251,19 @@ describe "global callbacks" do
     expect(create(:user).name).to eq "john doe!!!"
     expect(create(:user, :awesome).name).to eq "A___john doe___!!!Z"
     expect(build(:company).name).to eq "ACME SUPPLIERS"
+  end
+end
+
+describe "invalid callbacks" do
+  it "raises an error for unregistered callbacks" do
+    definition = -> do
+      FactoryBot.define do
+        factory :user do
+          after(:invalid_callback) {}
+        end
+      end
+    end
+
+    expect(&definition).to raise_error(FactoryBot::InvalidCallbackNameError)
   end
 end

--- a/spec/factory_bot/definition_proxy_spec.rb
+++ b/spec/factory_bot/definition_proxy_spec.rb
@@ -187,6 +187,7 @@ describe FactoryBot::DefinitionProxy, "adding callbacks" do
   end
 
   it "adding both a :before_stub and a :before_create callback succeeds" do
+    FactoryBot.register_callback(:before_stub)
     definition = FactoryBot::Definition.new(:name)
     proxy = FactoryBot::DefinitionProxy.new(definition)
     callback = -> { "my awesome callback!" }


### PR DESCRIPTION
While reading through some code I noticed that `DEFAULT_CALLBACKS` had a
duplicate `:after_create` and was missing `:before_create`. This was
changed in [f82e40c8], but it didn't cause any test failures. It has
also been release for a while now and we didn't see any bug reports.
Hm...

[f82e40c8]: https://github.com/thoughtbot/factory_bot/commit/f82e40c8c50c538c0fba0362c0f6b7f6f96f9a3c

It turns out we have always had the line:
`FactoryBot::Internal.register_callback(name)`,
which defines callbacks on the fly whenever you refer to them in your
factories.

We have a [callback unit test] to ensure the `Callback` class raises an
error on initialize for invalid callback names, but nobody will have
ever seen this error since our code has been registering the callback on
the fly immediately before initializing the `Callback`.

[callback unit test]: https://github.com/thoughtbot/factory_bot/blob/0bcb6151b884d421ef4e7d840c1b098e6ca74d97/spec/factory_bot/callback_spec.rb#L35-L38

I wrote an acceptance test to capture what I think the original intended
behavior was, and that spec led me to remove the questionable on-the-fly
callback registration.

Removing that gave me the failing test for `DEFAULT_CALLBACKS` that I
had been expecting.

I also fixed a couple of other tests that were using custom callbacks
without registering them.

NOTE: This is a breaking change, so I plan to release this as part of FactoryBot 6.