### PR TITLE
Fix default value for attribute named `new`

### DIFF
--- a/lib/factory_bot/attribute_assigner.rb
+++ b/lib/factory_bot/attribute_assigner.rb
@@ -37,8 +37,9 @@ module FactoryBot
     end
 
     def decorated_evaluator
-      Decorator::InvocationTracker.new(
-        Decorator::NewConstructor.new(@evaluator, @build_class)
+      Decorator::NewConstructor.new(
+        Decorator::InvocationTracker.new(@evaluator),
+        @build_class
       )
     end
 

--- a/spec/acceptance/add_attribute_spec.rb
+++ b/spec/acceptance/add_attribute_spec.rb
@@ -1,0 +1,37 @@
+describe "#add_attribute" do
+  it "assigns attributes for reserved words on .build" do
+    define_model("Post", title: :string, sequence: :string, new: :boolean)
+
+    FactoryBot.define do
+      factory :post do
+        add_attribute(:title) { "Title" }
+        add_attribute(:sequence) { "Sequence" }
+        add_attribute(:new) { true }
+      end
+    end
+
+    post = FactoryBot.build(:post)
+
+    expect(post.title).to eq "Title"
+    expect(post.sequence).to eq "Sequence"
+    expect(post.new).to eq true
+  end
+
+  it "assigns attributes for reserved words on .attributes_for" do
+    define_model("Post", title: :string, sequence: :string, new: :boolean)
+
+    FactoryBot.define do
+      factory :post do
+        add_attribute(:title) { "Title" }
+        add_attribute(:sequence) { "Sequence" }
+        add_attribute(:new) { true }
+      end
+    end
+
+    post = FactoryBot.attributes_for(:post)
+
+    expect(post[:title]).to eq "Title"
+    expect(post[:sequence]).to eq "Sequence"
+    expect(post[:new]).to eq true
+  end
+end


### PR DESCRIPTION
This is a fix to make it possible to define an attribute named `new` (which is a bad name for an attribute by the way =)).

```
FactoryBot.define do
  factory :post do
    add_attribute(:title) { "Title" }
    add_attribute(:sequence) { "Sequence" }
    add_attribute(:new) { true }
  end
end

FactoryBot.attributes_for(:post)
# => {:title=>"Title", :sequence=>"Sequence", :new=>true}

FactoryBot.build(:post)
# => #<Post id: nil, title: "Title", sequence: "Sequence", new: nil>
```