### PR TITLE
Add `require 'factory_bot_rails'` in GETTING-STARTED instructions

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -124,7 +124,7 @@ If you're using Rails, add the following configuration to
 `rails_helper.rb`:
 
 ```ruby
-require 'factory_bot'
+require 'factory_bot_rails'
 
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
@@ -134,6 +134,8 @@ end
 If you're *not* using Rails:
 
 ```ruby
+require 'factory_bot'
+
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -124,6 +124,8 @@ If you're using Rails, add the following configuration to
 `rails_helper.rb`:
 
 ```ruby
+require 'factory_bot'
+
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
Following readme results in the code below

rails_helper.rb:
```ruby
# This file is copied to spec/ when you run 'rails generate rspec:install'
require 'spec_helper'
ENV['RAILS_ENV'] ||= 'test'
require_relative '../config/environment'
# Prevent database truncation if the environment is production
abort('The Rails environment is running in production mode!') if Rails.env.production?
require 'rspec/rails'
# Add additional requires below this line. Rails is not loaded until this point!
require 'support/factory_bot'

...
```

support/factory_bot.rb:
```ruby
RSpec.configure do |config|
  config.include FactoryBot::Syntax::Methods
end
```

This results in an error:

```ruby
uninitialized constant `FactoryBot`
```

because factory_bot gem has not bene loaded yet. So I required it in factory_bot.rb to fix the issue.

support/factory_bot.rb:
```ruby
require 'factory_bot_rails'

RSpec.configure do |config|
  config.include FactoryBot::Syntax::Methods
end
```

This PR updates the instructions in Getting-Started accordingly