### PR TITLE
Add missing closing bracket in GETTING_STARTED.md

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -362,7 +362,7 @@ Transient Attributes
 
 There may be times where your code can be DRYed up by passing in transient
 attributes to factories. You can access transient attributes within other
-attributes (see [Dependent Attributes](#dependent-attributes):
+attributes (see [Dependent Attributes](#dependent-attributes)):
 
 ```ruby
 factory :user do


### PR DESCRIPTION
Add closing bracket after link to 'Dependent Attributes' section, in the 'With other attributes' section.