### PR TITLE
Document 6.0.0 may break `FactoryBot.lint`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,7 +28,9 @@
   * Added: automatic definition of traits for Active Record enum attributes, enabled by default
     (Note that this required changing where factory_bot constantizes the build
      class, which may affect applications that were using abstract factories for
-     inheritance. See issue #1409.)
+     inheritance. See issue #1409.) (This may break `FactoryBot.lint` because
+     there may be previously non-existing factory+trait combinations being
+     defined and checked)
   * Added: `traits_for_enum` method to define traits for non-Active Record enums
   * Added: `build_stubbed_starting_id=` option to define the starting id for `build_stubbed`
   * Removed: deprecated methods on the top-level `FactoryBot` module meant only for internal use


### PR DESCRIPTION
In a sufficiently large codebase, the automatic definition of traits for Active Record enum  (#1380) may result in more combinations being checked by `FactoryBot.lint`. This breaking change may not be obvious because the first impression of the error messages may be "these factories were passing before the upgrade but now failing ?", while the truth is that they don't exist before the upgrade. It took me a while to realize this so I hope adding this note could help people be aware of this situation when upgrading.
