### PR TITLE
decorator.rb: Remove redundant const_missing class method.

### DIFF
--- a/lib/factory_bot/decorator.rb
+++ b/lib/factory_bot/decorator.rb
@@ -17,9 +17,5 @@ module FactoryBot
     def send(symbol, *args, &block)
       __send__(symbol, *args, &block)
     end
-
-    def self.const_missing(name)
-      ::Object.const_get(name)
-    end
   end
 end


### PR DESCRIPTION
This code was added as a workaround to fix namespace issues in one of
the acceptance specs when running with Ruby 1.9.2. [1]

Since then Ruby's constant resolver has been updated and this
non-standard behaviour of `Decorator` is not documented or tested by the
FactoryBot test suite.

So this workaround is no longer needed and the code can be removed.

Removing it improves the test coverage of the project;

Before:
1140 / 1143 LOC (99.74%)

After:
1139 / 1141 LOC (99.82%)

Reference:
[1] https://github.com/thoughtbot/factory_bot/commit/775dc8bd88ae1ea5d746939db5ec7df3c6c276e0