### PR TITLE
Fix broken link on ref/modify.html page in docs

### DIFF
--- a/docs/src/ref/modify.md
+++ b/docs/src/ref/modify.md
@@ -10,4 +10,4 @@ defined. The block is a normal [factory definition block](factory.html). Take
 note that [hooks](hooks.html) cannot be cleared and continue to compound.
 
 For details on why you'd want to use this, see [the
-guide](/modifying-factories/summary.html).
+guide](../modifying-factories/summary.html).


### PR DESCRIPTION
The [FactoryBot.modify](https://thoughtbot.github.io/factory_bot/ref/modify.html) reference page on the documentation site has a broken link for "the guide".

This commit fixes the link.