### PR TITLE
Use value returned by to_create

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,11 @@ GEM
     activerecord (6.0.3.1)
       activemodel (= 6.0.3.1)
       activesupport (= 6.0.3.1)
+    activerecord-jdbc-adapter (60.2-java)
+      activerecord (~> 6.0.0)
+    activerecord-jdbcsqlite3-adapter (60.2-java)
+      activerecord-jdbc-adapter (= 60.2)
+      jdbc-sqlite3 (~> 3.8, < 3.30)
     activesupport (6.0.3.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -54,9 +59,11 @@ GEM
     diff-lcs (1.3)
     docile (1.3.2)
     ffi (1.12.2)
+    ffi (1.12.2-java)
     gherkin (5.1.0)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
+    jdbc-sqlite3 (3.28.0)
     minitest (5.14.1)
     multi_json (1.14.1)
     multi_test (0.1.2)
@@ -107,6 +114,7 @@ GEM
       rubocop-performance (~> 1.6.0)
     thor (1.0.1)
     thread_safe (0.3.6)
+    thread_safe (0.3.6-java)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
@@ -114,6 +122,7 @@ GEM
     zeitwerk (2.3.0)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES

--- a/lib/factory_bot/configuration.rb
+++ b/lib/factory_bot/configuration.rb
@@ -19,7 +19,10 @@ module FactoryBot
       @definition = Definition.new(:configuration)
       @inline_sequences = []
 
-      to_create(&:save!)
+      to_create do |object|
+        object.save!
+        object
+      end
       initialize_with { new }
     end
 

--- a/lib/factory_bot/definition.rb
+++ b/lib/factory_bot/definition.rb
@@ -78,7 +78,7 @@ module FactoryBot
     end
 
     def skip_create
-      @to_create = ->(instance) {}
+      @to_create = ->(instance) { instance }
     end
 
     def define_trait(trait)

--- a/lib/factory_bot/strategy/create.rb
+++ b/lib/factory_bot/strategy/create.rb
@@ -6,12 +6,12 @@ module FactoryBot
       end
 
       def result(evaluation)
-        evaluation.object.tap do |instance|
-          evaluation.notify(:after_build, instance)
-          evaluation.notify(:before_create, instance)
-          evaluation.create(instance)
-          evaluation.notify(:after_create, instance)
-        end
+        instance = evaluation.object
+        evaluation.notify(:after_build, instance)
+        evaluation.notify(:before_create, instance)
+        instance = evaluation.create(instance)
+        evaluation.notify(:after_create, instance)
+        instance 
       end
     end
   end

--- a/spec/acceptance/global_to_create_spec.rb
+++ b/spec/acceptance/global_to_create_spec.rb
@@ -4,10 +4,10 @@ describe "global to_create" do
     define_model("Post", name: :string)
 
     FactoryBot.define do
-      to_create { |instance| instance.name = "persisted!" }
+      to_create { |instance| instance.name = "persisted!"; instance }
 
       trait :override_to_create do
-        to_create { |instance| instance.name = "override" }
+        to_create { |instance| instance.name = "override"; instance }
       end
 
       factory :user do
@@ -79,7 +79,7 @@ describe "global skip_create" do
       skip_create
 
       trait :override_to_create do
-        to_create { |instance| instance.name = "override" }
+        to_create { |instance| instance.name = "override"; instance }
       end
 
       factory :user do

--- a/spec/acceptance/traits_spec.rb
+++ b/spec/acceptance/traits_spec.rb
@@ -609,11 +609,11 @@ describe "traits with to_create" do
     FactoryBot.define do
       factory :user do
         trait :with_to_create do
-          to_create { |instance| instance.name = "to_create" }
+          to_create { |instance| instance.name = "to_create"; instance }
         end
 
         factory :sub_user do
-          to_create { |instance| instance.name = "sub" }
+          to_create { |instance| instance.name = "sub"; instance }
 
           factory :child_user
         end
@@ -626,7 +626,7 @@ describe "traits with to_create" do
 
         factory :sub_user_with_trait_and_override do
           with_to_create
-          to_create { |instance| instance.name = "sub with trait and override" }
+          to_create { |instance| instance.name = "sub with trait and override"; instance }
 
           factory :child_user_with_trait_and_override
         end
@@ -661,7 +661,7 @@ describe "traits with to_create" do
   it "gives additional traits higher priority than base traits and factory definition" do
     FactoryBot.define do
       trait :overridden do
-        to_create { |instance| instance.name = "completely overridden" }
+        to_create { |instance| instance.name = "completely overridden"; instance }
       end
     end
 
@@ -774,7 +774,7 @@ describe "nested implicit traits" do
       FactoryBot.define do
         trait :female do
           gender { "female" }
-          to_create { |instance| instance.gender = instance.gender.upcase }
+          to_create { |instance| instance.gender = instance.gender.upcase; instance }
         end
 
         trait :jane_doe do
@@ -805,7 +805,7 @@ describe "nested implicit traits" do
         factory :user do
           trait :female do
             gender { "female" }
-            to_create { |instance| instance.gender = instance.gender.upcase }
+            to_create { |instance| instance.gender = instance.gender.upcase; instance }
           end
 
           trait :jane_doe do

--- a/spec/support/shared_examples/strategy.rb
+++ b/spec/support/shared_examples/strategy.rb
@@ -76,7 +76,7 @@ shared_examples_for "strategy with callbacks" do |*callback_names|
   end
 
   let(:evaluation) do
-    double("evaluation", object: result_instance, notify: true, create: nil)
+    double("evaluation", object: result_instance, notify: true, create: result_instance)
   end
 
   it "runs the callbacks #{callback_names} with the evaluation's object" do


### PR DESCRIPTION
Use value returned by to_create block, also pass this into the following after_create hooks. 

Guess this is a major change, as all tests using to_create have to be adapted if this is merged.