### PR TITLE
Deprecate remaining undocumented internal methods

### DIFF
--- a/lib/factory_bot.rb
+++ b/lib/factory_bot.rb
@@ -4,6 +4,7 @@ require "active_support/core_ext/module/attribute_accessors"
 require "active_support/deprecation"
 require "active_support/notifications"
 
+require "factory_bot/internal"
 require "factory_bot/definition_hierarchy"
 require "factory_bot/configuration"
 require "factory_bot/errors"
@@ -45,18 +46,9 @@ require "factory_bot/decorator/invocation_tracker"
 require "factory_bot/decorator/new_constructor"
 require "factory_bot/linter"
 require "factory_bot/version"
-require "factory_bot/internal"
 
 module FactoryBot
   Deprecation = ActiveSupport::Deprecation.new("6.0", "factory_bot")
-
-  def self.configuration
-    Internal.configuration
-  end
-
-  def self.reset_configuration
-    Internal.reset_configuration
-  end
 
   mattr_accessor :use_parent_strategy, instance_accessor: false
   self.use_parent_strategy = true
@@ -75,19 +67,13 @@ module FactoryBot
   end
 
   class << self
-    delegate :callbacks,
-             :callback_names,
+    delegate :callback_names,
+             :callbacks,
+             :configuration,
              :constructor,
              :factories,
+             :factory_by_name,
              :initialize_with,
-             :sequences,
-             :skip_create,
-             :strategies,
-             :to_create,
-             :traits,
-             to: :configuration
-
-    delegate :factory_by_name,
              :register_callback,
              :register_default_callbacks,
              :register_default_strategies,
@@ -95,10 +81,16 @@ module FactoryBot
              :register_sequence,
              :register_strategy,
              :register_trait,
+             :reset_configuration,
              :rewind_sequences,
              :sequence_by_name,
+             :sequences,
+             :skip_create,
+             :strategies,
              :strategy_by_name,
+             :to_create,
              :trait_by_name,
+             :traits,
              to: Internal
 
     attr_accessor :allow_class_lookup
@@ -106,15 +98,23 @@ module FactoryBot
     deprecate :allow_class_lookup,
               :allow_class_lookup=,
               :callback_names,
+              :callbacks,
+              :configuration,
+              :constructor,
               :factory_by_name,
+              :initialize_with,
               :register_callback,
               :register_default_callbacks,
               :register_default_strategies,
               :register_factory,
+              :register_sequence,
               :register_trait,
+              :reset_configuration,
               :sequence_by_name,
               :sequences,
+              :skip_create,
               :strategies,
+              :to_create,
               :trait_by_name,
               :traits,
               deprecator: Deprecation

--- a/lib/factory_bot/definition_hierarchy.rb
+++ b/lib/factory_bot/definition_hierarchy.rb
@@ -1,16 +1,6 @@
 module FactoryBot
   class DefinitionHierarchy
-    def callbacks
-      FactoryBot.callbacks
-    end
-
-    def constructor
-      FactoryBot.constructor
-    end
-
-    def to_create
-      FactoryBot.to_create
-    end
+    delegate :callbacks, :constructor, :to_create, to: Internal
 
     def self.build_from_definition(definition)
       build_to_create(&definition.to_create)

--- a/lib/factory_bot/internal.rb
+++ b/lib/factory_bot/internal.rb
@@ -1,24 +1,19 @@
 module FactoryBot
   # @api private
   module Internal
-    DEFAULT_STRATEGIES = {
-      build: FactoryBot::Strategy::Build,
-      create: FactoryBot::Strategy::Create,
-      attributes_for: FactoryBot::Strategy::AttributesFor,
-      build_stubbed: FactoryBot::Strategy::Stub,
-      null: FactoryBot::Strategy::Null,
-    }.freeze
-
-    DEFAULT_CALLBACKS = [
-      :after_create, :after_build, :after_stub, :after_create
-    ].freeze
-
     class << self
-      delegate :callback_names,
+      delegate :after,
+               :before,
+               :callback_names,
+               :callbacks,
+               :constructor,
                :factories,
+               :initialize_with,
                :inline_sequences,
                :sequences,
+               :skip_create,
                :strategies,
+               :to_create,
                :traits,
                to: :configuration
 
@@ -86,11 +81,18 @@ module FactoryBot
       end
 
       def register_default_strategies
-        DEFAULT_STRATEGIES.each { |name, klass| register_strategy(name, klass) }
+        register_strategy(:build, FactoryBot::Strategy::Build)
+        register_strategy(:create, FactoryBot::Strategy::Create)
+        register_strategy(:attributes_for, FactoryBot::Strategy::AttributesFor)
+        register_strategy(:build_stubbed, FactoryBot::Strategy::Stub)
+        register_strategy(:null, FactoryBot::Strategy::Null)
       end
 
       def register_default_callbacks
-        DEFAULT_CALLBACKS.each(&method(:register_callback))
+        register_callback(:after_create)
+        register_callback(:after_build)
+        register_callback(:after_stub)
+        register_callback(:before_create)
       end
 
       def register_callback(name)

--- a/lib/factory_bot/syntax/default.rb
+++ b/lib/factory_bot/syntax/default.rb
@@ -33,29 +33,17 @@ module FactoryBot
           Internal.register_trait(Trait.new(name, &block))
         end
 
-        def to_create(&block)
-          FactoryBot.to_create(&block)
-        end
-
-        def skip_create
-          FactoryBot.skip_create
-        end
-
-        def initialize_with(&block)
-          FactoryBot.initialize_with(&block)
-        end
-
         def self.run(block)
           new.instance_eval(&block)
         end
 
-        delegate :before, :after, :callback, to: :configuration
-
-        private
-
-        def configuration
-          Internal.configuration
-        end
+        delegate :after,
+                 :before,
+                 :callback,
+                 :initialize_with,
+                 :skip_create,
+                 :to_create,
+                 to: FactoryBot::Internal
       end
 
       class ModifyDSL

--- a/spec/factory_bot/internal_spec.rb
+++ b/spec/factory_bot/internal_spec.rb
@@ -140,21 +140,4 @@ describe FactoryBot::Internal do
         to eq :strategy_class
     end
   end
-
-  describe "default strategies and callbacks" do
-    FactoryBot::Internal::DEFAULT_STRATEGIES.
-      each do |strategy_name, strategy_class|
-      it "registers the #{strategy_name} strategy by default" do
-        expect(FactoryBot::Internal.strategy_by_name(strategy_name)).
-          to eq strategy_class
-      end
-    end
-
-    FactoryBot::Internal::DEFAULT_CALLBACKS.each do |callback_name|
-      it "registers the #{callback_name} by default" do
-        expect(FactoryBot::Internal.callback_names.include?(callback_name)).
-          to be_truthy
-      end
-    end
-  end
 end


### PR DESCRIPTION
This commit deprecates several undocumented top-level FactoryBot
methods:

  * callbacks
  * configuration
  * constructor
  * initialize_with
  * register_sequence
  * resent_configuration
  * skip_create
  * to_create

factory_bot users are not meant to access these methods directly.
Instead they are available for internal use through the new Internal
module introduced in #1262.

---

While addressing the new deprecation warnings, I tried to make the
delegation a bit more consistent, always delegating to
`FactoryBot::Internal`.

This involved requiring "factory_bot/internal" sooner. To avoid having
to fight with the order of requires and potential circular dependencies,
I moved the default strategy and callback registration out of constants
(this is how they used to be before #1297), so it doesn't matter if
those strategies are loaded before the `Internal` module. I also deleted
a pair of tests that were using these constants - these strategies and
callbacks are covered elsewhere in our test suite, and I don't think
these tests were adding much value (they missed #1379, for example).