### PR TITLE
Update actions/checkout version to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
     name: Run standard
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.1"


### PR DESCRIPTION
The version 3.x appears to be due to the following:
- https://github.com/actions/checkout/pull/689

There have been no breaking changes, and we seem to have no problem keeping up with the latest version.