### PR TITLE
rename references master -> main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ problem are especially helpful. -->
 
 <!-- You can create a reproduction script by copying this sample reproduction
 script and adding whatever code is necessary to get a failing test case:
-https://github.com/thoughtbot/factory_bot/blob/master/.github/REPRODUCTION_SCRIPT.rb -->
+https://github.com/thoughtbot/factory_bot/blob/main/.github/REPRODUCTION_SCRIPT.rb -->
 
 ### Expected behavior
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ coverage
 tmp
 bin
 .rubocop-https*
-gemfiles/master.gemfile.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,12 +94,12 @@ Use [standard] to automatically format your code:
 bundle exec rake standard:fix
 ```
 
-[repo]: https://github.com/thoughtbot/factory_bot/tree/master
+[repo]: https://github.com/thoughtbot/factory_bot/tree/main
 [fork]: https://help.github.com/articles/fork-a-repo/
 [branch]: https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/
 [pr]: https://help.github.com/articles/using-pull-requests/
 [standard]: https://github.com/testdouble/standard
 [appraisal]: https://github.com/thoughtbot/appraisal
-[reproduction script]: https://github.com/thoughtbot/factory_bot/blob/master/.github/REPRODUCTION_SCRIPT.rb
+[reproduction script]: https://github.com/thoughtbot/factory_bot/blob/main/.github/REPRODUCTION_SCRIPT.rb
 
 Inspired by https://github.com/middleman/middleman-heroku/blob/master/CONTRIBUTING.md

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -424,7 +424,7 @@ end
 Method Name / Reserved Word Attributes
 -------------------------------
 
-If your attributes conflict with existing methods or reserved words (all methods in the [DefinitionProxy](https://github.com/thoughtbot/factory_bot/blob/master/lib/factory_bot/definition_proxy.rb) class) you can define them with `add_attribute`.
+If your attributes conflict with existing methods or reserved words (all methods in the [DefinitionProxy](https://github.com/thoughtbot/factory_bot/blob/main/lib/factory_bot/definition_proxy.rb) class) you can define them with `add_attribute`.
 
 ```ruby
 factory :dna do

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ gem install factory_bot
 Supported Ruby versions
 -----------------------
 
-Supported Ruby versions are listed in [`.github/workflows/build.yml`](https://github.com/thoughtbot/factory_bot/blob/master/.github/workflows/build.yml)
+Supported Ruby versions are listed in [`.github/workflows/build.yml`](https://github.com/thoughtbot/factory_bot/blob/main/.github/workflows/build.yml)
 
 More Information
 ----------------
@@ -53,8 +53,8 @@ More Information
 * [Issues](https://github.com/thoughtbot/factory_bot/issues)
 * [GIANT ROBOTS SMASHING INTO OTHER GIANT ROBOTS](https://robots.thoughtbot.com/)
 
-[GETTING_STARTED]: https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md
-[NAME]: https://github.com/thoughtbot/factory_bot/blob/master/NAME.md
+[GETTING_STARTED]: https://github.com/thoughtbot/factory_bot/blob/main/GETTING_STARTED.md
+[NAME]: https://github.com/thoughtbot/factory_bot/blob/main/NAME.md
 
 Useful Tools
 ------------
@@ -64,7 +64,7 @@ Useful Tools
 Contributing
 ------------
 
-Please see [CONTRIBUTING.md](https://github.com/thoughtbot/factory_bot/blob/master/CONTRIBUTING.md).
+Please see [CONTRIBUTING.md](https://github.com/thoughtbot/factory_bot/blob/main/CONTRIBUTING.md).
 
 factory_bot was originally written by Joe Ferris and is maintained by thoughtbot.
 Many improvements and bugfixes were contributed by the [open source
@@ -77,7 +77,7 @@ factory_bot is Copyright © 2008-2022 Joe Ferris and thoughtbot. It is free
 software, and may be redistributed under the terms specified in the
 [LICENSE] file.
 
-[LICENSE]: https://github.com/thoughtbot/factory_bot/blob/master/LICENSE
+[LICENSE]: https://github.com/thoughtbot/factory_bot/blob/main/LICENSE
 
 
 About thoughtbot


### PR DESCRIPTION
This renames all references to `master` to `main`. The `master` branch
is no longer up to date, so these links go to outdated docs. There was
one in `.gitignore` that I removed entirely, as it looks like the
`.lock` files in the `gemfiles/` directory are intentionally checked in.
