### PR TITLE
Reject `sequence` definitions for Active Record primary keys

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # News
 
+## Unreleased
+  * Added: BREAKING CHANGE: Reject `sequence` definitions for Active Record primary keys
+
 ## 6.2.1 (March 8, 2022)
   * Added: CI testing against truffleruby
   * Changed: Documentation improvements for sequences and traits

--- a/spec/factory_bot/factory_spec.rb
+++ b/spec/factory_bot/factory_spec.rb
@@ -153,6 +153,27 @@ describe FactoryBot::Factory, "when defined with a custom class" do
   end
 end
 
+describe FactoryBot::Factory, "when defined with a class that descends from ActiveRecord::Base" do
+  context "with a sequence generating its primary key" do
+    it "raises an error" do
+      model = define_model "Article" do
+        self.primary_key = :an_id
+      end
+      sequence = FactoryBot::Sequence.new(model.primary_key)
+      FactoryBot::Internal.register_sequence(sequence)
+      factory = FactoryBot::Factory.new(:record, class: model)
+      factory.declare_attribute(FactoryBot::Declaration::Implicit.new(sequence.name))
+
+      expect { factory.run(FactoryBot::Strategy::AttributesFor, {}) }
+        .to raise_error(FactoryBot::AttributeDefinitionError)
+      expect { factory.run(FactoryBot::Strategy::Build, {}) }
+        .to raise_error(FactoryBot::AttributeDefinitionError)
+      expect { factory.run(FactoryBot::Strategy::Create, {}) }
+        .to raise_error(FactoryBot::AttributeDefinitionError)
+    end
+  end
+end
+
 describe FactoryBot::Factory, "when given a class that overrides #to_s" do
   it "sets build_class correctly" do
     define_class("Overriding")


### PR DESCRIPTION
It might be useful to define `sequence(:id)` attributes for models representing objects in external systems. It might be tempting to apply that same pattern to Active Record-backed models that are internal to the system under test.

However, a factory that generates its own sequence of `id` (or any other primary key attribute) risks collision or desynchronization with the underlying datastore (most likely an SQL database with its own primary key generation strategy and "next" value).

This commit introduces a check in the `FactoryBot::Definition#compile` method to ensure that descendants of `ActiveRecord::Base` cannot declare a sequence to generate their own primary key.