### PR TITLE
Pass block to `expect` as needed

### DIFF
--- a/spec/acceptance/defining_methods_inside_a_factory_spec.rb
+++ b/spec/acceptance/defining_methods_inside_a_factory_spec.rb
@@ -12,7 +12,7 @@ describe "defining methods inside FactoryBot" do
       end
     end
 
-    expect(bad_factory_definition).to raise_error(
+    expect(&bad_factory_definition).to raise_error(
       FactoryBot::MethodDefinitionError,
       /Defining methods in blocks \(trait or factory\) is not supported \(generate_name\)/
     )

--- a/spec/acceptance/modify_factories_spec.rb
+++ b/spec/acceptance/modify_factories_spec.rb
@@ -179,6 +179,6 @@ describe "modifying factories" do
       end
     end
 
-    expect(modify_unknown_factory).to raise_error(KeyError)
+    expect(&modify_unknown_factory).to raise_error(KeyError)
   end
 end

--- a/spec/factory_bot/definition_proxy_spec.rb
+++ b/spec/factory_bot/definition_proxy_spec.rb
@@ -68,7 +68,7 @@ describe FactoryBot::DefinitionProxy, "#method_missing" do
     proxy = FactoryBot::DefinitionProxy.new(definition)
     invalid_call = -> { proxy.static_attributes_are_gone "true" }
 
-    expect(invalid_call).to raise_error(
+    expect(&invalid_call).to raise_error(
       NoMethodError,
       "undefined method 'static_attributes_are_gone' in 'broken' factory\n" \
       "Did you mean? 'static_attributes_are_gone { \"true\" }'\n"

--- a/spec/support/matchers/raise_did_you_mean_error.rb
+++ b/spec/support/matchers/raise_did_you_mean_error.rb
@@ -13,6 +13,6 @@ RSpec::Matchers.define :raise_did_you_mean_error do
       raise_error(KeyError, /Did you mean\?/)
     end
 
-    expect(actual).to matcher
+    expect(&actual).to matcher
   end
 end


### PR DESCRIPTION
RSpec's `expect` has two forms:

- scalar: `expect(result).to be_truthy`
- block: `expect { thunk }.not_to raise_error(RuntimeError)`

So what happens when you mix them?

```ruby
thunk = -> { 1 / 0 }
expect(thunk).not_to raise_error(RuntimeError)
```

If you do that, RSpec complains:

> The implicit block expectation syntax is deprecated, you should pass a
> block rather than an argument to `expect` to use the provided block
> expectation matcher or the matcher must implement
> `supports_value_expectations?`

The easy solution is to pass the Proc as a block, using `&`:

```
thunk = -> { 1 / 0 }
expect(&thunk).not_to raise_error(RuntimeError)
```