### PR TITLE
Assign klass to global traits when find by name

### DIFF
--- a/lib/factory_bot/definition.rb
+++ b/lib/factory_bot/definition.rb
@@ -52,6 +52,7 @@ module FactoryBot
 
         declarations.attributes
 
+        self.klass ||= klass
         defined_traits.each do |defined_trait|
           defined_trait.klass ||= klass
           base_traits.each { |bt| bt.define_trait defined_trait }
@@ -152,7 +153,7 @@ module FactoryBot
     end
 
     def trait_by_name(name)
-      trait_for(name) || Internal.trait_by_name(name)
+      trait_for(name) || Internal.trait_by_name(name, klass)
     end
 
     def trait_for(name)

--- a/lib/factory_bot/internal.rb
+++ b/lib/factory_bot/internal.rb
@@ -39,8 +39,8 @@ module FactoryBot
         trait
       end
 
-      def trait_by_name(name)
-        traits.find(name)
+      def trait_by_name(name, klass)
+        traits.find(name).tap { |t| t.klass = klass }
       end
 
       def register_sequence(sequence)

--- a/spec/factory_bot/internal_spec.rb
+++ b/spec/factory_bot/internal_spec.rb
@@ -20,9 +20,12 @@ describe FactoryBot::Internal do
   describe ".trait_by_name" do
     it "finds a previously registered trait" do
       trait = FactoryBot::Trait.new(:admin)
+      klass = instance_double("klass")
       FactoryBot::Internal.register_trait(trait)
 
-      expect(FactoryBot::Internal.trait_by_name(trait.name)).to eq trait
+      expect(trait.klass).to be_nil
+      expect(FactoryBot::Internal.trait_by_name(trait.name, klass)).to eq trait
+      expect(trait.klass).to eq klass
     end
   end
 


### PR DESCRIPTION
We fixed the error that `defined_traits` had no class in #1600 .
But we can declare traits also in top level and mixin them as `base_traits` and `additional_traits`, like:

```ruby
FactoryBot.define do
  # top level trait
  trait :email do
    email { "#{name}@example.com" }
  end

  factory :school, traits: [:email] do
    name { "Charlie" }
  end

  factory :company do
    name { "Charlie" }
  end
end

# base_traits
FactoryBot.build(:school)
# additional_traits
FactoryBot.build(:company, :email)
```

The traits declared at the top level have their class determined when they are used, so assign the definition klass when the traits are used to pass their class to ActiveSuport::Notifications.
Re Fix https://github.com/thoughtbot/factory_bot_rails/issues/431