### PR TITLE
Avoid running Ruby 3 against Rails 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ gemfile:
   - gemfiles/master.gemfile
 matrix:
   fast_finish: true
+  exclude:
+    - rvm: ruby-head
+      gemfile: gemfiles/5.0.gemfile
   allow_failures:
     - rvm: ruby-head
     - gemfile: gemfiles/master.gemfile


### PR DESCRIPTION
Ruby 3 is not compatible with Rails 5.0. Rails 5.0 locked to
sqlite3 "~> 1.3.6", but only sqlite3 "<= 1.4.2" is compatible with Ruby
3. [Older versions of sqlite3 referenced `rb_check_safe_obj`][sqlite3],
which raised a warning in Ruby 2.7 and will fail in Ruby 3.0.

Since this combination of tests will always fail, this commit updates
Travis to stop running it.

[sqlite3]: https://github.com/sparklemotion/sqlite3-ruby/pull/277
