### PR TITLE
Use bundle add instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,11 @@ have [a detailed introductory video][], available for free on Upcase.
 Install
 --------
 
-Add the following line to Gemfile:
+Run:
 
 ```ruby
-gem 'factory_bot'
+bundle add factory_bot
 ```
-
-and run `bundle install` from your shell.
 
 To install the gem manually from your shell, run:
 


### PR DESCRIPTION
As per https://github.com/rubygems/rubygems/pull/5337, we can simplify the steps of adding a gem.