### PR TITLE
Fixed link to Modify factories summary

### DIFF
--- a/docs/src/ref/modify.md
+++ b/docs/src/ref/modify.md
@@ -10,4 +10,4 @@ defined. The block is a normal [factory definition block](factory.html). Take
 note that [hooks](hooks.html) cannot be cleared and continue to compound.
 
 For details on why you'd want to use this, see [the
-guide](/modifying-factories/summary.html).
+guide](./modifying-factories/summary.html).


### PR DESCRIPTION
**Issue**
- Link to https://thoughtbot.github.io/factory_bot/modifying-factories/summary.html in https://thoughtbot.github.io/factory_bot/ref/modify.html is failing. 

**Description**
- Updated reference to link in modify.md