### PR TITLE
fix(Stub): align #destroyed with #new_record/#persisted

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # News
 
+## Unreleased
+
+  * Changed: Explicitly define `#destroyed?` within the `Stub` strategy to return `false` to be consistent
+    with `#new_record?` and `#persisted?`.
+
 ## 6.2.1 (March 8, 2022)
   * Added: CI testing against truffleruby
   * Changed: Documentation improvements for sequences and traits

--- a/docs/src/ref/build-strategies.md
+++ b/docs/src/ref/build-strategies.md
@@ -76,7 +76,7 @@ data as appropriate:
 - all [ActiveModel::Dirty] change tracking is cleared
 - `persisted?` is true
 - `new_record?` is false
-- `destroyed?` is nil
+- `destroyed?` is false
 - persistence methods raise a `RuntimeError` (`#connection`, `#delete`, `#save`, `#update`, etc.)
 
 [ActiveModel::Dirty]: https://api.rubyonrails.org/classes/ActiveModel/Dirty.html

--- a/lib/factory_bot/strategy/stub.rb
+++ b/lib/factory_bot/strategy/stub.rb
@@ -66,7 +66,7 @@ module FactoryBot
           end
 
           def destroyed?
-            nil
+            false
           end
 
           DISABLED_PERSISTENCE_METHODS.each do |write_method|


### PR DESCRIPTION
I was surprised to find that #destroyed? returns nil
instead of false when I build_stubbed.  I don't see
a reason for it in the commit history nor in Rails,
so I thought it was fair game for this PR.