### PR TITLE
Add ToC to GETTING_STARTED

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,8 +1,86 @@
 Getting Started
 ===============
 
-Update Your Gemfile
--------------------
+* [Setup](#setup)
+  + [Update Your Gemfile](#update-your-gemfile)
+  + [JRuby](#jruby)
+  + [Configure your test suite](#configure-your-test-suite)
+    - [RSpec](#rspec)
+    - [Test::Unit](#testunit)
+    - [Cucumber](#cucumber)
+    - [Spinach](#spinach)
+    - [Minitest](#minitest)
+    - [Minitest::Spec](#minitestspec)
+    - [minitest-rails](#minitest-rails)
+* [Defining factories](#defining-factories)
+  + [Factory name and attributes](#factory-name-and-attributes)
+  + [Specifying the class explicitly](#specifying-the-class-explicitly)
+  + [Hash attributes](#hash-attributes)
+  + [Best practices](#best-practices)
+  + [Definition file paths](#definition-file-paths)
+  + [Static Attributes](#static-attributes)
+* [Using factories](#using-factories)
+  + [Build strategies](#build-strategies)
+  + [Attribute overrides](#attribute-overrides)
+  + [`build_stubbed` and `Marshal.dump`](#build_stubbed-and-marshaldump)
+* [Aliases](#aliases)
+* [Dependent Attributes](#dependent-attributes)
+* [Transient Attributes](#transient-attributes)
+  + [With other attributes](#with-other-attributes)
+  + [With `attributes_for`](#with-attributes_for)
+  + [With callbacks](#with-callbacks)
+* [Method Name / Reserved Word Attributes](#method-name--reserved-word-attributes)
+* [Inheritance](#inheritance)
+  + [Nested factories](#nested-factories)
+  + [Assigning parent explicitly](#assigning-parent-explicitly)
+  + [Best practices](#best-practices-1)
+* [Associations](#associations)
+  + [Implicit definition](#implicit-definition)
+  + [Explicit definition](#explicit-definition)
+  + [Specifying the factory](#specifying-the-factory)
+  + [Overriding attributes](#overriding-attributes)
+  + [Build strategies](#build-strategies-1)
+  + [`has_many` associations](#has_many-associations)
+  + [`has_and_belongs_to_many` associations](#has_and_belongs_to_many-associations)
+  + [Polymorphic associations](#polymorphic-associations)
+* [Sequences](#sequences)
+  + [Global sequences](#global-sequences)
+  + [With dynamic attributes](#with-dynamic-attributes)
+  + [As implicit attributes](#as-implicit-attributes)
+  + [Inline sequences](#inline-sequences)
+  + [Initial value](#initial-value)
+  + [Without a block](#without-a-block)
+  + [Aliases](#aliases-1)
+  + [Rewinding](#rewinding)
+* [Traits](#traits)
+  + [Defining traits](#defining-traits)
+  + [As implicit attributes](#as-implicit-attributes-1)
+  + [Attribute precedence](#attribute-precedence)
+  + [In child factories](#in-child-factories)
+  + [Using traits](#using-traits)
+  + [With associations](#with-associations)
+  + [Traits within traits](#traits-within-traits)
+  + [With transient attributes](#with-transient-attributes)
+* [Callbacks](#callbacks)
+  + [Default callbacks](#default-callbacks)
+  + [Multiple callbacks](#multiple-callbacks)
+  + [Global callbacks](#global-callbacks)
+  + [Symbol#to_proc](#symbolto_proc)
+* [Modifying factories](#modifying-factories)
+* [Building or Creating Multiple Records](#building-or-creating-multiple-records)
+* [Linting Factories](#linting-factories)
+* [Custom Construction](#custom-construction)
+* [Custom Strategies](#custom-strategies)
+* [Custom Callbacks](#custom-callbacks)
+* [Custom Methods to Persist Objects](#custom-methods-to-persist-objects)
+* [ActiveSupport Instrumentation](#activesupport-instrumentation)
+* [Rails Preloaders and RSpec](#rails-preloaders-and-rspec)
+* [Using Without Bundler](#using-without-bundler)
+
+Setup
+-----
+
+### Update Your Gemfile
 
 If you're using Rails:
 
@@ -16,8 +94,11 @@ If you're *not* using Rails:
 gem "factory_bot"
 ```
 
-JRuby users: factory_bot works with JRuby starting with 1.6.7.2 (latest stable, as per July 2012).
-JRuby has to be used in 1.9 mode, for that, use JRUBY_OPTS environment variable:
+### JRuby
+
+JRuby users: factory\_bot works with JRuby starting with 1.6.7.2 (latest stable,
+as per July 2012). JRuby has to be used in 1.9 mode, for that, use JRUBY_OPTS
+environment variable:
 
 ```bash
 export JRUBY_OPTS=--1.9
@@ -25,12 +106,13 @@ export JRUBY_OPTS=--1.9
 
 Once your Gemfile is updated, you'll want to update your bundle.
 
-Configure your test suite
--------------------------
+### Configure your test suite
 
-### RSpec
+#### RSpec
 
-If you're using Rails, add the following configuration to `spec/support/factory_bot.rb` and be sure to require that file in `rails_helper.rb`:
+If you're using Rails, add the following configuration to
+`spec/support/factory_bot.rb` and be sure to require that file in
+`rails_helper.rb`:
 
 ```ruby
 RSpec.configure do |config|
@@ -50,7 +132,7 @@ RSpec.configure do |config|
 end
 ```
 
-### Test::Unit
+#### Test::Unit
 
 ```ruby
 class Test::Unit::TestCase
@@ -58,14 +140,14 @@ class Test::Unit::TestCase
 end
 ```
 
-### Cucumber
+#### Cucumber
 
 ```ruby
 # env.rb (Rails example location - RAILS_ROOT/features/support/env.rb)
 World(FactoryBot::Syntax::Methods)
 ```
 
-### Spinach
+#### Spinach
 
 ```ruby
 class Spinach::FeatureSteps
@@ -73,7 +155,7 @@ class Spinach::FeatureSteps
 end
 ```
 
-### Minitest
+#### Minitest
 
 ```ruby
 class Minitest::Unit::TestCase
@@ -81,7 +163,7 @@ class Minitest::Unit::TestCase
 end
 ```
 
-### Minitest::Spec
+#### Minitest::Spec
 
 ```ruby
 class Minitest::Spec
@@ -89,7 +171,7 @@ class Minitest::Spec
 end
 ```
 
-### minitest-rails
+#### minitest-rails
 
 ```ruby
 class ActiveSupport::TestCase
@@ -97,12 +179,16 @@ class ActiveSupport::TestCase
 end
 ```
 
-If you do not include `FactoryBot::Syntax::Methods` in your test suite, then all factory_bot methods will need to be prefaced with `FactoryBot`.
+If you do not include `FactoryBot::Syntax::Methods` in your test suite, then all
+factory\_bot methods will need to be prefaced with `FactoryBot`.
 
 Defining factories
 ------------------
 
-Each factory has a name and a set of attributes. The name is used to guess the class of the object by default:
+### Factory name and attributes
+
+Each factory has a name and a set of attributes. The name is used to guess the
+class of the object by default:
 
 ```ruby
 # This will guess the User class
@@ -115,6 +201,8 @@ FactoryBot.define do
 end
 ```
 
+### Specifying the class explicitly
+
 It is also possible to explicitly specify the class:
 
 ```ruby
@@ -125,12 +213,14 @@ factory :admin, class: "User"
 If the constant is not available
 (if you are using a Rails engine that waits to load models, for example),
 you can also pass a symbol or string,
-which factory_bot will constantize later, once you start building objects:
+which factory\_bot will constantize later, once you start building objects:
 
 ```ruby
 # It's OK if Doorkeeper::AccessToken isn't loaded yet
 factory :access_token, class: "Doorkeeper::AccessToken"
 ```
+
+### Hash attributes
 
 Because of the block syntax in Ruby, defining attributes as `Hash`es (for
 serialized/JSON columns, for example) requires two sets of curly brackets:
@@ -141,9 +231,18 @@ factory :program do
 end
 ```
 
-It is highly recommended that you have one factory for each class that provides the simplest set of attributes necessary to create an instance of that class. If you're creating ActiveRecord objects, that means that you should only provide attributes that are required through validations and that do not have defaults. Other factories can be created through inheritance to cover common scenarios for each class.
+### Best practices
+
+It is recommended that you have one factory for each class that provides
+the simplest set of attributes necessary to create an instance of that class. If
+you're creating ActiveRecord objects, that means that you should only provide
+attributes that are required through validations and that do not have defaults.
+Other factories can be created through inheritance to cover common scenarios for
+each class.
 
 Attempting to define multiple factories with the same name will raise an error.
+
+### Definition file paths
 
 Factories can be defined anywhere, but will be automatically loaded after
 calling `FactoryBot.find_definitions` if factories are defined in files at the
@@ -154,10 +253,20 @@ following locations:
     test/factories/*.rb
     spec/factories/*.rb
 
+### Static Attributes
+
+Static attributes (without a block) are no longer available in factory\_bot 5.
+You can read more about the decision to remove them in
+[this blog post](https://robots.thoughtbot.com/deprecating-static-attributes-in-factory_bot-4-11).
+
+
 Using factories
 ---------------
 
-factory\_bot supports several different build strategies: build, create, attributes\_for and build\_stubbed:
+### Build strategies
+
+factory\_bot supports several different build strategies: build, create,
+attributes\_for and build\_stubbed:
 
 ```ruby
 # Returns a User instance that's not saved
@@ -178,7 +287,10 @@ create(:user) do |user|
 end
 ```
 
-No matter which strategy is used, it's possible to override the defined attributes by passing a hash:
+### Attribute overrides
+
+No matter which strategy is used, it's possible to override the defined
+attributes by passing a hash:
 
 ```ruby
 # Build a User instance and override the first_name property
@@ -187,19 +299,20 @@ user.first_name
 # => "Joe"
 ```
 
+### `build_stubbed` and `Marshal.dump`
+
 Note that objects created with `build_stubbed` cannot be serialized with
-`Marshal.dump`, since factory_bot defines singleton methods on these objects.
-
-Static Attributes
-------------------
-
-Static attributes (without a block) are no longer available in factory\_bot 5.
-You can read more about the decision to remove them in
-[this blog post](https://robots.thoughtbot.com/deprecating-static-attributes-in-factory_bot-4-11).
+`Marshal.dump`, since factory\_bot defines singleton methods on these objects.
 
 Aliases
 -------
-factory_bot allows you to define aliases to existing factories to make them easier to re-use. This could come in handy when, for example, your Post object has an author attribute that actually refers to an instance of a User class. While normally factory_bot can infer the factory name from the association name, in this case it will look for an author factory in vain. So, alias your user factory so it can be used under alias names.
+
+factory\_bot allows you to define aliases to existing factories to make them
+easier to re-use. This could come in handy when, for example, your Post object
+has an author attribute that actually refers to an instance of a User class.
+While normally factory\_bot can infer the factory name from the association name,
+in this case it will look for an author factory in vain. So, alias your user
+factory so it can be used under alias names.
 
 ```ruby
 factory :user, aliases: [:author, :commenter] do
@@ -244,35 +357,58 @@ create(:user, last_name: "Doe").email
 Transient Attributes
 --------------------
 
-There may be times where your code can be DRYed up by passing in transient attributes to factories.
+### With other attributes
+
+There may be times where your code can be DRYed up by passing in transient
+attributes to factories. You can access transient attributes within other
+attributes (see [Dependent Attributes](#dependent-attributes):
 
 ```ruby
 factory :user do
   transient do
     rockstar { true }
-    upcased { false }
   end
 
   name { "John Doe#{" - Rockstar" if rockstar}" }
-  email { "#{name.downcase}@example.com" }
+end
+
+create(:user).name
+#=> "John Doe - ROCKSTAR"
+
+create(:user, rockstart: false).name
+#=> "John Doe"
+```
+
+### With `attributes_for`
+
+Transient attributes will be ignored within attributes\_for and won't be set on
+the model, even if the attribute exists or you attempt to override it.
+
+### With callbacks
+
+If you need to access the evaluator in a factory\_bot callback,
+you'll need to declare a second block argument (for the evaluator) and access
+transient attributes from there.
+
+```ruby
+factory :user do
+  transient do
+    upcased { false }
+  end
+
+  name { "John Doe" }
 
   after(:create) do |user, evaluator|
     user.name.upcase! if evaluator.upcased
   end
 end
 
+create(:user).name
+#=> "John Doe"
+
 create(:user, upcased: true).name
-#=> "JOHN DOE - ROCKSTAR"
+#=> "JOHN DOE"
 ```
-
-Transient attributes will be ignored within attributes\_for and won't be
-set on the model,
-even if the attribute exists or you attempt to override it.
-
-Within factory_bot's dynamic attributes, you can access transient attributes as
-you would expect. If you need to access the evaluator in a factory_bot callback,
-you'll need to declare a second block argument (for the evaluator) and access
-transient attributes from there.
 
 Method Name / Reserved Word Attributes
 -------------------------------
@@ -293,7 +429,10 @@ end
 Inheritance
 -----------
 
-You can easily create multiple factories for the same class without repeating common attributes by nesting factories:
+### Nested factories
+
+You can easily create multiple factories for the same class without repeating
+common attributes by nesting factories:
 
 ```ruby
 factory :post do
@@ -309,6 +448,8 @@ approved_post.title    # => "A title"
 approved_post.approved # => true
 ```
 
+### Assigning parent explicitly
+
 You can also assign the parent explicitly:
 
 ```ruby
@@ -321,6 +462,8 @@ factory :approved_post, parent: :post do
 end
 ```
 
+### Best practices
+
 As mentioned above, it's good practice to define a basic factory for each class
 with only the attributes required to create it. Then, create more specific
 factories that inherit from this basic parent. Factory definitions are still
@@ -329,7 +472,10 @@ code, so keep them DRY.
 Associations
 ------------
 
-It's possible to set up associations within factories. If the factory name is the same as the association name, the factory name can be left out.
+### Implicit definition
+
+It's possible to set up associations within factories. If the factory name is
+the same as the association name, the factory name can be left out.
 
 ```ruby
 factory :post do
@@ -338,14 +484,65 @@ factory :post do
 end
 ```
 
-You can also specify a different factory or override attributes:
+### Explicit definition
+
+You can define associations explicitly. This can be handy especially when
+[Overriding attributes](#overriding-attributes)
 
 ```ruby
 factory :post do
   # ...
-  association :author, factory: :user, last_name: "Writely"
+  association :author
 end
 ```
+
+### Specifying the factory
+
+You can specify a different factory (although [Aliases](#aliases) might also
+help you out here).
+
+Implicitly:
+
+```ruby
+factory :post do
+  # ...
+  author factory: :user
+end
+```
+
+Explicitly:
+
+```ruby
+factory :post do
+  # ...
+  association :author, factory: :user
+end
+```
+
+### Overriding attributes
+
+You can also override attributes.
+
+Implicitly:
+
+```ruby
+factory :post do
+  # ...
+  author factory: :author, last_name: "Writely"
+end
+```
+
+Explicitly:
+
+
+```ruby
+factory :post do
+  # ...
+  association :author, last_name: "Writely"
+end
+```
+
+### Build strategies
 
 In factory\_bot 5, associations default to using the same build strategy as
 their parent object:
@@ -412,6 +609,8 @@ factory :post do
   author strategy: :build    # <<< this does *not* work; causes author_id to be nil
 ```
 
+### `has_many` associations
+
 Generating data for a `has_many` relationship is a bit more involved,
 depending on the amount of flexibility desired, but here's a surefire example
 of generating associated data.
@@ -456,6 +655,8 @@ create(:user).posts.length # 0
 create(:user_with_posts).posts.length # 5
 create(:user_with_posts, posts_count: 15).posts.length # 15
 ```
+
+### `has_and_belongs_to_many` associations
 
 Generating data for a `has_and_belongs_to_many` relationship is very similar
 to the above `has_many` relationship, with a small change, you need to pass an
@@ -508,6 +709,8 @@ create(:profile_with_languages).languages.length # 5
 create(:profile_with_languages, languages_count: 15).languages.length # 15
 ```
 
+### Polymorphic associations
+
 Polymorphic associations can be handled with traits:
 
 ```ruby
@@ -541,6 +744,8 @@ create(:comment, :for_photo)
 Sequences
 ---------
 
+### Global sequences
+
 Unique values in a specific format (for example, e-mail addresses) can be
 generated using sequences. Sequences are defined by calling `sequence` in a
 definition block, and values in a sequence are generated by calling
@@ -561,6 +766,8 @@ generate :email
 # => "person2@example.com"
 ```
 
+### With dynamic attributes
+
 Sequences can be used in dynamic attributes:
 
 ```ruby
@@ -568,6 +775,8 @@ factory :invite do
   invitee { generate(:email) }
 end
 ```
+
+### As implicit attributes
 
 Or as implicit attributes:
 
@@ -580,6 +789,8 @@ end
 Note that defining sequences as implicit attributes will not work if you have a
 factory with the same name as the sequence.
 
+### Inline sequences
+
 And it's also possible to define an in-line sequence that is only used in
 a particular factory:
 
@@ -589,13 +800,18 @@ factory :user do
 end
 ```
 
-You can also override the initial value:
+### Initial value
+
+You can override the initial value. Any value that response to the `#next`
+method will work (e.g. 1, 2, 3, 'a', 'b', 'c')
 
 ```ruby
 factory :user do
   sequence(:email, 1000) { |n| "person#{n}@example.com" }
 end
 ```
+
+### Without a block
 
 Without a block, the value will increment itself, starting at its initial value:
 
@@ -604,6 +820,8 @@ factory :post do
   sequence(:position)
 end
 ```
+
+### Aliases
 
 Sequences can also have aliases. The sequence aliases share the same counter:
 
@@ -634,6 +852,8 @@ end
 
 The value just needs to support the `#next` method. Here the next value will be 'a', then 'b', etc.
 
+### Rewinding
+
 Sequences can also be rewound with `FactoryBot.rewind_sequences`:
 
 ```ruby
@@ -652,6 +872,8 @@ This rewinds all registered sequences.
 
 Traits
 ------
+
+### Defining traits
 
 Traits allow you to group attributes together and then apply them
 to any factory.
@@ -688,6 +910,8 @@ factory :story do
 end
 ```
 
+### As implicit attributes
+
 Traits can be used as implicit attributes:
 
 ```ruby
@@ -700,6 +924,8 @@ end
 
 Note that defining traits as implicit attributes will not work if you have a
 factory or sequence with the same name as the trait.
+
+### Attribute precedence
 
 Traits that define the same attributes won't raise AttributeDefinitionErrors;
 the trait that defines the attribute latest gets precedence.
@@ -731,7 +957,9 @@ factory :user do
 end
 ```
 
-You can also override individual attributes granted by a trait in subclasses.
+### In child factories
+
+You can override individual attributes granted by a trait in a child factory:
 
 ```ruby
 factory :user do
@@ -751,7 +979,10 @@ factory :user do
 end
 ```
 
-Traits can also be passed in as a list of symbols when you construct an instance from factory_bot.
+### Using traits
+
+Traits can also be passed in as a list of symbols when you construct an instance
+from factory\_bot.
 
 ```ruby
 factory :user do
@@ -789,6 +1020,8 @@ end
 # creates 3 admin users with gender "Male" and name "Jon Snow"
 create_list(:user, 3, :admin, :male, name: "Jon Snow")
 ```
+
+### With associations
 
 Traits can be used with associations easily too:
 
@@ -830,6 +1063,8 @@ end
 create(:post).author
 ```
 
+### Traits within traits
+
 Traits can be used within other traits to mix in their attributes.
 
 ```ruby
@@ -844,6 +1079,8 @@ factory :order do
   end
 end
 ```
+
+### With transient attributes
 
 Finally, traits can accept transient attributes.
 
@@ -866,6 +1103,8 @@ create :invoice, :with_amount, amount: 2
 Callbacks
 ---------
 
+### Default callbacks
+
 factory\_bot makes available four callbacks for injecting some code:
 
 * after(:build)   - called after a factory is built   (via `FactoryBot.build`, `FactoryBot.create`)
@@ -884,6 +1123,8 @@ end
 
 Note that you'll have an instance of the user in the block. This can be useful.
 
+### Multiple callbacks
+
 You can also define multiple types of callbacks on the same factory:
 
 ```ruby
@@ -893,7 +1134,8 @@ factory :user do
 end
 ```
 
-Factories can also define any number of the same kind of callback.  These callbacks will be executed in the order they are specified:
+Factories can also define any number of the same kind of callback.  These
+callbacks will be executed in the order they are specified:
 
 ```ruby
 factory :user do
@@ -904,9 +1146,12 @@ end
 
 Calling `create` will invoke both `after_build` and `after_create` callbacks.
 
-Also, like standard attributes, child factories will inherit (and can also define) callbacks from their parent factory.
+Also, like standard attributes, child factories will inherit (and can also
+define) callbacks from their parent factory.
 
-Multiple callbacks can be assigned to run a block; this is useful when building various strategies that run the same code (since there are no callbacks that are shared across all strategies).
+Multiple callbacks can be assigned to run a block; this is useful when building
+various strategies that run the same code (since there are no callbacks that are
+shared across all strategies).
 
 ```ruby
 factory :user do
@@ -915,6 +1160,8 @@ factory :user do
   before(:create, :custom) { do_a_third_thing }
 end
 ```
+
+### Global callbacks
 
 To override callbacks for all factories, define them within the
 `FactoryBot.define` block:
@@ -930,7 +1177,9 @@ FactoryBot.define do
 end
 ```
 
-You can also call callbacks that rely on `Symbol#to_proc`:
+### Symbol#to_proc
+
+You can call callbacks that rely on `Symbol#to_proc`:
 
 ```ruby
 # app/models/user.rb
@@ -953,8 +1202,9 @@ create(:user) # creates the user and confirms it
 Modifying factories
 -------------------
 
-If you're given a set of factories (say, from a gem developer) but want to change them to fit into your application better, you can
-modify that factory instead of creating a child factory and adding attributes there.
+If you're given a set of factories (say, from a gem developer) but want to
+change them to fit into your application better, you can modify that factory
+instead of creating a child factory and adding attributes there.
 
 If a gem were to give you a User factory:
 
@@ -1040,7 +1290,7 @@ users_attrs = attributes_for_list(:user, 25) # array of attribute hashes
 Linting Factories
 -----------------
 
-factory_bot allows for linting known factories:
+factory\_bot allows for linting known factories:
 
 ```ruby
 FactoryBot.lint
@@ -1126,7 +1376,7 @@ FactoryBot.lint verbose: true
 Custom Construction
 -------------------
 
-If you want to use factory_bot to construct an object where some attributes
+If you want to use factory\_bot to construct an object where some attributes
 are passed to `initialize` or if you want to do something other than simply
 calling `new` on your build class, you can override the default behavior by
 defining `initialize_with` on your factory. Example:
@@ -1154,7 +1404,7 @@ end
 build(:user).name # Jane Doe
 ```
 
-Although factory_bot is written to work with ActiveRecord out of the box, it
+Although factory\_bot is written to work with ActiveRecord out of the box, it
 can also work with any Ruby class. For maximum compatibility with ActiveRecord,
 the default initializer builds all instances by calling `new` on your build class
 without any arguments. It then calls attribute writer methods to assign all the
@@ -1165,7 +1415,7 @@ You can override the initializer in order to:
 
 * Build non-ActiveRecord objects that require arguments to `initialize`
 * Use a method other than `new` to instantiate the instance
-* Do crazy things like decorate the instance after it's built
+* Do wild things like decorate the instance after it's built
 
 When using `initialize_with`, you don't have to declare the class itself when
 calling `new`; however, any other class methods you want to call will have to
@@ -1227,7 +1477,7 @@ build(:user)
 User.new('value')
 ```
 
-This prevents duplicate assignment; in versions of factory_bot before 4.0, it
+This prevents duplicate assignment; in versions of factory\_bot before 4.0, it
 would run this:
 
 ```ruby


### PR DESCRIPTION
I have always found the GETTING_STARTED guide to be a bit overwhelming.
I have troubling finding the information I want, even after having used
factory\_bot for years.

This commit adds a whole bunch of section headings,
then adds a Table of Contents
(autogenerated by https://ecotrust-canada.github.io/markdown-toc/)
to make it easier to navigate this document.

This commit also makes a few small improvements to the content I noticed
while reading through the document.