### PR TITLE
Document integration with 2.7 and 3.0 syntactic sugars

### DIFF
--- a/docs/src/associations/association-overrides.md
+++ b/docs/src/associations/association-overrides.md
@@ -16,3 +16,15 @@ end
 eunji = build(:author, name: 'Eunji')
 post = build(:post, author: eunji)
 ```
+
+Ruby 3.1's support for [omitting values][] from `Hash` literals dovetails with
+attribute overrides, and provides an opportunity to limit the repetition of
+variable names:
+
+```ruby
+author = build(:author, name: 'Eunji')
+
+post = build(:post, author:)
+```
+
+[omitting values]: https://docs.ruby-lang.org/en/3.1/syntax/literals_rdoc.html#label-Hash+Literals

--- a/docs/src/sequences/inline-sequences.md
+++ b/docs/src/sequences/inline-sequences.md
@@ -8,3 +8,14 @@ factory :user do
   sequence(:email) { |n| "person#{n}@example.com" }
 end
 ```
+
+With Ruby 2.7's support for [numbered parameters][], inline definitions can be
+even more abbreviated:
+
+```ruby
+factory :user do
+  sequence(:email) { "person#{_1}@example.com" }
+end
+```
+
+[numbered parameters]: https://ruby-doc.org/core-2.7.1/Proc.html#class-Proc-label-Numbered+parameters

--- a/docs/src/using-factories/attribute-overrides.md
+++ b/docs/src/using-factories/attribute-overrides.md
@@ -9,3 +9,18 @@ user = build(:user, first_name: "Joe")
 user.first_name
 # => "Joe"
 ```
+
+Ruby 3.1's support for [omitting values][] from `Hash` literals dovetails with
+attribute overrides and provides an opportunity to limit the repetition of
+variable names:
+
+```ruby
+first_name = "Joe"
+
+# Build a User instance and override the first_name property
+user = build(:user, first_name:)
+user.first_name
+# => "Joe"
+```
+
+[omitting values]: https://docs.ruby-lang.org/en/3.1/syntax/literals_rdoc.html#label-Hash+Literals

--- a/docs/src/using-factories/build-strategies.md
+++ b/docs/src/using-factories/build-strategies.md
@@ -13,6 +13,9 @@ user = create(:user)
 # Returns a hash of attributes, which can be used to build a User instance for example
 attrs = attributes_for(:user)
 
+# Integrates with Ruby 3.0's support for pattern matching assignment
+attributes_for(:user) => {email:, name:, **attrs}
+
 # Returns an object with all defined attributes stubbed out
 stub = build_stubbed(:user)
 

--- a/spec/acceptance/attributes_for_destructuring.rb
+++ b/spec/acceptance/attributes_for_destructuring.rb
@@ -1,0 +1,24 @@
+describe "Ruby 3.0: attributes_for destructuring syntax" do
+  include FactoryBot::Syntax::Methods
+
+  before do
+    define_model("User", name: :string)
+
+    FactoryBot.define do
+      factory :user do
+        sequence(:email) { "email_#{_1}@example.com" }
+        name { "John Doe" }
+      end
+    end
+  end
+
+  it "supports being destructured" do
+    # rubocop:disable Lint/Syntax
+    attributes_for(:user) => {name:, **attributes}
+    # rubocop:disable Lint/Syntax
+
+    expect(name).to eq("John Doe")
+    expect(attributes.keys).to eq([:email])
+    expect(attributes.fetch(:email)).to match(/email_\d+@example.com/)
+  end
+end

--- a/spec/acceptance/attributes_for_spec.rb
+++ b/spec/acceptance/attributes_for_spec.rb
@@ -1,3 +1,7 @@
+if RUBY_VERSION >= "3.0" && RUBY_ENGINE != "truffleruby"
+  require_relative "./attributes_for_destructuring"
+end
+
 describe "a generated attributes hash" do
   include FactoryBot::Syntax::Methods
 


### PR DESCRIPTION
Ruby 2.7 introduced [numbered block parameters][], and 3.0 introduced [Hash literal value omission][], so document how they integrate with Factory Bot.

[numbered block parameters]: https://ruby-doc.org/core-2.7.1/Proc.html#class-Proc-label-Numbered+parameters
[Hash literal value omission]: https://docs.ruby-lang.org/en/3.1/syntax/literals_rdoc.html#label-Hash+Literals