### PR TITLE
Relax the exception message check

### DIFF
--- a/spec/factory_bot/definition_proxy_spec.rb
+++ b/spec/factory_bot/definition_proxy_spec.rb
@@ -70,8 +70,7 @@ describe FactoryBot::DefinitionProxy, "#method_missing" do
 
     expect(&invalid_call).to raise_error(
       NoMethodError,
-      "undefined method 'static_attributes_are_gone' in 'broken' factory\n" \
-      "Did you mean? 'static_attributes_are_gone { \"true\" }'\n"
+      /'static_attributes_are_gone'.*'broken' factory.*Did you mean\? 'static_attributes_are_gone \{ "true" \}'/m
     )
   end
 end


### PR DESCRIPTION
We don't actually care about the specific letters used in Ruby's `NoMethodError` exception message. We do care about the important parts, though: the method name, the object, and that "Did you mean" worked.