### PR TITLE
Use match? in FactoryBot#aliases_for to save allocations

### DIFF
--- a/lib/factory_bot/aliases.rb
+++ b/lib/factory_bot/aliases.rb
@@ -10,7 +10,7 @@ module FactoryBot
 
   def self.aliases_for(attribute)
     aliases.map { |(pattern, replace)|
-      if pattern.match(attribute.to_s)
+      if pattern.match?(attribute)
         attribute.to_s.sub(pattern, replace).to_sym
       end
     }.compact << attribute


### PR DESCRIPTION
FactoryBot relies on ruby >= 2.5, so we can use Regexp#match? that does not allocate MatchData

Allocations measured with heap-profiler gem in an internal test suite with 7497 examples and 149470 calls to aliases_for:

allocated memory by file
-----------------------------------
    59.79 MB  factory_bot-6.1.0/lib/factory_bot/aliases.rb
    38.27 MB  factory_bot-6.1.0/lib/factory_bot/aliases.rb

allocated objects by file
-----------------------------------
    896880  factory_bot-6.1.0/lib/factory_bot/aliases.rb
    597940  factory_bot-6.1.0/lib/factory_bot/aliases.rb

The remaining allocations are mainly caused by https://github.com/thoughtbot/factory_bot/blob/9e58a34e1e584dfd41b7327969b06c7a7c9b7559/lib/factory_bot/aliases.rb#L14

In the test suite I used, I noticed that `attribute` values are repeated quite often. For the 149470 calls I just got 16 unique `attribute` values. So a simple caching mechanism prevents most of the allocations:

```ruby
  @aliases_for_cache = {}

  def self.aliases_for(attribute)
    @aliases_for_cache[attribute] ||=
      aliases.map { |(pattern, replace)|
        if pattern.match?(attribute)
          attribute.to_s.sub(pattern, replace).to_sym
        end
      }.compact << attribute
  end
```
In another test suite I got 56 unique `attribute` values for 228979 calls to `aliases_for`. I don't know if this is representative for other users of FactoryBot, but I could prepare a second PR with the cache idea.