### PR TITLE
Address Ruby 2.7 kwargs edge case

### DIFF
--- a/lib/factory_bot/decorator/invocation_tracker.rb
+++ b/lib/factory_bot/decorator/invocation_tracker.rb
@@ -6,8 +6,13 @@ module FactoryBot
         @invoked_methods = []
       end
 
-      if ::Gem::Version.new(::RUBY_VERSION) >= ::Gem::Version.new("2.7")
+      if ::Gem::Version.new(::RUBY_VERSION) >= ::Gem::Version.new("3.0")
         def method_missing(name, *args, **kwargs, &block) # rubocop:disable Style/MissingRespondToMissing
+          @invoked_methods << name
+          super
+        end
+      elsif ::Gem::Version.new(::RUBY_VERSION) >= ::Gem::Version.new("2.7")
+        ruby2_keywords def method_missing(name, *args, &block) # rubocop:disable Style/MissingRespondToMissing
           @invoked_methods << name
           super
         end

--- a/spec/acceptance/initialize_with_spec.rb
+++ b/spec/acceptance/initialize_with_spec.rb
@@ -254,3 +254,23 @@ describe "initialize_with for a constructor that requires a block" do
     expect(FactoryBot.build(:awesome).output).to eq "Output"
   end
 end
+
+describe "initialize_with with a hash argument" do
+  it "builds the object correctly" do
+    define_class("Container") do
+      attr_reader :contents
+
+      def initialize(contents)
+        @contents = contents
+      end
+    end
+
+    FactoryBot.define do
+      factory :container do
+        initialize_with { new({key: :value}) }
+      end
+    end
+
+    expect(FactoryBot.build(:container).contents).to eq({key: :value})
+  end
+end


### PR DESCRIPTION
Closes #1423

5c071d42 fixed most kwarg deprecation warnings coming from within
factory_bot, but using the Ruby 3-style argument forwarding does not
handle every case.

To handle the case of `initialize_with` being used with a method that
takes a final hash argument, this commit adds an additional branch to
this code to use `ruby2_keywords` for Ruby >= 2.7 and < 3.0. On 3.0 we
use the 3.0-style forwarding.

I added a tests that was outputting a deprecation warning on Ruby 2.7
before this change, but that no longer outputs the warning after this
change.

Yes, this is a bit of a mess, but I don't see a better way. I got
inspiration here from this [fantastic blog post on argument delegating
with Ruby 2.7 and 3][delegating].

[delegating]: https://eregon.me/blog/2019/11/10/the-delegation-challenge-of-ruby27.html#the-delegation-challenge.
