### PR TITLE
Raise more helpful error for invalid attribute

### DIFF
--- a/lib/factory_bot/declaration/association.rb
+++ b/lib/factory_bot/declaration/association.rb
@@ -25,7 +25,7 @@ module FactoryBot
       attr_reader :factory_name, :overrides, :traits
 
       def build
-        ensure_factory_is_not_a_declaration!
+        raise_if_arguments_are_declarations!
 
         [
           Attribute::Association.new(
@@ -36,12 +36,21 @@ module FactoryBot
         ]
       end
 
-      def ensure_factory_is_not_a_declaration!
+      def raise_if_arguments_are_declarations!
         if factory_name.is_a?(Declaration)
           raise ArgumentError.new(<<~MSG)
             Association '#{name}' received an invalid factory argument.
             Did you mean? 'factory: :#{factory_name.name}'
           MSG
+        end
+
+        overrides.each do |attribute, value|
+          if value.is_a?(Declaration)
+            raise ArgumentError.new(<<~MSG)
+              Association '#{name}' received an invalid attribute override.
+              Did you mean? '#{attribute}: :#{value.name}'
+            MSG
+          end
         end
       end
     end

--- a/spec/acceptance/associations_spec.rb
+++ b/spec/acceptance/associations_spec.rb
@@ -1,6 +1,6 @@
 describe "associations" do
   context "when accidentally using an implicit delcaration for the factory" do
-    it "raises an error about the trait not being registered" do
+    it "raises an error" do
       define_class("Post")
 
       FactoryBot.define do
@@ -13,6 +13,24 @@ describe "associations" do
         ArgumentError,
         "Association 'author' received an invalid factory argument.\n" \
         "Did you mean? 'factory: :user'\n"
+      )
+    end
+  end
+
+  context "when accidentally using an implicit delcaration as an override" do
+    it "raises an error" do
+      define_class("Post")
+
+      FactoryBot.define do
+        factory :post do
+          author factory: :user, invalid_attribute: implicit_trait
+        end
+      end
+
+      expect { FactoryBot.build(:post) }.to raise_error(
+        ArgumentError,
+        "Association 'author' received an invalid attribute override.\n" \
+        "Did you mean? 'invalid_attribute: :implicit_trait'\n"
       )
     end
   end


### PR DESCRIPTION
Closes #1391

Along the same lines as #1286, this commit raises a more helpful error
if somebody passes an implicit declaration as an association argument.

Before this commit, an association with an implicit trait passed as an
override attribute:

```rb
person factory: :user, invalid_attribute: implicit_trait
```

Would raise an error `KeyError: Trait not registered: "implicit_trait"`.

This is potentially confusing, since the author probably didn't intend
to define an implicit trait.

After this commit, this will raise a more helpful error:

```
ArgumentError: Association 'person' received an invalid attribute override.
Did you mean? 'invalid_attribute}: :implicit_trait}'
```