### PR TITLE
Change string to User class reference in Getting Started doc

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -119,7 +119,7 @@ It is also possible to explicitly specify the class:
 
 ```ruby
 # This will use the User class (otherwise Admin would have been guessed)
-factory :admin, class: "User"
+factory :admin, class: User
 ```
 
 If the constant is not available


### PR DESCRIPTION
`User` was quoted in the example that presumably shows how to refer to a class directly, which makes the subsequent usage example:

> you can also pass a symbol or string,

confusing.