### PR TITLE
Disable cucumber publish message

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,1 +1,1 @@
-default: -r features features
+default: --publish-quiet -r features features


### PR DESCRIPTION
Otherwise we see this every time we run cucumber:

```
┌──────────────────────────────────────────────────────────────────────────┐
│ Share your Cucumber Report with your team at https://reports.cucumber.io │
│                                                                          │
│ Command line option:    --publish                                        │
│ Environment variable:   CUCUMBER_PUBLISH_ENABLED=true                    │
│ cucumber.yml:           default: --publish                               │
│                                                                          │
│ More information at https://reports.cucumber.io/docs/cucumber-ruby       │
│                                                                          │
│ To disable this message, specify CUCUMBER_PUBLISH_QUIET=true or use the  │
│ --publish-quiet option. You can also add this to your cucumber.yml:      │
│ default: --publish-quiet                                                 │
└──────────────────────────────────────────────────────────────────────────┘
```