### PR TITLE
Bump minimum required ruby version to 3.0

### DIFF
--- a/factory_bot.gemspec
+++ b/factory_bot.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
     %w[CONTRIBUTING.md GETTING_STARTED.md LICENSE NAME.md NEWS.md README.md .yardopts]
 
   s.require_path = "lib"
-  s.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
+  s.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
 
   s.authors = ["Josh Clayton", "Joe Ferris"]
   s.email = ["jclayton@thoughtbot.com", "jferris@thoughtbot.com"]


### PR DESCRIPTION
See #1612
Closes #1614

I would suggest against yanking the affected version. Doing so will result in installs for those that already upgraded not working anymore so you get another disruption for free. It's been a month since that release and it would have been better to do this as early as possible instead.