### PR TITLE
[1452] update traits_for_enum to accept _prefix and _suffix

### DIFF
--- a/lib/factory_bot/definition.rb
+++ b/lib/factory_bot/definition.rb
@@ -173,7 +173,12 @@ module FactoryBot
     end
 
     def automatically_register_defined_enums(klass)
-      klass.defined_enums.each_key { |name| register_enum(Enum.new(name)) }
+      klass.defined_enums.each_key do |name|
+        next if registered_enums.any? do |registered_enum|
+          registered_enum.attribute_name.to_s == name
+        end
+        register_enum(Enum.new(name))
+      end
     end
 
     def automatically_register_defined_enums?(klass)

--- a/lib/factory_bot/definition.rb
+++ b/lib/factory_bot/definition.rb
@@ -8,7 +8,7 @@ module FactoryBot
       @declarations = DeclarationList.new(name)
       @callbacks = []
       @defined_traits = Set.new
-      @registered_enums = []
+      @registered_enums = {}
       @to_create = nil
       @base_traits = base_traits
       @additional_traits = []
@@ -86,7 +86,7 @@ module FactoryBot
     end
 
     def register_enum(enum)
-      @registered_enums << enum
+      @registered_enums[enum.attribute_name.to_sym] = enum
     end
 
     def define_constructor(&block)
@@ -164,7 +164,7 @@ module FactoryBot
         automatically_register_defined_enums(klass)
       end
 
-      registered_enums.each do |enum|
+      registered_enums.each do |_name, enum|
         traits = enum.build_traits(klass)
         traits.each { |trait| define_trait(trait) }
       end
@@ -174,10 +174,7 @@ module FactoryBot
 
     def automatically_register_defined_enums(klass)
       klass.defined_enums.each_key do |name|
-        next if registered_enums.any? do |registered_enum|
-          registered_enum.attribute_name.to_s == name
-        end
-        register_enum(Enum.new(name))
+        register_enum(Enum.new(name)) unless registered_enums.key? name.to_sym
       end
     end
 

--- a/lib/factory_bot/definition_proxy.rb
+++ b/lib/factory_bot/definition_proxy.rb
@@ -274,11 +274,18 @@ module FactoryBot
     #     those traits. When this argument is not provided, factory_bot will
     #     attempt to get the values by calling the pluralized `attribute_name`
     #     class method.
-    def traits_for_enum(attribute_name, values = nil, _prefix: false, _suffix: false, **values_as_hash)
-      enum_prefix = _prefix || (values.delete(:_prefix) if values.respond_to?(:delete))
-      enum_suffix = _suffix || (values.delete(:_suffix) if values.respond_to?(:delete))
-      values ||= values_as_hash.present? ? values_as_hash : nil
-      @definition.register_enum(Enum.new(attribute_name, values, prefix: enum_prefix, suffix: enum_suffix))
+    def traits_for_enum(attribute_name, values = nil, options = {})
+      if options.empty? && values.is_a?(Hash)
+        prefix = values.delete(:_prefix) { false }
+        suffix = values&.delete(:_suffix) { false }
+        values = nil if values.empty?
+        enum = Enum.new(attribute_name, values, prefix: prefix, suffix: suffix)
+      else
+        prefix = options.fetch(:_prefix, false)
+        suffix = options.fetch(:_suffix, false)
+        enum = Enum.new(attribute_name, values, prefix: prefix, suffix: suffix)
+      end
+      @definition.register_enum enum
     end
 
     def initialize_with(&block)

--- a/lib/factory_bot/definition_proxy.rb
+++ b/lib/factory_bot/definition_proxy.rb
@@ -221,6 +221,50 @@ module FactoryBot
     #     end
     #   end
     #
+    # Prefix and Suffixes can be used for trait definition.
+    # both can be set to true (prefix/suffix will be set to enum name), or to a custom string
+    #
+    # Example:
+    #   factory :task do
+    #     traits_for_enum :status, [:started, :finished], _prefix: true
+    #   end
+    #
+    # Equivalent to:
+    #   factory :task do
+    #     traits_for_enum :status, [:started, :finished], _prefix: 'status'
+    #   end
+    #
+    # Both Equivalent to:
+    #   factory :task do
+    #     trait :status_started do
+    #       status { :started }
+    #     end
+    #
+    #     trait :status_finished do
+    #       status { :finished }
+    #     end
+    #   end
+    #
+    # Example:
+    #   factory :task do
+    #     traits_for_enum :status, [:started, :finished], _suffix: true
+    #   end
+    #
+    # Equivalent to:
+    #   factory :task do
+    #     traits_for_enum :status, [:started, :finished], _suffix: 'status'
+    #   end
+    #
+    # Both Equivalent to:
+    #   factory :task do
+    #     trait :started_status do
+    #       status { :started }
+    #     end
+    #
+    #     trait :finished_status do
+    #       status { :finished }
+    #     end
+    #   end
     #
     # Arguments:
     #   attribute_name: +Symbol+ or +String+
@@ -230,8 +274,11 @@ module FactoryBot
     #     those traits. When this argument is not provided, factory_bot will
     #     attempt to get the values by calling the pluralized `attribute_name`
     #     class method.
-    def traits_for_enum(attribute_name, values = nil)
-      @definition.register_enum(Enum.new(attribute_name, values))
+    def traits_for_enum(attribute_name, values = nil, _prefix: false, _suffix: false, **values_as_hash)
+      enum_prefix = _prefix || (values.delete(:_prefix) if values.respond_to?(:delete))
+      enum_suffix = _suffix || (values.delete(:_suffix) if values.respond_to?(:delete))
+      values ||= values_as_hash.present? ? values_as_hash : nil
+      @definition.register_enum(Enum.new(attribute_name, values, prefix: enum_prefix, suffix: enum_suffix))
     end
 
     def initialize_with(&block)

--- a/lib/factory_bot/enum.rb
+++ b/lib/factory_bot/enum.rb
@@ -1,9 +1,20 @@
 module FactoryBot
   # @api private
   class Enum
-    def initialize(attribute_name, values = nil)
+    def initialize(attribute_name, values = nil, prefix: false, suffix: false)
       @attribute_name = attribute_name
       @values = values
+      @prefix = if prefix == true
+                  "#{@attribute_name}_"
+                elsif prefix
+                  "#{prefix}_"
+                end
+
+      @suffix = if suffix == true
+                  "_#{@attribute_name}"
+                elsif suffix
+                  "_#{suffix}"
+                end
     end
 
     def build_traits(klass)
@@ -12,6 +23,8 @@ module FactoryBot
       end
     end
 
+    attr_reader :attribute_name
+
     private
 
     def enum_values(klass)
@@ -19,7 +32,7 @@ module FactoryBot
     end
 
     def build_trait(trait_name, attribute_name, value)
-      Trait.new(trait_name) do
+      Trait.new("#{@prefix}#{trait_name}#{@suffix}") do
         add_attribute(attribute_name) { value }
       end
     end

--- a/spec/acceptance/enum_traits_spec.rb
+++ b/spec/acceptance/enum_traits_spec.rb
@@ -57,7 +57,7 @@ describe "enum traits" do
 
       FactoryBot.define do
         factory :task do
-          traits_for_enum :status, statuses
+          traits_for_enum :status, **statuses
         end
       end
 
@@ -111,6 +111,211 @@ describe "enum traits" do
         task = FactoryBot.build(:task, trait_name)
 
         expect(task.status).to eq(trait_name)
+      end
+    end
+
+    context 'when prefix is used' do
+      context 'when values are a hash' do
+        context 'when prefix is a boolean' do
+          it "builds traits for each enumerated value, applies default prefix and does not build the auto enum trait" do
+            statuses = { queued: 0, started: 1, finished: 2 }
+            define_model("Task", status: :integer) do
+              enum status: statuses, _prefix: true
+            end
+
+            FactoryBot.define do
+              factory :task do
+                traits_for_enum :status, _prefix: true
+              end
+            end
+
+            statuses.each_key do |trait_name|
+              task = FactoryBot.build(:task, "status_#{trait_name}")
+
+              expect{ FactoryBot.build(:task, trait_name) }.to raise_error KeyError, /Trait not registered/
+              expect(task.status).to eq(trait_name.to_s)
+            end
+
+            Task.reset_column_information
+          end
+        end
+
+        context 'when prefix is a string' do
+          it "builds traits for each enumerated value, applies custom prefix and does not build the auto enum trait" do
+            statuses = { queued: 0, started: 1, finished: 2 }
+            define_model("Task", status: :integer) do
+              enum status: statuses, _prefix: 'foobar'
+            end
+
+            FactoryBot.define do
+              factory :task do
+                traits_for_enum :status, _prefix: 'foobar'
+              end
+            end
+
+            statuses.each_key do |trait_name|
+              task = FactoryBot.build(:task, "foobar_#{trait_name}")
+
+              expect{ FactoryBot.build(:task, trait_name) }.to raise_error KeyError, /Trait not registered/
+              expect(task.status).to eq(trait_name.to_s)
+            end
+
+            Task.reset_column_information
+          end
+        end
+      end
+
+      context 'when values are a list' do
+        context 'when prefix is a boolean' do
+          it "builds traits for each enumerated value, applies default prefix and does not build the auto enum trait" do
+            statuses = %w[queued started finished]
+
+            define_model("Task", status: :integer) do
+              enum status: statuses, _prefix: true
+            end
+
+            FactoryBot.define do
+              factory :task do
+                traits_for_enum :status, _prefix: true
+              end
+            end
+
+            statuses.each do |trait_name|
+              task = FactoryBot.build(:task, "status_#{trait_name}")
+
+              expect{ FactoryBot.build(:task, trait_name) }.to raise_error KeyError, /Trait not registered/
+              expect(task.status).to eq(trait_name)
+            end
+
+            Task.reset_column_information
+          end
+        end
+
+        context 'when prefix is a string' do
+          it "builds traits for each enumerated value, applies custom prefix and does not build the auto enum trait" do
+            statuses = %w[queued started finished]
+            define_model("Task", status: :integer) do
+              enum status: statuses, _prefix: 'foobar'
+            end
+
+            FactoryBot.define do
+              factory :task do
+                traits_for_enum :status, _prefix: 'foobar'
+              end
+            end
+
+            statuses.each do |trait_name|
+              task = FactoryBot.build(:task, "foobar_#{trait_name}")
+
+              expect{ FactoryBot.build(:task, trait_name) }.to raise_error KeyError, /Trait not registered/
+              expect(task.status).to eq(trait_name)
+            end
+
+            Task.reset_column_information
+          end
+        end
+      end
+    end
+
+    context 'when suffix is used' do
+      context 'when values are a hash' do
+        context 'when suffix is a boolean' do
+          it "builds traits for each enumerated value, applies default suffix and does not build the auto enum trait" do
+            statuses = { queued: 0, started: 1, finished: 2 }
+            define_model("Task", status: :integer) do
+              enum status: statuses, _suffix: true
+            end
+
+            FactoryBot.define do
+              factory :task do
+                traits_for_enum :status, _suffix: true
+              end
+            end
+
+            statuses.each_key do |trait_name|
+              task = FactoryBot.build(:task, "#{trait_name}_status")
+
+              expect{ FactoryBot.build(:task, trait_name) }.to raise_error KeyError, /Trait not registered/
+              expect(task.status).to eq(trait_name.to_s)
+            end
+
+            Task.reset_column_information
+          end
+        end
+
+        context 'when suffix is a string' do
+          it "builds traits for each enumerated value, applies custom suffix and does not build the auto enum trait" do
+            statuses = {queued: 0, started: 1, finished: 2}
+            define_model("Task", status: :integer) do
+              enum status: statuses, _suffix: 'foobar'
+            end
+
+            FactoryBot.define do
+              factory :task do
+                traits_for_enum :status, _suffix: 'foobar'
+              end
+            end
+
+            statuses.each do |trait_name, _trait_value|
+              task = FactoryBot.build(:task, "#{trait_name}_foobar")
+
+              expect{ FactoryBot.build(:task, trait_name) }.to raise_error KeyError, /Trait not registered/
+              expect(task.status).to eq(trait_name.to_s)
+            end
+
+            Task.reset_column_information
+          end
+        end
+      end
+
+      context 'when values are a list' do
+        context 'when suffix is a boolean' do
+          it "builds traits for each enumerated value, applies default suffix and does not build the auto enum trait" do
+            statuses = %w[queued started finished]
+            define_model("Task", status: :integer) do
+              enum status: statuses, _suffix: true
+            end
+
+            FactoryBot.define do
+              factory :task do
+                traits_for_enum :status, _suffix: true
+              end
+            end
+
+            statuses.each do |trait_name|
+              task = FactoryBot.build(:task, "#{trait_name}_status")
+
+              expect{ FactoryBot.build(:task, trait_name) }.to raise_error KeyError, /Trait not registered/
+              expect(task.status).to eq(trait_name)
+            end
+
+            Task.reset_column_information
+          end
+        end
+
+        context 'when suffix is a string' do
+          it "builds traits for each enumerated value, applies custom suffix and does not build the auto enum trait" do
+            statuses = %w[queued started finished]
+            define_model("Task", status: :integer) do
+              enum status: statuses, _suffix: 'foobar'
+            end
+
+            FactoryBot.define do
+              factory :task do
+                traits_for_enum :status, _suffix: 'foobar'
+              end
+            end
+
+            statuses.each do |trait_name|
+              task = FactoryBot.build(:task, "#{trait_name}_foobar")
+
+              expect(task.status).to eq(trait_name)
+              expect{ FactoryBot.build(:task, trait_name) }.to raise_error KeyError, /Trait not registered/
+            end
+
+            Task.reset_column_information
+          end
+        end
       end
     end
   end

--- a/spec/acceptance/enum_traits_spec.rb
+++ b/spec/acceptance/enum_traits_spec.rb
@@ -57,7 +57,7 @@ describe "enum traits" do
 
       FactoryBot.define do
         factory :task do
-          traits_for_enum :status, **statuses
+          traits_for_enum :status, statuses
         end
       end
 

--- a/spec/factory_bot/definition_spec.rb
+++ b/spec/factory_bot/definition_spec.rb
@@ -76,10 +76,10 @@ describe FactoryBot::Definition do
   it "maintains a list of enum fields" do
     definition = described_class.new(:name)
 
-    enum_field = double("enum_field")
+    enum_field = double("enum_field", attribute_name: 'enum')
 
     definition.register_enum(enum_field)
 
-    expect(definition.registered_enums).to include(enum_field)
+    expect(definition.registered_enums[:enum]).to eq enum_field
   end
 end


### PR DESCRIPTION
in response to [Issue](https://github.com/thoughtbot/factory_bot/issues/1452).

goal is to allow _prefix and _suffix for enum trait definitions to stay in line with ruby implementations
also will not define the standard enum (without prefix/suffix) will only define the ones with prefix/suffix
