### PR TITLE
Fix stub strategy for non-ActiveRecord models

### DIFF
--- a/lib/factory_bot/strategy/stub.rb
+++ b/lib/factory_bot/strategy/stub.rb
@@ -75,7 +75,7 @@ module FactoryBot
       end
 
       def has_settable_id?(result_instance)
-        !result_instance.class.respond_to?(:primary_key) ||
+        result_instance.class.respond_to?(:primary_key) &&
           result_instance.class.primary_key
       end
 

--- a/spec/acceptance/stub_spec.rb
+++ b/spec/acceptance/stub_spec.rb
@@ -99,3 +99,21 @@ describe "a stubbed instance with no primary key" do
     end
   end
 end
+
+describe "a stubbed instance for non active record models" do
+  it "builds a stubbed instance" do
+    define_class("NonArModel")
+
+    FactoryBot.define do
+      factory :non_ar_model do
+        skip_create
+      end
+    end
+
+    model = FactoryBot.build_stubbed(:non_ar_model)
+
+    expect(model).to be_truthy
+    expect(model).to be_persisted
+    expect(model).not_to be_new_record
+  end
+end


### PR DESCRIPTION
The following example failed previously with:

```
NoMethodError: undefined method `id' for #<Foo:0x...>
```

```ruby
class Foo
end

FactoryBot.define do
  factory :foo do
    skip_create # non ActiveRecord object
  end
end

FactoryBot.build_stubbed(:foo) # => NoMethodError above
```

It's a follow-up of https://github.com/thoughtbot/factory_bot/pull/1316.

This allows GitLab to use non-`ActiveRecord` models with FactoryBot :tada: See https://gitlab.com/gitlab-org/gitlab/-/merge_requests/52923