### PR TITLE
Build stubbed generate uuids primary keys

### DIFF
--- a/lib/factory_bot/strategy/stub.rb
+++ b/lib/factory_bot/strategy/stub.rb
@@ -43,13 +43,17 @@ module FactoryBot
 
       private
 
-      def next_id
-        @@next_id += 1
+      def next_id(result_instance)
+        if uuid_primary_key?(result_instance)
+          SecureRandom.uuid
+        else
+          @@next_id += 1
+        end
       end
 
       def stub_database_interaction_on_result(result_instance)
         if has_settable_id?(result_instance)
-          result_instance.id ||= next_id
+          result_instance.id ||= next_id(result_instance)
         end
 
         result_instance.instance_eval do
@@ -77,6 +81,11 @@ module FactoryBot
       def has_settable_id?(result_instance)
         !result_instance.class.respond_to?(:primary_key) ||
           result_instance.class.primary_key
+      end
+
+      def uuid_primary_key?(result_instance)
+        result_instance.respond_to?(:column_for_attribute) &&
+          result_instance.column_for_attribute(result_instance.class.primary_key).sql_type == "uuid"
       end
 
       def clear_changes_information(result_instance)


### PR DESCRIPTION
Closes #1498

When the primary key of a table has a type of `uuid` and when using the `build_stubbed` strategy, the `id` was not set properly.

This PR checks if the primary key of the `result_instance` is an `uuid`. If so, we use `SecureRandom.uuid` instead of an `Integer` to generate the `id` of the model.

This is my first contribution to FactoryBot so please tell me if I did anything wrong 😄