### PR TITLE
Fix the factory definition in traits documentation

### DIFF
--- a/docs/src/traits/using.md
+++ b/docs/src/traits/using.md
@@ -31,6 +31,11 @@ the "Building or Creating Multiple Records" section of this file.
 factory :user do
   name { "Friendly User" }
 
+  trait :active do
+    name { "John Doe" }
+    status { :active }
+  end
+
   trait :admin do
     admin { true }
   end


### PR DESCRIPTION
## What's in this MR?

The https://thoughtbot.github.io/factory_bot/traits/using.html page has a small typo.

The second code block uses the `active` trait, but it's not defined in the Factory.

This MR adds the missing trait.