### PR TITLE
Don't run simplecov on alternate Ruby

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,6 +1,6 @@
 PROJECT_ROOT = File.expand_path(File.join(File.dirname(__FILE__), "..", ".."))
 
-require "simplecov"
+require "simplecov" if RUBY_ENGINE == "ruby"
 
 $: << File.join(PROJECT_ROOT, "lib")
 

--- a/spec/factory_bot/find_definitions_spec.rb
+++ b/spec/factory_bot/find_definitions_spec.rb
@@ -1,3 +1,5 @@
+require "fileutils"
+
 shared_examples_for "finds definitions" do
   before do
     allow(FactoryBot).to receive(:load)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require "rspec"
 require "rspec/its"
 
-require "simplecov"
+require "simplecov" if RUBY_ENGINE == "ruby"
 
 require "factory_bot"
 


### PR DESCRIPTION
The truffleruby + Rails 7.0 build was failing because of some kind of simplecov incompatibility. I don't think we need to run simplecov on the truffleruby and jruby builds (we might not need it on any build—it prints some output but doesn't affect the build status at all—but I figured I'd leave it alone for now in case somebody is looking at it).

I needed to add a fileutils require to one test that was presumably getting implicitly required before via simplecov.