### PR TITLE
Use attr_readers in association declaration

### DIFF
--- a/lib/factory_bot/declaration/association.rb
+++ b/lib/factory_bot/declaration/association.rb
@@ -6,6 +6,7 @@ module FactoryBot
         super(name, false)
         @options = options.dup
         @overrides = options.extract_options!
+        @factory_name = @overrides.delete(:factory) || name
         @traits = options
       end
 
@@ -21,18 +22,25 @@ module FactoryBot
 
       private
 
+      attr_reader :factory_name, :overrides, :traits
+
       def build
         ensure_factory_is_not_a_declaration!
 
-        factory_name = @overrides[:factory] || name
-        [Attribute::Association.new(name, factory_name, [@traits, @overrides.except(:factory)].flatten)]
+        [
+          Attribute::Association.new(
+            name,
+            factory_name,
+            [traits, overrides].flatten
+          )
+        ]
       end
 
       def ensure_factory_is_not_a_declaration!
-        if @overrides[:factory].is_a?(Declaration)
+        if factory_name.is_a?(Declaration)
           raise ArgumentError.new(<<~MSG)
             Association '#{name}' received an invalid factory argument.
-            Did you mean? 'factory: :#{@overrides[:factory].name}'
+            Did you mean? 'factory: :#{factory_name.name}'
           MSG
         end
       end


### PR DESCRIPTION
This commit separates the factory name from the overrides on initialize,
then uses attr_readers throughout instead of manipulating instance
variables.

This is a bit cleaner, and will make it easier to reused the
factory_name and overrides in a future code change.