### PR TITLE
Fix typo in getting started readme

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -375,7 +375,7 @@ end
 create(:user).name
 #=> "John Doe - ROCKSTAR"
 
-create(:user, rockstart: false).name
+create(:user, rockstar: false).name
 #=> "John Doe"
 ```
 


### PR DESCRIPTION
While reviewing some documentation I noticed a typo which is corrected in this PR.