### PR TITLE
Update arity checks for Symbol#to_proc change

### DIFF
--- a/lib/factory_bot/attribute/dynamic.rb
+++ b/lib/factory_bot/attribute/dynamic.rb
@@ -12,7 +12,7 @@ module FactoryBot
 
         -> {
           value = case block.arity
-                  when 1, -1 then instance_exec(self, &block)
+                  when 1, -1, -2 then instance_exec(self, &block)
                   else instance_exec(&block)
           end
           raise SequenceAbuseError if FactoryBot::Sequence === value

--- a/lib/factory_bot/callback.rb
+++ b/lib/factory_bot/callback.rb
@@ -9,7 +9,7 @@ module FactoryBot
 
     def run(instance, evaluator)
       case block.arity
-      when 1, -1 then syntax_runner.instance_exec(instance, &block)
+      when 1, -1, -2 then syntax_runner.instance_exec(instance, &block)
       when 2 then syntax_runner.instance_exec(instance, evaluator, &block)
       else syntax_runner.instance_exec(&block)
       end


### PR DESCRIPTION
Ruby has [changed the arity of Symbol#to_proc from -1 to -2][ruby]. This commit
updates some arity checks we have in factory_bot to handle that case.
This should get the Ruby HEAD + Rails 6 tests passing on CI (the Ruby
head with other versions of Rails is still failing for various reasons).

[ruby]: https://github.com/ruby/ruby/commit/5b29ea0845c14092abd866ce0183c52635bade4c
