### PR TITLE
Fix a typo in GETTING_STARTED.md

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -971,7 +971,7 @@ end
 
 ### Initial value
 
-You can override the initial value. Any value that response to the `#next`
+You can override the initial value. Any value that responds to the `#next`
 method will work (e.g. 1, 2, 3, 'a', 'b', 'c')
 
 ```ruby


### PR DESCRIPTION
Signed-off-by: Randy Barlow <rbarlow@credible.com>