### PR TITLE
Skip double CI build on main branch pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }}
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Why:
----

The trigger for the build job is either a `push` or a `pull_request`. When a pull request is opened against master two CI run start, since
both triggers are valid.

This Commit:
----

- Skip the build job if the event is a pull request made from the same repository. Since a CI build job hast started already because a push trigger was detected.