### PR TITLE
DefinitionProxy#method_missing: Forward given block to #association

### DIFF
--- a/lib/factory_bot/definition_proxy.rb
+++ b/lib/factory_bot/definition_proxy.rb
@@ -94,7 +94,7 @@ module FactoryBot
       if association_options.nil?
         __declare_attribute__(name, block)
       elsif __valid_association_options?(association_options)
-        association(name, association_options)
+        association(name, association_options, &block)
       else
         raise NoMethodError.new(<<~MSG)
           undefined method '#{name}' in '#{@definition.name}' factory

--- a/spec/factory_bot/definition_proxy_spec.rb
+++ b/spec/factory_bot/definition_proxy_spec.rb
@@ -74,6 +74,19 @@ describe FactoryBot::DefinitionProxy, "#method_missing" do
       "Did you mean? 'static_attributes_are_gone { \"true\" }'\n"
     )
   end
+
+  it "raises an AssociationDefinitionError when called with a `:factory`-key and providing a block" do
+    definition = FactoryBot::Definition.new(:user)
+    proxy = FactoryBot::DefinitionProxy.new(definition)
+    invalid_call = lambda do
+      proxy.author(factory: :user) { :this_should_raise_an_error }
+    end
+
+    expect(invalid_call).to raise_error(
+      FactoryBot::AssociationDefinitionError,
+      "Unexpected block passed to 'author' association in 'user' factory"
+    )
+  end
 end
 
 describe FactoryBot::DefinitionProxy, "#sequence" do


### PR DESCRIPTION
Replacement for the prematurely closed PR #1518

Why:
----
When defining an association the block-argument will be ignored when also providing a `factory`-key on the association definition.

This behaviour might be unexpected, so we should raise an error that the passed block is unexpected/ignored.