### PR TITLE
Update getting_started guide, use_parent_strategy

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -649,7 +649,7 @@ post.author.new_record? # => false
 To not save the associated object, specify `strategy: :build` in the factory:
 
 ```ruby
-FactoryBot.use_parent_strategy = false
+FactoryBot.use_parent_strategy = true
 
 factory :post do
   # ...


### PR DESCRIPTION
<!-- By contributing to this project, you agree to abide by the thoughtbot Code
of Conduct: https://thoughtbot.com/open-source-code-of-conduct -->

### Description

From my understanding, based on the [acceptance spec here](https://github.com/thoughtbot/factory_bot/blob/main/spec/acceptance/build_spec.rb#L33-L39), `use_parent_strategy` should be `true` if we _do not_ want to save associations.

Should the corresponding example in the [build strategies section](https://github.com/thoughtbot/factory_bot/blob/main/GETTING_STARTED.md#build-strategies-1) of the Getting Started guide be changed to `FactoryBot.use_parent_strategy = true` ?


### Reproduction Steps

<!-- Steps for others to reproduce the bug. Be as specific as possible. A
reproduction script or link to a sample application that demonstrates the
problem are especially helpful. -->

<!-- You can create a reproduction script by copying this sample reproduction
script and adding whatever code is necessary to get a failing test case:
https://github.com/thoughtbot/factory_bot/blob/master/.github/REPRODUCTION_SCRIPT.rb -->

### Expected behavior

<!-- What you expected to happen. -->

### Actual behavior

<!-- What happened instead. -->

### System configuration
**factory_bot version**:  
**rails version**:  
**ruby version**:
