### PR TITLE
Add per model automatically_define_enum_traits option

### DIFF
--- a/docs/src/traits/enum.md
+++ b/docs/src/traits/enum.md
@@ -59,6 +59,25 @@ FactoryBot.define do
 end
 ```
 
+If you want to override `FactoryBot.automatically_define_enum_traits` on a
+per-model basis, you can use an additional attribute on your factory:
+
+```rb
+FactoryBot.define do
+  factory :task, automatically_define_enum_traits: false do
+    status { :queued }
+
+    trait :in_progress do
+      status { :started }
+    end
+
+    trait :complete do
+      status {:finished }
+    end
+  end
+end
+```
+
 It is also possible to use this feature for other enumerable values, not
 specifically tied to Active Record enum attributes.
 

--- a/lib/factory_bot/definition.rb
+++ b/lib/factory_bot/definition.rb
@@ -17,6 +17,7 @@ module FactoryBot
       @constructor = nil
       @attributes = nil
       @compiled = false
+      @automatically_define_enum_traits = opts[:automatically_define_enum_traits]
       @expanded_enum_traits = false
     end
 
@@ -203,8 +204,13 @@ module FactoryBot
     end
 
     def automatically_register_defined_enums?(klass)
-      FactoryBot.automatically_define_enum_traits &&
-        klass.respond_to?(:defined_enums)
+      automatically_define_enum_traits = if @automatically_define_enum_traits.nil?
+        FactoryBot.automatically_define_enum_traits
+      else
+        @automatically_define_enum_traits
+      end
+
+      automatically_define_enum_traits && klass.respond_to?(:defined_enums)
     end
   end
 end

--- a/lib/factory_bot/factory.rb
+++ b/lib/factory_bot/factory.rb
@@ -13,7 +13,12 @@ module FactoryBot
       @aliases = options[:aliases] || []
       @class_name = options[:class]
       @uri_manager = FactoryBot::UriManager.new(names)
-      @definition = Definition.new(@name, options[:traits] || [], uri_manager: @uri_manager)
+      @definition = Definition.new(
+        @name,
+        options[:traits] || [],
+        automatically_define_enum_traits: options[:automatically_define_enum_traits],
+        uri_manager: @uri_manager
+      )
       @compiled = false
     end
 
@@ -148,7 +153,7 @@ module FactoryBot
     private
 
     def assert_valid_options(options)
-      options.assert_valid_keys(:class, :parent, :aliases, :traits)
+      options.assert_valid_keys(:class, :parent, :aliases, :traits, :automatically_define_enum_traits)
     end
 
     def parent

--- a/spec/acceptance/enum_traits_spec.rb
+++ b/spec/acceptance/enum_traits_spec.rb
@@ -9,7 +9,7 @@ describe "enum traits" do
     end
   end
 
-  context "when automatically_define_enum_traits is true" do
+  context "when FactoryBot.automatically_define_enum_traits is true" do
     it "builds traits automatically for model enum field" do
       define_model_with_enum("Task", :status, {queued: 0, started: 1, finished: 2})
 
@@ -119,9 +119,45 @@ describe "enum traits" do
         expect(task.status).to eq(trait_name)
       end
     end
+
+    context "when the factory specifies automatically_define_enum_traits as false" do
+      it "raises an error for undefined traits" do
+        define_model_with_enum("Task", :status, {queued: 0, started: 1, finished: 2})
+
+        FactoryBot.define do
+          factory :task, automatically_define_enum_traits: false
+        end
+
+        Task.statuses.each_key do |trait_name|
+          expect { FactoryBot.build(:task, trait_name) }.to raise_error(
+            KeyError, "Trait not registered: \"#{trait_name}\""
+          )
+        end
+
+        Task.reset_column_information
+      end
+
+      it "builds traits for each enumerated value when traits_for_enum are specified" do
+        define_model_with_enum("Task", :status, {queued: 0, started: 1, finished: 2})
+
+        FactoryBot.define do
+          factory :task, automatically_define_enum_traits: false do
+            traits_for_enum(:status)
+          end
+        end
+
+        Task.statuses.each_key do |trait_name|
+          task = FactoryBot.build(:task, trait_name)
+
+          expect(task.status).to eq(trait_name)
+        end
+
+        Task.reset_column_information
+      end
+    end
   end
 
-  context "when automatically_define_enum_traits is false" do
+  context "when FactoryBot.automatically_define_enum_traits is false" do
     it "raises an error for undefined traits" do
       with_temporary_assignment(FactoryBot, :automatically_define_enum_traits, false) do
         define_model_with_enum("Task", :status, {queued: 0, started: 1, finished: 2})
@@ -157,6 +193,26 @@ describe "enum traits" do
         end
 
         Task.reset_column_information
+      end
+    end
+
+    context "when the factory specifies automatically_define_enum_traits as true" do
+      it "builds traits automatically for model enum field" do
+        with_temporary_assignment(FactoryBot, :automatically_define_enum_traits, false) do
+          define_model_with_enum("Task", :status, {queued: 0, started: 1, finished: 2})
+
+          FactoryBot.define do
+            factory :task, automatically_define_enum_traits: true
+          end
+
+          Task.statuses.each_key do |trait_name|
+            task = FactoryBot.build(:task, trait_name)
+
+            expect(task.status).to eq(trait_name)
+          end
+
+          Task.reset_column_information
+        end
       end
     end
   end


### PR DESCRIPTION
Currently you can only specify whether to automatically define enum traits at a global level, through `FactoryBot.automatically_define_enum_traits`. This means that an entire codebase has to either opt-in, or opt-out from automatically defining enum traits. If you are in a large, established codebase with lots of enum's, this is quite hard to change globally when you find that automatically defining them doesn't fit for your new use case.

If we could override this at a per-factory level, we could allow individual factories to override the global setting where appropriate, in order to do customise them where necessary.

Given `FactoryBot.automatically_define_enum_traits` being set to `true`, and a model called `Task` with the following enum definition:

```
class Task
  enum :confirmed_by, [:user, :organisation], prefix: true
end
```

You would be able to override disable this on a per-factory basis like so:

```
FactoryBot.define do
  factory :task, automatically_define_enum_traits: false do
    confirmed_by { :user }

    trait :org_confirmed do
      confirmed_by { :organisation }
    end
  end
end
```

If `FactoryBot.automatically_define_enum_traits` was instead set to `false`, then the same model with a factory override set to `true` you would end up with the following automatic traits:

```
FactoryBot.define do
  factory :task, automatically_define_enum_traits: true do
    # The :user and :organisation traits below would be automatically
    # defined in the following way:
    #
    # trait :user do
    #   confirmed_by { :user }
    # end

    # trait :organisation do
    #   confirmed_by { :organisation }
    # end
  end
end
```

Fixes: https://github.com/thoughtbot/factory_bot/issues/1597