### PR TITLE
Fix delegation

### DIFF
--- a/lib/factory_bot/decorator/invocation_tracker.rb
+++ b/lib/factory_bot/decorator/invocation_tracker.rb
@@ -6,22 +6,11 @@ module FactoryBot
         @invoked_methods = []
       end
 
-      if ::Gem::Version.new(::RUBY_VERSION) >= ::Gem::Version.new("3.0")
-        def method_missing(name, *args, **kwargs, &block) # rubocop:disable Style/MissingRespondToMissing
-          @invoked_methods << name
-          super
-        end
-      elsif ::Gem::Version.new(::RUBY_VERSION) >= ::Gem::Version.new("2.7")
-        ruby2_keywords def method_missing(name, *args, &block) # rubocop:disable Style/MissingRespondToMissing
-          @invoked_methods << name
-          super
-        end
-      else
-        def method_missing(name, *args, &block) # rubocop:disable Style/MissingRespondToMissing
-          @invoked_methods << name
-          super
-        end
+      def method_missing(name, *args, &block) # rubocop:disable Style/MissingRespondToMissing
+        @invoked_methods << name
+        super
       end
+      ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
 
       def __invoked_methods__
         @invoked_methods.uniq

--- a/lib/factory_bot/evaluator.rb
+++ b/lib/factory_bot/evaluator.rb
@@ -35,23 +35,14 @@ module FactoryBot
 
     attr_accessor :instance
 
-    if ::Gem::Version.new(::RUBY_VERSION) >= ::Gem::Version.new("2.7")
-      def method_missing(method_name, *args, **kwargs, &block) # rubocop:disable Style/MethodMissingSuper, Style/MissingRespondToMissing
-        if @instance.respond_to?(method_name)
-          @instance.send(method_name, *args, **kwargs, &block)
-        else
-          SyntaxRunner.new.send(method_name, *args, **kwargs, &block)
-        end
-      end
-    else
-      def method_missing(method_name, *args, &block) # rubocop:disable Style/MethodMissingSuper, Style/MissingRespondToMissing
-        if @instance.respond_to?(method_name)
-          @instance.send(method_name, *args, &block)
-        else
-          SyntaxRunner.new.send(method_name, *args, &block)
-        end
+    def method_missing(method_name, *args, &block) # rubocop:disable Style/MethodMissingSuper, Style/MissingRespondToMissing
+      if @instance.respond_to?(method_name)
+        @instance.send(method_name, *args, &block)
+      else
+        SyntaxRunner.new.send(method_name, *args, &block)
       end
     end
+    ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
 
     def respond_to_missing?(method_name, _include_private = false)
       @instance.respond_to?(method_name) || SyntaxRunner.new.respond_to?(method_name)


### PR DESCRIPTION
* (*args, **kwargs) delegation is incorrect in 2.7, only ruby2_keywords works on 2.7.
* See https://eregon.me/blog/2021/02/13/correct-delegation-in-ruby-2-27-3.html or https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

I noticed this while investigating https://github.com/oracle/truffleruby/issues/2258.