### PR TITLE
Fix some typo

### DIFF
--- a/spec/acceptance/associations_spec.rb
+++ b/spec/acceptance/associations_spec.rb
@@ -1,5 +1,5 @@
 describe "associations" do
-  context "when accidentally using an implicit delcaration for the factory" do
+  context "when accidentally using an implicit declaration for the factory" do
     it "raises an error" do
       define_class("Post")
 
@@ -17,7 +17,7 @@ describe "associations" do
     end
   end
 
-  context "when accidentally using an implicit delcaration as an override" do
+  context "when accidentally using an implicit declaration as an override" do
     it "raises an error" do
       define_class("Post")
 

--- a/spec/factory_bot/attribute/association_spec.rb
+++ b/spec/factory_bot/attribute/association_spec.rb
@@ -8,7 +8,7 @@ describe FactoryBot::Attribute::Association do
 
   before do
     # Define an '#association' instance method allowing it to be mocked.
-    # Ususually this is determined via '#method_missing'
+    # Usually this is determined via '#method_missing'
     missing_methods = Module.new {
       def association(*args)
       end

--- a/spec/factory_bot/attribute/dynamic_spec.rb
+++ b/spec/factory_bot/attribute/dynamic_spec.rb
@@ -28,7 +28,7 @@ describe FactoryBot::Attribute::Dynamic do
 
     before do
       # Define an '#attribute_defined_on_attribute' instance method allowing it
-      # be mocked. Ususually this is determined via '#method_missing'
+      # be mocked. Usually this is determined via '#method_missing'
       missing_methods = Module.new {
         def attribute_defined_on_attribute(*args)
         end

--- a/spec/factory_bot/declaration/implicit_spec.rb
+++ b/spec/factory_bot/declaration/implicit_spec.rb
@@ -21,7 +21,7 @@ describe FactoryBot::Declaration::Implicit do
   end
 
   context "with a known sequence" do
-    it "does not create an assocition attribute" do
+    it "does not create an association attribute" do
       allow(FactoryBot::Internal.sequences).to receive(:registered?).and_return true
 
       declaration = FactoryBot::Declaration::Implicit.new(:name)

--- a/spec/factory_bot/definition_proxy_spec.rb
+++ b/spec/factory_bot/definition_proxy_spec.rb
@@ -91,7 +91,7 @@ describe FactoryBot::DefinitionProxy, "#sequence" do
     expect(FactoryBot::Sequence).to have_received(:new).with(:sequence)
   end
 
-  it "creates a new sequence with an overridden starting vaue" do
+  it "creates a new sequence with an overridden starting value" do
     allow(FactoryBot::Sequence).to receive(:new).and_call_original
     proxy = build_proxy(:factory)
     override = "override"


### PR DESCRIPTION
Hello! Thank you for this awesome project!

This PR has fixed some typo.

- "delcaration" -> "declaration"
- "Ususually" -> "Usually"
- "assocition" -> "association"
- "vaue" -> "value"