### PR TITLE
Add a security workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,22 @@ jobs:
             rails: "7.1"
           - ruby: jruby-9.4
             rails: main
+          - ruby: 2.6
+            rails: main
+          - ruby: jruby-9.2.16.0
+            rails: main
+          - ruby: 3.0
+            rails: "5.0"
+          - ruby: 3.0
+            rails: "5.1"
+          - ruby: 3.0
+            rails: "5.2"
+          - ruby: truffleruby
+            rails: "5.0"
+          - ruby: truffleruby
+            rails: "5.1"
+          - ruby: truffleruby
+            rails: "5.2"
 
     runs-on: 'ubuntu-latest'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,10 +47,10 @@ jobs:
     name: Run standard
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.0"
       - name: Setup project
         run: bundle install
       - name: Run test

--- a/.github/workflows/dynamic-security.yml
+++ b/.github/workflows/dynamic-security.yml
@@ -1,0 +1,19 @@
+name: update-security
+
+on:
+  push:
+    paths:
+      - SECURITY.md
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update-security:
+    permissions:
+      contents: write
+      pull-requests: write
+      pages: write
+    uses: thoughtbot/templates/.github/workflows/dynamic-security.yaml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,8 @@
+⚠️ **Warning:** You are viewing this file on the `master` branch, which is no
+longer used and does not receive any updates. Please view [this file on the
+`main` branch](https://github.com/thoughtbot/factory_bot/blob/main/CODE_OF_CONDUCT.md)
+for up-to-date information.
+
 # Code of conduct
 
 By participating in this project, you agree to abide by the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,8 @@
+⚠️ **Warning:** You are viewing this file on the `master` branch, which is no
+longer used and does not receive any updates. Please view [this file on the
+`main` branch](https://github.com/thoughtbot/factory_bot/blob/main/CONTRIBUTING.md)
+for up-to-date information.
+
 # Contributing to Factory Bot
 
 We love pull requests from everyone. By participating in this project, you

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -648,7 +648,7 @@ post = build(:post, author: eunji)
 
 ### Build strategies
 
-In factory\_bot 5, associations default to using the same build strategy as
+Starting with factory\_bot 5, associations default to using the same build strategy as
 their parent object:
 
 ```ruby

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,18 +1,7 @@
-**Deprecated**
-
-See our extensive reference, guides, and cookbook in [the factory_bot book][].
-
-For information on integrations with third party libraries, such as RSpec or
-Rails, see [the factory_bot wiki][].
-
- We also have [a detailed introductory video][], available for free on Upcase.
-
-[a detailed introductory video]: https://upcase.com/videos/factory-bot?utm_source=github&utm_medium=open-source&utm_campaign=factory-girl
-[the factory_bot book]: https://thoughtbot.github.io/factory_bot
-[the factory_bot wiki]: https://github.com/thoughtbot/factory_bot/wiki
-
-This document is deprecated and preserved for historical use. It may disappear
-at any time.
+⚠️ **Warning:** You are viewing this file on the `master` branch, which is no
+longer used and does not receive any updates. Please view [this file on the
+`main` branch](https://github.com/thoughtbot/factory_bot/blob/main/GETTING_STARTED.md)
+for up-to-date information.
 
 Getting Started
 ===============

--- a/NAME.md
+++ b/NAME.md
@@ -1,3 +1,8 @@
+⚠️ **Warning:** You are viewing this file on the `master` branch, which is no
+longer used and does not receive any updates. Please view [this file on the
+`main` branch](https://github.com/thoughtbot/factory_bot/blob/main/NAME.md) for
+up-to-date information.
+
 # Project Naming History
 
 ## Factory Girl

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+⚠️ **Warning:** You are viewing this file on the `master` branch, which is no
+longer used and does not receive any updates. Please view [this file on the
+`main` branch](https://github.com/thoughtbot/factory_bot/blob/main/NEWS.md) for
+up-to-date information.
+
 # News
 
 ## 6.4.6 (January 30, 2023)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+⚠️ **Warning:** You are viewing this file on the `master` branch, which is no
+longer used and does not receive any updates. Please view [this file on the
+`main` branch](https://github.com/thoughtbot/factory_bot/tree/main#readme) for
+up-to-date information.
+
 # factory_bot [![Build Status][ci-image]][ci] [![Code Climate][grade-image]][grade] [![Gem Version][version-image]][version]
 
 factory_bot is a fixtures replacement with a straightforward definition syntax, support for multiple build strategies (saved instances, unsaved instances, attribute hashes, and stubbed objects), and support for multiple factories for the same class (user, admin_user, and so on), including factory inheritance.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,3 +1,8 @@
+⚠️ **Warning:** You are viewing this file on the `master` branch, which is no
+longer used and does not receive any updates. Please view [this file on the
+`main` branch](https://github.com/thoughtbot/factory_bot/blob/main/RELEASING.md)
+for up-to-date information.
+
 # Releasing
 
 1. Update version file accordingly and run `bundle install` to update the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,2 @@
+<!-- START /templates/security.md -->
+<!-- END /templates/security.md -->

--- a/lib/factory_bot/find_definitions.rb
+++ b/lib/factory_bot/find_definitions.rb
@@ -13,12 +13,18 @@ module FactoryBot
     absolute_definition_file_paths = definition_file_paths.map { |path| File.expand_path(path) }
 
     absolute_definition_file_paths.uniq.each do |path|
-      load("#{path}.rb") if File.exist?("#{path}.rb")
+      load_file_or_directory(path)
+    end
+  end
 
-      if File.directory? path
-        Dir[File.join(path, "**", "*.rb")].sort.each do |file|
-          load file
-        end
+  def self.load_file_or_directory(path)
+    load("#{path}.rb") if File.exist?("#{path}.rb")
+
+    load path if File.file? path
+
+    if File.directory? path
+      Dir[File.join(path, "**", "*.rb")].sort.each do |file|
+        load file
       end
     end
   end

--- a/spec/factory_bot/find_definitions_spec.rb
+++ b/spec/factory_bot/find_definitions_spec.rb
@@ -111,4 +111,45 @@ describe "definition loading" do
       end
     end
   end
+
+  describe "definition_file_paths" do
+    in_directory_with_files "spec/my_factories/factory_one.rb", "spec/my_factories/factory_two.rb"
+
+    before { allow(FactoryBot).to receive(:load) }
+
+    it "supports files without extension" do
+      old_paths = FactoryBot.definition_file_paths
+      FactoryBot.definition_file_paths = ["spec/my_factories/factory_one"]
+
+      FactoryBot.find_definitions
+
+      expect(FactoryBot).to have_received(:load).once.with(File.expand_path("spec/my_factories/factory_one.rb"))
+    ensure
+      FactoryBot.definition_file_paths = old_paths
+    end
+
+    it "supports directories" do
+      old_paths = FactoryBot.definition_file_paths
+      FactoryBot.definition_file_paths = ["spec/my_factories"]
+
+      FactoryBot.find_definitions
+
+      expect(FactoryBot).to have_received(:load).twice
+      expect(FactoryBot).to have_received(:load).with(File.expand_path("spec/my_factories/factory_one.rb"))
+      expect(FactoryBot).to have_received(:load).with(File.expand_path("spec/my_factories/factory_two.rb"))
+    ensure
+      FactoryBot.definition_file_paths = old_paths
+    end
+
+    it "supports files with extension" do
+      old_paths = FactoryBot.definition_file_paths
+      FactoryBot.definition_file_paths = ["spec/my_factories/factory_one.rb"]
+
+      FactoryBot.find_definitions
+
+      expect(FactoryBot).to have_received(:load).once.with(File.expand_path("spec/my_factories/factory_one.rb"))
+    ensure
+      FactoryBot.definition_file_paths = old_paths
+    end
+  end
 end


### PR DESCRIPTION
We’re committed to protecting our systems, information, and our client’s information.

One of the ways we can enforce that in our OS projects is to provide a way to report a Vulnerability.

Add a dynamic security workflow that will automatically create PRs to update our Security policies in this repo. 