### PR TITLE
Pass key and receiver to custom key errors

### DIFF
--- a/lib/factory_bot/registry.rb
+++ b/lib/factory_bot/registry.rb
@@ -39,9 +39,21 @@ module FactoryBot
 
     def key_error_with_custom_message(key_error)
       message = key_error.message.sub("key not found", "#{@name} not registered")
-      error = KeyError.new(message)
-      error.set_backtrace(key_error.backtrace)
-      error
+      new_key_error(message, key_error).tap do |error|
+        error.set_backtrace(key_error.backtrace)
+      end
+    end
+
+    # detailed_message introduced in Ruby 3.2 for cleaner integration with
+    # did_you_mean. See https://bugs.ruby-lang.org/issues/18564
+    if KeyError.method_defined?(:detailed_message)
+      def new_key_error(message, key_error)
+        KeyError.new(message, key: key_error.key, receiver: key_error.receiver)
+      end
+    else
+      def new_key_error(message, _)
+        KeyError.new(message)
+      end
     end
   end
 end

--- a/spec/acceptance/traits_spec.rb
+++ b/spec/acceptance/traits_spec.rb
@@ -324,13 +324,7 @@ describe "looking up traits that don't exist" do
         end
       end
 
-      expect { FactoryBot.build(:user) }.to raise_error(
-        KeyError,
-        <<~MSG.strip
-          Trait not registered: "not_quite" referenced within "user" definition
-          Did you mean?  "not_quit"
-        MSG
-      )
+      expect { FactoryBot.build(:user) }.to raise_did_you_mean_error
     end
   end
 

--- a/spec/factory_bot/registry_spec.rb
+++ b/spec/factory_bot/registry_spec.rb
@@ -33,8 +33,7 @@ describe FactoryBot::Registry do
     registered_object = double(:registered_object)
     registry.register(:factory_bot, registered_object)
 
-    expect { registry.find(:factory_bit) }
-      .to raise_error(KeyError, /Did you mean\?  "factory_bot"/)
+    expect { registry.find(:factory_bit) }.to raise_did_you_mean_error
   end
 
   it "adds and returns the object registered" do

--- a/spec/support/matchers/raise_did_you_mean_error.rb
+++ b/spec/support/matchers/raise_did_you_mean_error.rb
@@ -1,0 +1,18 @@
+RSpec::Matchers.define :raise_did_you_mean_error do
+  supports_block_expectations
+
+  match do |actual|
+    # detailed_message introduced in Ruby 3.2 for cleaner integration with
+    # did_you_mean. See https://bugs.ruby-lang.org/issues/18564
+    matcher = if KeyError.method_defined?(:detailed_message)
+      raise_error(
+        an_instance_of(KeyError)
+        .and(having_attributes(detailed_message: /Did you mean\?/))
+      )
+    else
+      raise_error(KeyError, /Did you mean\?/)
+    end
+
+    expect(actual).to matcher
+  end
+end


### PR DESCRIPTION
did_you_mean tests started failing on Ruby 3.2 because of https://bugs.ruby-lang.org/issues/18564.

This gets did_you_mean working again for Ruby 3.2 by adding the original KeyError's key and receiver over to the custom KeyError. That way the did_you_mean can get added to the custom KeyError via the new detailed_message.

Once this is merged we can add Ruby 3.2 to the test matrix