### PR TITLE
Fix docs about definition file paths

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -255,10 +255,12 @@ Factories can be defined anywhere, but will be automatically loaded after
 calling `FactoryBot.find_definitions` if factories are defined in files at the
 following locations:
 
+    factories.rb
+    factories/**/*.rb
     test/factories.rb
+    test/factories/**/*.rb
     spec/factories.rb
-    test/factories/*.rb
-    spec/factories/*.rb
+    spec/factories/**/*.rb
 
 ### Static Attributes
 

--- a/docs/src/defining/file-paths.md
+++ b/docs/src/defining/file-paths.md
@@ -4,7 +4,9 @@ Factories can be defined anywhere, but will be automatically loaded after
 calling `FactoryBot.find_definitions` if factories are defined in files at the
 following locations:
 
+    factories.rb
+    factories/**/*.rb
     test/factories.rb
+    test/factories/**/*.rb
     spec/factories.rb
-    test/factories/*.rb
-    spec/factories/*.rb
+    spec/factories/**/*.rb

--- a/docs/src/ref/find_definitions.md
+++ b/docs/src/ref/find_definitions.md
@@ -7,6 +7,7 @@ The load order is controlled by the `FactoryBot.definition_file_paths`
 attribute. The default load order is:
 
 1. `factories.rb`
+1. `factories/**/*.rb`
 1. `test/factories.rb`
 1. `test/factories/**/*.rb`
 1. `spec/factories.rb`

--- a/lib/factory_bot/find_definitions.rb
+++ b/lib/factory_bot/find_definitions.rb
@@ -2,8 +2,7 @@ module FactoryBot
   class << self
     # An Array of strings specifying locations that should be searched for
     # factory definitions. By default, factory_bot will attempt to require
-    # "factories", "test/factories" and "spec/factories". Only the first
-    # existing file will be loaded.
+    # "factories", "test/factories" and "spec/factories".
     attr_accessor :definition_file_paths
   end
 


### PR DESCRIPTION
The current implementation seems to load all definition files that match the following pattern in this order:

1. `factories.rb`
1. `factories/**/*.rb`
1. `test/factories.rb`
1. `test/factories/**/*.rb`
1. `spec/factories.rb`
1. `spec/factories/**/*.rb`

There are several documents that mention definition file paths, but none of them are consistent with the current implementation.  So I propose to first eliminate the gap between the documentation and the implementation in this pull request.

I would also be interested to know if this implementation is intentional or not, as it is important to know which files should be ideally scanned by rubocop-factory_bot.