### PR TITLE
Fix activesupport 7.2.1 compatibility

### DIFF
--- a/lib/factory_bot.rb
+++ b/lib/factory_bot.rb
@@ -4,6 +4,7 @@ require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/module/attribute_accessors"
 require "active_support/deprecation"
 require "active_support/notifications"
+require "active_support/inflector"
 
 require "factory_bot/internal"
 require "factory_bot/definition_hierarchy"

--- a/lib/factory_bot/factory.rb
+++ b/lib/factory_bot/factory.rb
@@ -1,5 +1,4 @@
 require "active_support/core_ext/hash/keys"
-require "active_support/inflector"
 
 module FactoryBot
   # @api private


### PR DESCRIPTION
Relates to: https://github.com/thoughtbot/factory_bot/issues/1690

The latest active_support gem breaks factory_bot due to a missing require of the active_support/inflector.