### PR TITLE
Bump github actions/checkout to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
       RUBYOPT: "--disable-error_highlight"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
@@ -89,7 +89,7 @@ jobs:
     name: Run standard
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.1"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,10 +8,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # To push a branch 
+      contents: write  # To push a branch
       pull-requests: write  # To create a PR from that branch
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Install mdbook


### PR DESCRIPTION
This Pull Request has been created because [actions/checkout](https://github.com/actions/checkout) has been bumped to [version 4](https://github.com/actions/checkout/releases/tag/v4.0.0) on the 04/09/2023

This Pull Request changes all the CI that use `actions/checkout@v3` and `actions/checkout@v2` in favour of `actions/checkout@v4`
