### PR TITLE
Remove unused null object code

### DIFF
--- a/lib/factory_bot/null_object.rb
+++ b/lib/factory_bot/null_object.rb
@@ -13,7 +13,7 @@ module FactoryBot
       end
     end
 
-    def respond_to?(method, _include_private = false)
+    def respond_to?(method)
       @methods_to_respond_to.include? method.to_s
     end
   end

--- a/lib/factory_bot/null_object.rb
+++ b/lib/factory_bot/null_object.rb
@@ -5,7 +5,7 @@ module FactoryBot
       @methods_to_respond_to = methods_to_respond_to.map(&:to_s)
     end
 
-    def method_missing(name, *args, &block)
+    def method_missing(name, *args, &block) # rubocop:disable Style/MissingRespondToMissing
       if respond_to?(name)
         nil
       else
@@ -15,10 +15,6 @@ module FactoryBot
 
     def respond_to?(method, _include_private = false)
       @methods_to_respond_to.include? method.to_s
-    end
-
-    def respond_to_missing?(*)
-      false
     end
   end
 end


### PR DESCRIPTION
Since `NullObject` inherits from `BasicObject` rather than `Object` it does not need to implement `respond_to?` or `respond_to_missing?` in the way that Rubocop suggests (which assumes that `Object` is the base class).

Rather than writing unused code just to make Rubocop happy, we can tell Rubocop to ignore the `Style/MissingRespondToMissing` cop and delete the useless code.

This improves the test coverage for the project:

Before:
`1140 / 1143 LOC (99.74%)`

After:
`1139 / 1141 LOC (99.82%)`
