### PR TITLE
Add back did_you_mean spec

### DIFF
--- a/spec/factory_bot/registry_spec.rb
+++ b/spec/factory_bot/registry_spec.rb
@@ -28,6 +28,15 @@ describe FactoryBot::Registry do
       .to raise_error(KeyError, "Great thing not registered: \"object_name\"")
   end
 
+  it "includes a did_you_mean message" do
+    registry = FactoryBot::Registry.new(:registry)
+    registered_object = double(:registered_object)
+    registry.register(:factory_bot, registered_object)
+
+    expect { registry.find(:factory_bit) }
+      .to raise_error(KeyError, /Did you mean\?  "factory_bot"/)
+  end
+
   it "adds and returns the object registered" do
     registry = FactoryBot::Registry.new("Great thing")
     registered_object = double("registered object")


### PR DESCRIPTION
This essentially reverts commit 3a4d6f48. We removed that test because
we couldn't get it passing on Ruby 2.3 and 2.4, but we have since
removed support for those versions of Ruby.