### PR TITLE
Support uuids in build_stubbed

### DIFF
--- a/lib/factory_bot/strategy/stub.rb
+++ b/lib/factory_bot/strategy/stub.rb
@@ -47,13 +47,17 @@ module FactoryBot
 
       private
 
-      def next_id
-        @@next_id += 1
+      def next_id(result_instance)
+        if uuid_primary_key?(result_instance)
+          SecureRandom.uuid
+        else
+          @@next_id += 1
+        end
       end
 
       def stub_database_interaction_on_result(result_instance)
         if has_settable_id?(result_instance)
-          result_instance.id ||= next_id
+          result_instance.id ||= next_id(result_instance)
         end
 
         result_instance.instance_eval do
@@ -81,6 +85,13 @@ module FactoryBot
       def has_settable_id?(result_instance)
         !result_instance.class.respond_to?(:primary_key) ||
           result_instance.class.primary_key
+      end
+
+      def uuid_primary_key?(result_instance)
+        result_instance.respond_to?(:column_for_attribute) &&
+          (column = result_instance.column_for_attribute(result_instance.class.primary_key)) &&
+          column.respond_to?(:sql_type) &&
+          column.sql_type == "uuid"
       end
 
       def clear_changes_information(result_instance)


### PR DESCRIPTION
This is based on #1514 and fixes #1498.

The only things i did, compared to #1514, are the following:

- rebased on main
- added one more guard clause, to ensure that the worst-case result if the relevant rails API is ever removed is the same lack of UUID support that we have currently

The relevant rails API hasn't changed since PR #1514 was created 2 years ago. It would be nice to finally get support for UUIDs. 😊 

