### PR TITLE
Warn about viewing docs on old `master` branch

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,8 @@
+⚠️ **Warning:** You are viewing this file on the `master` branch, which is no
+longer used and does not receive any updates. Please view [this file on the
+`main` branch](https://github.com/thoughtbot/factory_bot/blob/main/CODE_OF_CONDUCT.md)
+for up-to-date information.
+
 # Code of conduct
 
 By participating in this project, you agree to abide by the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,8 @@
+⚠️ **Warning:** You are viewing this file on the `master` branch, which is no
+longer used and does not receive any updates. Please view [this file on the
+`main` branch](https://github.com/thoughtbot/factory_bot/blob/main/CONTRIBUTING.md)
+for up-to-date information.
+
 # Contributing to Factory Bot
 
 We love pull requests from everyone. By participating in this project, you

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,3 +1,8 @@
+⚠️ **Warning:** You are viewing this file on the `master` branch, which is no
+longer used and does not receive any updates. Please view [this file on the
+`main` branch](https://github.com/thoughtbot/factory_bot/blob/main/GETTING_STARTED.md)
+for up-to-date information.
+
 Getting Started
 ===============
 

--- a/NAME.md
+++ b/NAME.md
@@ -1,3 +1,8 @@
+⚠️ **Warning:** You are viewing this file on the `master` branch, which is no
+longer used and does not receive any updates. Please view [this file on the
+`main` branch](https://github.com/thoughtbot/factory_bot/blob/main/NAME.md) for
+up-to-date information.
+
 # Project Naming History
 
 ## Factory Girl

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+⚠️ **Warning:** You are viewing this file on the `master` branch, which is no
+longer used and does not receive any updates. Please view [this file on the
+`main` branch](https://github.com/thoughtbot/factory_bot/blob/main/NEWS.md) for
+up-to-date information.
+
 # News
 
 ## 6.2.0 (May 7, 2021)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+⚠️ **Warning:** You are viewing this file on the `master` branch, which is no
+longer used and does not receive any updates. Please view [this file on the
+`main` branch](https://github.com/thoughtbot/factory_bot/tree/main#readme) for
+up-to-date information.
+
 # factory_bot [![Build Status][ci-image]][ci] [![Code Climate][grade-image]][grade] [![Gem Version][version-image]][version]
 
 factory_bot is a fixtures replacement with a straightforward definition syntax, support for multiple build strategies (saved instances, unsaved instances, attribute hashes, and stubbed objects), and support for multiple factories for the same class (user, admin_user, and so on), including factory inheritance.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,3 +1,8 @@
+⚠️ **Warning:** You are viewing this file on the `master` branch, which is no
+longer used and does not receive any updates. Please view [this file on the
+`main` branch](https://github.com/thoughtbot/factory_bot/blob/main/RELEASING.md)
+for up-to-date information.
+
 # Releasing
 
 1. Update version file accordingly and run `bundle install` to update the


### PR DESCRIPTION
Since [the deprecation of `GETTING_STARTED.md`](https://github.com/thoughtbot/factory_bot/pull/1574), I've gotten better at noticing when people online link to it on the old `master` branch. That version does not have the deprecation notice linking to the new docs, nor does it have any changes made in the past couple years.

This PR targets the `master` branch and adds a warning to the top of each Markdown file with a link to it on the `main` branch. It doesn't directly link to the news docs, which is deliberate so that we don't potentially have to update the `master` branch again in the future (if we move the docs again, for example).

If this PR is merged, I plan to make a similar change in [factory_bot_rails](https://github.com/thoughtbot/factory_bot_rails).