### PR TITLE
Add randomise_sequence_start option

### DIFF
--- a/lib/factory_bot.rb
+++ b/lib/factory_bot.rb
@@ -51,6 +51,9 @@ require "factory_bot/version"
 module FactoryBot
   Deprecation = ActiveSupport::Deprecation.new("7.0", "factory_bot")
 
+  mattr_accessor :randomise_sequence_start, instance_accessor: false
+  self.randomise_sequence_start = false
+
   mattr_accessor :use_parent_strategy, instance_accessor: false
   self.use_parent_strategy = true
 

--- a/lib/factory_bot/sequence.rb
+++ b/lib/factory_bot/sequence.rb
@@ -10,7 +10,7 @@ module FactoryBot
       @proc    = proc
 
       options  = args.extract_options!
-      @value   = args.first || 1
+      @value   = args.first || default_value
       @aliases = options.fetch(:aliases) { [] }
 
       if !@value.respond_to?(:peek)
@@ -39,6 +39,12 @@ module FactoryBot
     end
 
     private
+
+    def default_value
+      offset = FactoryBot.randomise_sequence_start ? Random.rand(1_000) : 0
+
+      offset + 1
+    end
 
     def value
       @value.peek

--- a/spec/acceptance/sequence_spec.rb
+++ b/spec/acceptance/sequence_spec.rb
@@ -69,4 +69,24 @@ describe "sequences" do
     expect(values.first).to eq("somebody1@example.com")
     expect(values.second).to eq("somebody2@example.com")
   end
+
+  context "when the :randomise_sequence_start config option is set to true" do
+    before { allow(Random).to receive(:rand).and_return(123) }
+
+    it "randomly offsets the initial sequence value" do
+      with_temporary_assignment(FactoryBot, :randomise_sequence_start, true) do
+        FactoryBot.define do
+          sequence :email do |n|
+            "somebody#{n}@example.com"
+          end
+        end
+
+        first_value = generate(:email)
+        another_value = generate(:email)
+
+        expect(first_value).to eq "somebody124@example.com"
+        expect(another_value).to eq "somebody125@example.com"
+      end
+    end
+  end
 end

--- a/spec/factory_bot_spec.rb
+++ b/spec/factory_bot_spec.rb
@@ -10,4 +10,10 @@ describe FactoryBot do
       expect(FactoryBot.use_parent_strategy).to be true
     end
   end
+
+  describe ".randomise_sequence_start" do
+    it "is false by default" do
+      expect(FactoryBot.randomise_sequence_start).to be false
+    end
+  end
 end


### PR DESCRIPTION
This change adds the `FactoryBot.randomise_sequence_start` flag, which,
when set to `true` will make default integer sequences start with a
random number rather than always starting at `1`.

We recently had an incorrect spec slip by reviews and cause our test
suite to be flaky as it passed only if that spec file was run before any
other using the specified factory, as the sequences were in sync.

Randomising the sequence ids might help to catch subtle errors like
this.

This is probably the simplest representation of how randomising would
catch subtle errors earlier, the error is in which value is being used in the
expectation `id` vs `publisher_id`.
```ruby
    # frozen_string_literal: true

    require "bundler/inline"

    gemfile(true) do
      source "https://rubygems.org"

      git_source(:github) { |repo| "https://github.com/#{repo}.git" }

      gem "activerecord", "6.0.3"
      gem "sqlite3"
      gem "factory_bot"
      gem "rspec"
    end

    require "active_record"
    require "rspec/autorun"
    require "logger"

    ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
    ActiveRecord::Base.logger = Logger.new(STDOUT)

    ActiveRecord::Schema.define do
      create_table :authors, force: true do |t|
        t.timestamps
      end

      create_table :books, force: true do |t|
        t.integer :author_id
        t.integer :publisher_id
        t.timestamps
      end
    end

    class Author < ActiveRecord::Base
      has_many :books

      def publisher_ids
        books.order(created_at: :desc).map(&:publisher_id)
      end
    end

    class Book < ActiveRecord::Base
      belongs_to :author
    end

    FactoryBot.define do
      factory :author do
      end

      factory :book do
        association :author

        sequence :publisher_id
      end
    end

    RSpec.describe Author do
      # Uncomment to simulate another spec file using the factory and updating
      # the sequence!
      #
      # before { FactoryBot.build(:book) }

      let!(:author) { FactoryBot.create(:author) }
      let!(:old_book) { FactoryBot.create(:book, author: author, created_at: 1.month.ago) }
      let!(:older_book) { FactoryBot.create(:book, author: author, created_at: 2.month.ago) }
      let!(:recent_book) { FactoryBot.create(:book, author: author, created_at: 1.day.ago) }

      describe '#publisher_ids' do
        it { expect(author.publisher_ids).to eq([recent_book.id, old_book.id, older_book.id]) }
      end
    end
```