### PR TITLE
Make the evaluator instance public

### DIFF
--- a/lib/factory_bot/evaluator.rb
+++ b/lib/factory_bot/evaluator.rb
@@ -33,7 +33,7 @@ module FactoryBot
       @build_strategy.association(runner)
     end
 
-    attr_writer :instance
+    attr_accessor :instance
 
     if ::Gem::Version.new(::RUBY_VERSION) >= ::Gem::Version.new("2.7")
       def method_missing(method_name, *args, **kwargs, &block) # rubocop:disable Style/MethodMissingSuper, Style/MissingRespondToMissing

--- a/spec/acceptance/associations_spec.rb
+++ b/spec/acceptance/associations_spec.rb
@@ -34,4 +34,73 @@ describe "associations" do
       )
     end
   end
+
+  context "when building interrelated associations" do
+    it "assigns the instance passed as an association attribute" do
+      define_class("Supplier") do
+        attr_accessor :account
+      end
+
+      define_class("Account") do
+        attr_accessor :supplier
+      end
+
+      FactoryBot.define do
+        factory :supplier
+
+        factory :account do
+          supplier { association(:supplier, account: instance) }
+        end
+      end
+
+      account = FactoryBot.build(:account)
+
+      expect(account.supplier.account).to eq(account)
+    end
+
+    it "connects records with interdependent relationships" do
+      define_model("User", school_id: :integer) do
+        belongs_to :school
+        has_one :profile
+      end
+
+      define_model("Profile", school_id: :integer, user_id: :integer) do
+        belongs_to :school
+        belongs_to :user
+      end
+
+      define_model("School") do
+        has_many :users
+        has_many :profiles
+      end
+
+      FactoryBot.define do
+        factory :user do
+          school
+          profile { association :profile, user: instance, school: school }
+        end
+
+        factory :profile do
+          school
+          user { association :user, profile: instance, school: school }
+        end
+
+        factory :school
+      end
+
+      user = FactoryBot.create(:user)
+
+      expect(user.profile.school).to eq(user.school)
+      expect(user.profile.user).to eq(user)
+      expect(user.school.users.map(&:id)).to eq([user.id])
+      expect(user.school.profiles.map(&:id)).to eq([user.profile.id])
+
+      profile = FactoryBot.create(:profile)
+
+      expect(profile.user.school).to eq(profile.school)
+      expect(profile.user.profile).to eq(profile)
+      expect(profile.school.profiles.map(&:id)).to eq([profile.id])
+      expect(profile.school.users.map(&:id)).to eq([profile.user.id])
+    end
+  end
 end


### PR DESCRIPTION
closes #1309
closes #1063

It has come up several times over the years that folks want direct
access to the evaluator instance, in most cases to build up more complex
networks of associations. Some folks are already doing this with the
private `@instance` instance variable.

Given that this is such a minimal change, and it makes the library more
flexible for these more complex use cases, this commit adds an
`attr_reader` for the evaluator instance. Now folks can reference it
without reaching into the private api.

Documentation to follow as part of
https://github.com/thoughtbot/factory_bot/issues/1268