### PR TITLE
Support models without ID setters in build_stubbed

### DIFF
--- a/lib/factory_bot/strategy/stub.rb
+++ b/lib/factory_bot/strategy/stub.rb
@@ -83,8 +83,9 @@ module FactoryBot
       end
 
       def has_settable_id?(result_instance)
-        !result_instance.class.respond_to?(:primary_key) ||
-          result_instance.class.primary_key
+        result_instance.respond_to?(:id=) &&
+          (!result_instance.class.respond_to?(:primary_key) ||
+          result_instance.class.primary_key)
       end
 
       def uuid_primary_key?(result_instance)

--- a/spec/acceptance/stub_spec.rb
+++ b/spec/acceptance/stub_spec.rb
@@ -121,6 +121,17 @@ describe "overridden primary keys conventions" do
     end
   end
 
+  describe "a stubbed instance with no id setter" do
+    it "builds a stubbed instance" do
+      FactoryBot.define do
+        factory :model_hash, class: Hash
+      end
+
+      model = FactoryBot.build_stubbed(:model_hash)
+      expect(model).to be_truthy
+    end
+  end
+
   def using_model(name, primary_key:)
     define_class(name, ActiveRecord::Base)
 


### PR DESCRIPTION
Some "models" may not have an ID setter at all. This PR ensures that `build_stubbed` only tries to set the ID if the model does have an ID setter (i.e. does have an `#id=` method).