### PR TITLE
fix attribute name mismatch in the associations example

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -592,7 +592,7 @@ Attribute overrides can be used to link associated objects:
 ```ruby
 FactoryBot.define do
   factory :author do
-    author_last_name { 'Taylor' }
+    name { 'Taylor' }
   end
 
   factory :post do


### PR DESCRIPTION
Follow-up to https://github.com/thoughtbot/factory_bot/pull/1446
looks like `name` should be used here (in line with this and other examples), not `author_last_name`, this is how it was suggested in [this PR review comment](https://github.com/thoughtbot/factory_bot/pull/1446#discussion_r516157987) but got mixed up in the end somehow