### PR TITLE
Ensure factory options are a Hash

### DIFF
--- a/lib/factory_bot/factory.rb
+++ b/lib/factory_bot/factory.rb
@@ -7,8 +7,10 @@ module FactoryBot
     attr_reader :name, :definition
 
     def initialize(name, options = {})
-      assert_valid_options(options)
       @name = name.respond_to?(:to_sym) ? name.to_sym : name.to_s.underscore.to_sym
+
+      assert_valid_options(options)
+
       @parent = options[:parent]
       @aliases = options[:aliases] || []
       @class_name = options[:class]
@@ -140,6 +142,8 @@ module FactoryBot
     private
 
     def assert_valid_options(options)
+      raise ArgumentError, "Expected a Hash of options for factory '#{name.inspect}', got '#{options.inspect}'" unless options.is_a?(Hash)
+
       options.assert_valid_keys(:class, :parent, :aliases, :traits)
     end
 

--- a/spec/factory_bot/factory_spec.rb
+++ b/spec/factory_bot/factory_spec.rb
@@ -185,6 +185,12 @@ describe FactoryBot::Factory, "when defined with a class instead of a name" do
   end
 end
 
+describe FactoryBot::Factory, "when options are not a Hash" do
+  it "raises an ArgumentError" do
+    expect { FactoryBot::Factory.new(:author, Class.new) }.to raise_error(ArgumentError, /^Expected a Hash of options for factory ':author', got '#<Class:/)
+  end
+end
+
 describe FactoryBot::Factory, "when defined with a custom class name" do
   it "has a build_class equal to its custom class name" do
     factory = FactoryBot::Factory.new(:author, class: :argument_error)


### PR DESCRIPTION
I accidentally typed

```ruby
factory :thing, Thing do
  # ...
end
```

and was confused by the error message.

This commit ensures that the options are a Hash,
and gives an informative error message otherwise.