### PR TITLE
Allow the initial value of a sequence to be lazy loaded

### DIFF
--- a/docs/src/ref/sequence.md
+++ b/docs/src/ref/sequence.md
@@ -13,7 +13,7 @@ The `sequence` method takes a name, optional arguments, and a block. The name
 is expected to be a Symbol.
 
 The supported arguments are a number representing the starting value (default:
-`1`), and `:aliases` (default `[]`). The starting value must respond to `#next`.
+`1`), `:aliases` (default `[]`), and `lazy` (default:`nil`). The starting value must respond to `#next`.
 
 The block takes a value as an argument, and returns a result.
 

--- a/docs/src/sequences/initial-value.md
+++ b/docs/src/sequences/initial-value.md
@@ -8,3 +8,19 @@ factory :user do
   sequence(:email, 1000) { |n| "person#{n}@example.com" }
 end
 ```
+
+The initial value can also be lazily set by passing a Proc object via the `lazy` option. This Proc will be called the first time the `sequence.next` is called.
+
+```ruby
+factory :user do
+  sequence(:email, lazy: -> { Person.count }) { |n| "person#{n}@example.com" }
+end
+```
+
+If an initial value is supplied both as an argument and with lazy, then the lazy proc will be used.
+
+```ruby
+sequence(:item), 12, lazy: -> { "A" })
+
+generate(:item) # "A"
+```

--- a/spec/acceptance/sequence_resetting_spec.rb
+++ b/spec/acceptance/sequence_resetting_spec.rb
@@ -5,20 +5,24 @@ describe "FactoryBot.rewind_sequences" do
     FactoryBot.define do
       sequence(:email) { |n| "somebody#{n}@example.com" }
       sequence(:name, %w[Joe Josh].to_enum)
+      sequence(:age, lazy: -> { 21 })
     end
 
     2.times do
       generate(:email)
       generate(:name)
+      generate(:age)
     end
 
     FactoryBot.rewind_sequences
 
     email = generate(:email)
     name = generate(:name)
+    age = generate(:age)
 
     expect(email).to eq "somebody1@example.com"
     expect(name).to eq "Joe"
+    expect(age).to eq 21
   end
 
   it "resets inline sequences back to their starting value" do

--- a/spec/acceptance/sequence_spec.rb
+++ b/spec/acceptance/sequence_spec.rb
@@ -57,6 +57,24 @@ describe "sequences" do
     expect(third_value).to eq "called-c"
   end
 
+  it "generates sequences after lazy loading an initial value" do
+    loaded = false
+
+    FactoryBot.define do
+      sequence :count, lazy: -> { loaded = true; "d" }
+    end
+
+    expect(loaded).to be false
+
+    first_value = generate(:count)
+    another_value = generate(:count)
+
+    expect(loaded).to be true
+
+    expect(first_value).to eq "d"
+    expect(another_value).to eq "e"
+  end
+
   it "generates few values of the sequence" do
     FactoryBot.define do
       sequence :email do |n|

--- a/spec/factory_bot/sequence_spec.rb
+++ b/spec/factory_bot/sequence_spec.rb
@@ -74,10 +74,44 @@ describe FactoryBot::Sequence do
     it_behaves_like "a sequence", first_value: "=3", second_value: "=4"
   end
 
+  describe "a sequence with lazy initial value and a block" do
+    subject do
+      FactoryBot::Sequence.new(:test, lazy: -> { "J" }) do |n|
+        "=#{n}"
+      end
+    end
+
+    it_behaves_like "a sequence", first_value: "=J", second_value: "=K"
+  end
+
+  describe "a sequence with value and a lazy initial value and a block" do
+    it "uses the lazy value as the initial value" do
+      sequence = FactoryBot::Sequence.new(:test, 3, lazy: -> { "x" }) do |n|
+        "=#{n}"
+      end
+
+      expect(sequence.next).to eq "=x"
+    end
+  end
+
+  describe "a sequence with lazy initial value that is not a proc" do
+    it "raises an error" do
+      expect { FactoryBot::Sequence.new(:test, lazy: 1) }.to raise_error(ArgumentError, "The 'lazy' argument value must be a Proc")
+    end
+  end
+
   describe "a basic sequence without a block" do
     subject { FactoryBot::Sequence.new(:name) }
 
     it_behaves_like "a sequence", first_value: 1, second_value: 2
+  end
+
+  describe "a sequence with lazy initial value without a block" do
+    subject do
+      FactoryBot::Sequence.new(:test, lazy: -> { 3 })
+    end
+
+    it_behaves_like "a sequence", first_value: 3, second_value: 4
   end
 
   describe "a custom sequence without a block" do
@@ -107,6 +141,14 @@ describe FactoryBot::Sequence do
     scope = double("scope", foo: "attribute")
 
     expect(sequence.next(scope)).to eq "=Aattribute"
+  end
+
+  it "a custom lazy sequence and scope increments within the correct scope" do
+    sequence = FactoryBot::Sequence.new(:name, lazy: -> { "A" }) { |n| "=#{n}#{foo}" }
+    scope = double("scope", foo: "attribute")
+
+    expect(sequence.next(scope)).to eq "=Aattribute"
+    expect(sequence.next(scope)).to eq "=Battribute"
   end
 
   it "a custom sequence and scope increments within the correct scope when incrementing" do


### PR DESCRIPTION
## Allow the initial value of a sequence to be evaluated on first use

In order to be able to use factory_bot to generate seeds for a database where the database might not have the schema set up yet or might have data already populated, it is useful to be able to defer assigning the initial value to a sequence until it is needed. 
Currently, factory_bot needs the initial value of the sequence to be defined when the factory file is loaded.

This lazy loading behaviour has been very handy for use when we need to create objects that have unique sequential id in formats specific to third party systems. We can use these factories in our development and CI environments without having to think about which values have already been used.

I found https://github.com/thoughtbot/factory_bot/pull/1434 and thought it was worth submitting this PR.

This PR adds a `lazy` option to the sequence method, where a Proc can be passed that will be called the first time as sequence is used, to set the initial value. 
After the initial `#next` call, these sequences behave exactly the same as any other factory_bot sequence.
Rewinding a lazy sequence uses the originally calculated value, it does not re-call the lazy Proc object.

Example usage:

```ruby
FactoryBot.define do
  sequence(:email, lazy: -> {  User.count + 1 }) { "user#{_1}@example.com" }
end

generate(:email) # user42@example.com if you already have 41 users
```

The way we initially solved this was to pass in a `LazyEnumeratorAdapter` instance (as defined in the PR) as the initial value, eg 
`sequence(:name, LazyEnumeratorAdaper.new {  User.count }) { "User#{_1}" }`. 

This can be done without any changes to factory_bot, but I thought this functionality might be useful to others. 

I'm happy to remove the `lazy` option and instead do detection on whether the initial arg is a Proc object, but I like that the `lazy` arg name sets expectations about when this will be evaluated. Although it does result in the need for a whole extra class.