### PR TITLE
Cache gem dependencies in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,8 +86,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Setup project
-        run: bundle install
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Run test
         run: bundle exec rake all_specs
 


### PR DESCRIPTION
Around 20 seconds is spent on installing gems, using gem caching it should make the tests even faster.