### PR TITLE
Add support for before build callback

### DIFF
--- a/lib/factory_bot/strategy/build.rb
+++ b/lib/factory_bot/strategy/build.rb
@@ -7,6 +7,7 @@ module FactoryBot
 
       def result(evaluation)
         evaluation.object.tap do |instance|
+          evaluation.notify(:before_build, instance)
           evaluation.notify(:after_build, instance)
         end
       end

--- a/lib/factory_bot/strategy/create.rb
+++ b/lib/factory_bot/strategy/create.rb
@@ -7,6 +7,7 @@ module FactoryBot
 
       def result(evaluation)
         evaluation.object.tap do |instance|
+          evaluation.notify(:before_build, instance)
           evaluation.notify(:after_build, instance)
           evaluation.notify(:before_create, instance)
           evaluation.create(instance)


### PR DESCRIPTION
Fixes https://github.com/thoughtbot/factory_bot/issues/1633

add support for `before(:build)` callback as requested in the issue

Tested the changes by adding the local gem to a project
![image](https://github.com/thoughtbot/factory_bot/assets/135416851/ad56ea34-b219-413d-a900-b4e762d002c5)
![image](https://github.com/thoughtbot/factory_bot/assets/135416851/bfc3abd7-ef03-4a13-872a-c1c5770c32e5)

I am honestly not sure how to add unit tests for the change, any help would be appreciated