### PR TITLE
Don't run CI builds on TruffleRuby and Rails 5.0, 5.1, and 5.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,12 @@ jobs:
             rails: "5.1"
           - ruby: "3.0"
             rails: "5.2"
+          - ruby: truffleruby
+            rails: "5.0"
+          - ruby: truffleruby
+            rails: "5.1"
+          - ruby: truffleruby
+            rails: "5.2"
           - ruby: "3.1"
             rails: "5.0"
           - ruby: "3.1"


### PR DESCRIPTION
The latest TruffleRuby release (22.2.0) is compatible with CRuby 3.0 so now they will be check on CI against the same Rails versions.

TruffleRuby CI builds fail on Rails 5.0, 5.1 and 5.0 because of missing `rb_check_safe_obj` function. It was removed in CRuby 3.0 (https://github.com/ruby/ruby/commit/ada2f71c70bb11f1d71485e2090ce36872608217)