### PR TITLE
Fix build_stubbed timestamps being different

### DIFF
--- a/lib/factory_bot/strategy/stub.rb
+++ b/lib/factory_bot/strategy/stub.rb
@@ -102,12 +102,14 @@ module FactoryBot
       end
 
       def set_timestamps(result_instance)
+        timestamp = Time.current
+
         if missing_created_at?(result_instance)
-          result_instance.created_at = Time.current
+          result_instance.created_at = timestamp
         end
 
         if missing_updated_at?(result_instance)
-          result_instance.updated_at = Time.current
+          result_instance.updated_at = timestamp
         end
       end
 

--- a/spec/acceptance/stub_spec.rb
+++ b/spec/acceptance/stub_spec.rb
@@ -29,6 +29,24 @@ describe "a stubbed instance" do
   end
 end
 
+describe "a stubbed instance with timestamps" do
+  include FactoryBot::Syntax::Methods
+
+  before do
+    define_model("ModelWithTimestamps", created_at: :datetime, updated_at: :datetime)
+
+    FactoryBot.define do
+      factory :model_with_timestamps
+    end
+  end
+
+  subject { build_stubbed(:model_with_timestamps) }
+
+  it "assigns the exact same datetime" do
+    expect(subject.created_at).to eq(subject.updated_at)
+  end
+end
+
 describe "a stubbed instance overriding strategy" do
   include FactoryBot::Syntax::Methods
 


### PR DESCRIPTION
### Description

Ensures build_stubbed generates a record with equal created_at and updated_at.

### Current behavior

Calling `.build_stubbed` on factories with entities that have created_at and updated_at assigns a slightly different time for each one of then because the code calls `Time.current` twice.

### Expected behavior

I think the expected behavior should be for them to be exact the same.

### Concerns

There are two concerns with the current solution:

1. We would be calling `Time.current` even if created_at and updated_at don't exist on the entity;
2. ~~It might be a problem that we're assigning the same object to both timestamps, should we `dup` updated_at?~~ (edit: dates are immutable, never mind :grimacing: :face_with_peeking_eye:).

I preferred to ask if these are valid concerns before investigating how to solve them.