### PR TITLE
Clarify some examples in GETTING_STARTED

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -314,17 +314,17 @@ factory :user, aliases: [:author, :commenter] do
 end
 
 factory :post do
-  author
-  # instead of
+  # The alias allows us to write author instead of
   # association :author, factory: :user
+  author
   title { "How to read a book effectively" }
   body { "There are five steps involved." }
 end
 
 factory :comment do
-  commenter
-  # instead of
+  # The alias allows us to write commenter instead of
   # association :commenter, factory: :user
+  commenter
   body { "Great article!" }
 end
 ```


### PR DESCRIPTION
I found it confusing that there were line comments under the line
they applied to. I moved them to be above the line so that it was
clearer which code they were referring to.

I also adjusted the language a little bit for clarity.

Signed-off-by: Randy Barlow <rbarlow@credible.com>