### PR TITLE
Fix typo

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -375,7 +375,7 @@ end
 create(:user).name
 #=> "John Doe - ROCKSTAR"
 
-create(:user, rockstart: false).name
+create(:user, rockstar: false).name
 #=> "John Doe"
 ```
 


### PR DESCRIPTION
Change `rockstart` to `rockstar` to match usage example.