### PR TITLE
Support `:traits` option on implicit association

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1296,6 +1296,8 @@ factory :post do
   association :author, :admin, factory: :user, name: 'John Doe'
   # or
   association :author, factory: [:user, :admin], name: 'John Doe'
+  # or
+  author factory: :user, traits: [:admin], name: 'John Doe'
 end
 
 # creates an admin user with name "John Doe"

--- a/lib/factory_bot/declaration/association.rb
+++ b/lib/factory_bot/declaration/association.rb
@@ -7,7 +7,7 @@ module FactoryBot
         @options = options.dup
         @overrides = options.extract_options!
         @factory_name = @overrides.delete(:factory) || name
-        @traits = options
+        @traits = options + (@overrides.delete(:traits) || [])
       end
 
       def ==(other)

--- a/lib/factory_bot/definition_proxy.rb
+++ b/lib/factory_bot/definition_proxy.rb
@@ -15,6 +15,11 @@ module FactoryBot
       method
     ].freeze
 
+    VALID_OPTION_KEYS = %i[
+      factory
+      traits
+    ].freeze
+
     (instance_methods + private_instance_methods).each do |method|
       undef_method(method) unless UNPROXIED_METHODS.include?(method.to_s)
     end
@@ -250,7 +255,8 @@ module FactoryBot
     end
 
     def __valid_association_options?(options)
-      options.respond_to?(:has_key?) && options.has_key?(:factory)
+      options.respond_to?(:has_key?) &&
+        VALID_OPTION_KEYS.any? { |key| options.has_key?(key) }
     end
   end
 end

--- a/spec/acceptance/associations_spec.rb
+++ b/spec/acceptance/associations_spec.rb
@@ -142,4 +142,32 @@ describe "associations" do
       )
     end
   end
+
+  context "when building implicit association with :traits option" do
+    it "builds the association according to the given strategy" do
+      define_model("Article", user_id: :integer) do
+        belongs_to :user
+      end
+
+      define_model("User") do
+        has_many :articles
+        attr_accessor :active
+      end
+
+      FactoryBot.define do
+        factory :article do
+          user traits: [:active]
+        end
+
+        factory :user do
+          trait :active do
+            active { true }
+          end
+        end
+      end
+
+      article = FactoryBot.create(:article)
+      expect(article.user.active).to be true
+    end
+  end
 end

--- a/spec/factory_bot/definition_proxy_spec.rb
+++ b/spec/factory_bot/definition_proxy_spec.rb
@@ -53,6 +53,15 @@ describe FactoryBot::DefinitionProxy, "#method_missing" do
       .with_options(factory: :user)
   end
 
+  it 'declares an association when called with a ":traits" key' do
+    definition = FactoryBot::Definition.new(:name)
+    proxy = FactoryBot::DefinitionProxy.new(definition)
+    proxy.author traits: [:admin]
+
+    expect(definition).to have_association_declaration(:author)
+      .with_options(traits: [:admin])
+  end
+
   it "declares a dynamic attribute when called with a block" do
     definition = FactoryBot::Definition.new(:name)
     proxy = FactoryBot::DefinitionProxy.new(definition)


### PR DESCRIPTION
Until now, if we wanted to specify traits in implicit associations, we had to use `:factory` option. 
This is not only a naming problem, but also redundant in implicit style, because when using `:factory` option, the main factory name must always be specified, so the same name must be written twice.

```ruby
  user factory: [:user, :trait1, :trait2]
# ^^^^            ^^^^
```

To resolve this problem, I propose to allow `:traits` option on implicit associations in this Pull Request.

```ruby
  user traits: [:trait1, :trait2]
```