### PR TITLE
Unconditionally declare observer as a dependency

### DIFF
--- a/factory_bot.gemspec
+++ b/factory_bot.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   }
 
   s.add_dependency("activesupport", ">= 5.0.0")
-  s.add_dependency("observer") if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.3")
+  s.add_dependency("observer")
 
   s.add_development_dependency("activerecord")
   s.add_development_dependency("appraisal")


### PR DESCRIPTION
I believe #1607 wasn't sufficient. After upgrading the factory_bot gem my lockfile still doesn't include `observer` as a dependency and the warning is still triggered.

This can also be confirmed by looking at its rubygems page https://rubygems.org/gems/factory_bot

I'm not certain on the reason for this but I do know that condition dependencies like this aren't great. I believe it may have something to do with the ruby version being used during release.

Either way, doing this should fix it. I don't think there should be any issues with declaring it like this. Many gems did it the same, see https://github.com/rails/rails/pull/48907 for example.