### PR TITLE
Publish `factory_bot.compile_factory` notification

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1990,7 +1990,7 @@ ActiveSupport Instrumentation
 
 In order to track what factories are created (and with what build strategy),
 `ActiveSupport::Notifications` are included to provide a way to subscribe to
-factories being run. One example would be to track factories based on a
+factories being compiled and run. One example would be to track factories based on a
 threshold of execution time.
 
 ```ruby
@@ -2016,6 +2016,29 @@ config.before(:suite) do
     factory_bot_results[factory_name] ||= {}
     factory_bot_results[factory_name][strategy_name] ||= 0
     factory_bot_results[factory_name][strategy_name] += 1
+  end
+end
+
+config.after(:suite) do
+  puts factory_bot_results
+end
+```
+
+Another example could involve tracking the attributes and traits that factories are compiled with. If you're using RSpec, you could add `before(:suite)` and `after(:suite)` blocks that subscribe to `factory_bot.compile_factory` notifications:
+
+```ruby
+factory_bot_results = {}
+config.before(:suite) do
+  ActiveSupport::Notifications.subscribe("factory_bot.compile_factory") do |name, start, finish, id, payload|
+    factory_name = payload[:name]
+    factory_class = payload[:class]
+    attributes = payload[:attributes]
+    traits = payload[:traits]
+    factory_bot_results[factory_class] ||= {}
+    factory_bot_results[factory_class][factory_name] = {
+      attributes: attributes.map(&:name)
+      traits: traits.map(&:name)
+    }
   end
 end
 

--- a/lib/factory_bot/definition.rb
+++ b/lib/factory_bot/definition.rb
@@ -57,6 +57,13 @@ module FactoryBot
         end
 
         @compiled = true
+
+        ActiveSupport::Notifications.instrument "factory_bot.compile_factory", {
+          name: name,
+          attributes: declarations.attributes,
+          traits: defined_traits,
+          class: klass
+        }
       end
     end
 


### PR DESCRIPTION
Related to [comment on thoughtbot/factory_bot#1586][]
---

Publish Active Support Notifications under the
`factory_bot.compile_factory` key.

They payload for that event is a `Hash` with keys:

* `name:` - the name of the Factory
* `class:` - the Ruby class the Factory constructs instances of
* `attributes:` - a `FactoryBot::AttributesList` instance for the available attributes
* `traits:` - an Array of `FactoryBot::Trait` instances for the available traits

[comment on thoughtbot/factory_bot#1586]: https://github.com/thoughtbot/factory_bot/pull/1586#issuecomment-1674003814