### PR TITLE
Update GETTING_STARTED: include note about saving in `create_list`

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1583,6 +1583,15 @@ twenty_somethings = build_list(:user, 10) do |user, i|
 end
 ```
 
+`create_list` passes saved instances into the block. If you modify the instance, you must save it again:
+
+```ruby
+twenty_somethings = create_list(:user, 10) do |user, i|
+  user.date_of_birth = (20 + i).years.ago
+  user.save!
+end
+```
+
 `build_stubbed_list` will give you fully stubbed out instances:
 
 ```ruby


### PR DESCRIPTION
Fixes #1444 and #1479

Add a short note in GETTING_STARTED.md about the need to save the record
after it has been modified