### PR TITLE
Added a case for build_class to handle class names with underscores passed as a string

### DIFF
--- a/lib/factory_bot/factory.rb
+++ b/lib/factory_bot/factory.rb
@@ -22,6 +22,8 @@ module FactoryBot
     def build_class
       @build_class ||= if class_name.is_a? Class
         class_name
+      elsif class_name.to_s.safe_constantize
+        class_name.to_s.safe_constantize
       else
         class_name.to_s.camelize.constantize
       end

--- a/spec/factory_bot/factory_spec.rb
+++ b/spec/factory_bot/factory_spec.rb
@@ -215,6 +215,15 @@ describe FactoryBot::Factory, "with a string for a name" do
 
     expect(factory.name).to eq name
   end
+
+  it "sets build_class correctly with a class with an underscore" do
+    name = :settings
+    define_class("Admin_Settings_1")
+    settings_class = Admin_Settings_1
+    factory = FactoryBot::Factory.new(name, class: "Admin_Settings_1")
+
+    expect(factory.build_class).to eq settings_class
+  end
 end
 
 describe FactoryBot::Factory, "for namespaced class" do


### PR DESCRIPTION
Fixes https://github.com/thoughtbot/factory_bot/issues/1588

Fixes a bug where a class defined with underscores, ex. `factory :customs_declaration_nl_ddu_1, class: "Customs::Declarations::NL::DDU_1_0"` strips out the underscores and then raises an NameError.