### PR TITLE
Add spaces to enum_attribute in the Enum traits column of GETTING_STARTED.md

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1323,7 +1323,7 @@ Given an Active Record model with an enum attribute:
 
 ```rb
 class Task < ActiveRecord::Base
-  enum status: {queued: 0, started: 1, finished: 2}
+  enum status: { queued: 0, started: 1, finished: 2 }
 end
 
 ```


### PR DESCRIPTION
In other places, hash literals were having spaces around them, so I added spaces.