### PR TITLE
Update has_many-associations.md

### DIFF
--- a/docs/src/cookbook/has_many-associations.md
+++ b/docs/src/cookbook/has_many-associations.md
@@ -68,9 +68,9 @@ create(:user_with_posts).posts.length # 5
 create(:user_with_posts, posts_count: 15).posts.length # 15
 ```
 
-Or, for a solution that works with `build`, `build_stubbed`, and `create`
-(although it doesn't work well with `attributes_for`), you can use inline
-associations:
+The following is a simple example that works without having to save to the
+database. It works with `build`, `build_stubbed`, and `create` (although it
+doesn't work well with `attributes_for`), you can use inline associations:
 
 ```ruby
 FactoryBot.define do
@@ -83,6 +83,12 @@ FactoryBot.define do
     name { "Taylor Kim" }
 
     factory :user_with_posts do
+      posts { [association(:post)] }
+    end
+
+    # or
+
+    trait :with_posts do
       posts { [association(:post)] }
     end
   end


### PR DESCRIPTION
I struggled to figure out how to make the has_many association work with the build strategy in a simple way. I asked ChatGPT and it came up with this strategy, which I tested and worked on an app last night. I also looked in my past code and realized years ago I figured this out previously in other apps I have written. I imagine its a common pattern.

It would be handy to be able to look up this code snippet for me in the repetitive but not common case I need to do this. I find it easier to reason about than the other examples in the documentation, it works well, and can save the need to persist to the database. I also would prefer to be able to look this up in official documentation and not an AI assistant.