### PR TITLE
Only run this workflow if the README has been updated

### DIFF
--- a/.github/workflows/dynamic-readme.yml
+++ b/.github/workflows/dynamic-readme.yml
@@ -1,9 +1,11 @@
 name: update-templates
 
-on: 
+on:
   push:
     branches:
       - main
+    paths:
+      - README.md
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ software, and may be redistributed under the terms specified in the
 [LICENSE]: https://github.com/thoughtbot/factory_bot/blob/main/LICENSE
 
 <!-- START /templates/footer.md -->
+
 <!-- END /templates/footer.md -->
 
 [ci-image]: https://github.com/thoughtbot/factory_bot/actions/workflows/build.yml/badge.svg?branch=main


### PR DESCRIPTION
In the templates repo, the update-templates workflow has been updated to accommodate repositories that have main branch rules (like factory_bot). To generate the README dynamically, you’ll need to merge a PR with the README changes. That will trigger the GitHub workflow

The PR won’t be generated if the footer content does not have any differences from the template. The PR will only be opened if there’s an update to the footer snippet.

In this PR, we are limiting this workflow to be triggered only when README changes have been merged to main (where the snippet lives).