### PR TITLE
Prefer string argument to class option [ci skip]

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -199,17 +199,15 @@ It is also possible to explicitly specify the class:
 
 ```ruby
 # This will use the User class (otherwise Admin would have been guessed)
-factory :admin, class: User
+factory :admin, class: "User"
 ```
 
-If the constant is not available
-(if you are using a Rails engine that waits to load models, for example),
-you can also pass a symbol or string,
-which factory\_bot will constantize later, once you start building objects:
+You can pass a constant as well, if the constant is available (note that this
+can cause test performance problems in large Rails applications, since
+referring to the constant will cause it to be eagerly loaded).
 
 ```ruby
-# It's OK if Doorkeeper::AccessToken isn't loaded yet
-factory :access_token, class: "Doorkeeper::AccessToken"
+factory :access_token, class: User
 ```
 
 ### Hash attributes


### PR DESCRIPTION
This swaps the string and constant examples for the `class:` option, treating
the string example as the normal case and the constant example as an
alternate approach with caveats.

I have seen a number of problems with using constants, and
[rubocop-rspec][] even has a custom cop to prevent this.

I could almost remove the constant example, except that a lot of folks
are still using it and there may be room for confusion if it totally
disappears. Instead, I present it with a note about the potential
performance problem.

[rubocop-rspec]: https://github.com/rubocop-hq/rubocop-rspec/blob/master/lib/rubocop/cop/rspec/factory_bot/factory_class_name.rb

cc @HParker 
