### PR TITLE
Chore - Add link to the changelog 

### DIFF
--- a/factory_bot.gemspec
+++ b/factory_bot.gemspec
@@ -22,6 +22,10 @@ Gem::Specification.new do |s|
 
   s.homepage = "https://github.com/thoughtbot/factory_bot"
 
+  s.metadata = {
+    "changelog_uri" => "https://github.com/thoughtbot/factory_bot/blob/main/NEWS.md"
+  }
+
   s.add_dependency("activesupport", ">= 5.0.0")
 
   s.add_development_dependency("activerecord")


### PR DESCRIPTION
[Ruby gems](https://rubygems.org/gems/factory_bot) doesn't show the link to the changelog.
I thought this was especially important since the filename is unconventional, it would speed up the workflow of this gem's users.