### PR TITLE
Allow to pass a lambda function to sequence initial value

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -980,6 +980,14 @@ factory :user do
 end
 ```
 
+You can also pass a lambda function for a lazy evaluation of the initial value.
+
+```ruby
+factory :user do
+  sequence(:email, -> { User.count }) { |n| "person#{n}@example.com" }
+end
+```
+
 ### Without a block
 
 Without a block, the value will increment itself, starting at its initial value:

--- a/lib/factory_bot/sequence.rb
+++ b/lib/factory_bot/sequence.rb
@@ -55,15 +55,33 @@ module FactoryBot
       end
 
       def peek
-        @value
+        value
       end
 
       def next
-        @value = @value.next
+        @value = value.next
       end
 
       def rewind
-        @value = @first_value
+        @value = first_value
+      end
+
+      private
+
+      def value
+        if @value.respond_to?(:call)
+          @value = @value.call
+        else
+          @value
+        end
+      end
+
+      def first_value
+        if @first_value.respond_to?(:call)
+          @first_value = @first_value.call
+        else
+          @first_value
+        end
       end
     end
   end

--- a/spec/factory_bot/sequence_spec.rb
+++ b/spec/factory_bot/sequence_spec.rb
@@ -102,6 +102,12 @@ describe FactoryBot::Sequence do
     it_behaves_like "a sequence", first_value: "=foo", second_value: "=bar"
   end
 
+  describe "a basic sequence with lambda function as custom value" do
+    subject { FactoryBot::Sequence.new(:name, -> { "A" }) }
+
+    it_behaves_like "a sequence", first_value: "A", second_value: "B"
+  end
+
   it "a custom sequence and scope increments within the correct scope" do
     sequence = FactoryBot::Sequence.new(:name, "A") { |n| "=#{n}#{foo}" }
     scope = double("scope", foo: "attribute")


### PR DESCRIPTION
This merge allow us to pass a lambda function as the initial value of sequence. This lambda will be called the first time that is used (lazy load). For example:

```ruby
factory :user do
  sequence(:email, -> { User.count }) { |n| "person#{n}@example.com" }
end
```