### PR TITLE
Update rexml following dependabot alert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.3)
     regexp_parser (2.0.3)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)

--- a/gemfiles/5.0.gemfile.lock
+++ b/gemfiles/5.0.gemfile.lock
@@ -84,7 +84,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.3)
     regexp_parser (2.0.3)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)

--- a/gemfiles/5.1.gemfile.lock
+++ b/gemfiles/5.1.gemfile.lock
@@ -84,7 +84,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.3)
     regexp_parser (2.0.3)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)

--- a/gemfiles/5.2.gemfile.lock
+++ b/gemfiles/5.2.gemfile.lock
@@ -84,7 +84,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.3)
     regexp_parser (2.0.3)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)

--- a/gemfiles/6.0.gemfile.lock
+++ b/gemfiles/6.0.gemfile.lock
@@ -83,7 +83,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.3)
     regexp_parser (2.0.3)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)

--- a/gemfiles/6.1.gemfile.lock
+++ b/gemfiles/6.1.gemfile.lock
@@ -83,7 +83,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.3)
     regexp_parser (2.0.3)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)

--- a/gemfiles/main.gemfile.lock
+++ b/gemfiles/main.gemfile.lock
@@ -89,7 +89,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.3)
     regexp_parser (2.0.3)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)


### PR DESCRIPTION
Why:
----

Dependabot issued a warning about a development dependency security update for the [rexml] gem used by rubocop.

[rexml]: https://github.com/advisories/GHSA-8cr8-4vfw-mr7h

This Commit:
----

- Ran `bundle update rexml` on the root path to update `rexml` from 3.2.4 => 3.2.5
- Updated static Gemfiles to reflect the same version