### PR TITLE
Stop passing disable-error_highlight

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,6 @@ jobs:
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.rails }}.gemfile
-      RUBYOPT: "--disable-error_highlight"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The `error_highlight` gem was added in Ruby 3.1, which means we cannot disable it on Ruby 3.0 or earlier.

So long as we support those versions, let's stop disabling it. This is the fastest way to get CI passing again.