### PR TITLE
Bump the minimum required activesupport version to 6.1

### DIFF
--- a/factory_bot.gemspec
+++ b/factory_bot.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
     "changelog_uri" => "https://github.com/thoughtbot/factory_bot/blob/main/NEWS.md"
   }
 
-  s.add_dependency("activesupport", ">= 5.0.0")
+  s.add_dependency("activesupport", ">= 6.1.0")
 
   s.add_development_dependency("activerecord")
   s.add_development_dependency("appraisal")


### PR DESCRIPTION
They were dropped from CI in #1612. Also see #1614 and #1622.

Noticed while adding 7.2 to CI.