### PR TITLE
fix to used ruby 2.7

### DIFF
--- a/lib/factory_bot/definition_proxy.rb
+++ b/lib/factory_bot/definition_proxy.rb
@@ -88,6 +88,8 @@ module FactoryBot
     #   end
     #
     # are equivalent.
+
+    
     def method_missing(name, *args, &block) # rubocop:disable Style/MissingRespondToMissing
       association_options = args.first
 
@@ -119,8 +121,8 @@ module FactoryBot
     #   end
     #
     # Except that no globally available sequence will be defined.
-    def sequence(name, ...)
-      sequence = Sequence.new(name, ...)
+    def sequence(name, *args, &block)
+      sequence = Sequence.new(name, *args, &block)
       FactoryBot::Internal.register_inline_sequence(sequence)
       add_attribute(name) { increment_sequence(sequence) }
     end

--- a/lib/factory_bot/evaluator.rb
+++ b/lib/factory_bot/evaluator.rb
@@ -35,11 +35,11 @@ module FactoryBot
 
     attr_accessor :instance
 
-    def method_missing(method_name, ...)
+    def method_missing(method_name, *args, &block) # Correção: adicionados *args e &block
       if @instance.respond_to?(method_name)
-        @instance.send(method_name, ...)
+        @instance.send(method_name, *args, &block) # Correção: adicionados *args e &block
       else
-        SyntaxRunner.new.send(method_name, ...)
+        SyntaxRunner.new.send(method_name, *args, &block) # Correção: adicionados *args e &block
       end
     end
 

--- a/lib/factory_bot/syntax/default.rb
+++ b/lib/factory_bot/syntax/default.rb
@@ -25,8 +25,8 @@ module FactoryBot
           end
         end
 
-        def sequence(name, ...)
-          Internal.register_sequence(Sequence.new(name, ...))
+        def sequence(name, *args, &block)
+          register_sequence(Sequence.new(name, *args, &block))
         end
 
         def trait(name, &block)


### PR DESCRIPTION
## Description

Syntax error in factory_bot gem files when using Ruby 2.7.0.

## Reproduction Steps

1. Install Ruby 2.7.0.
2. Create a new Rails application.
3. Add the `factory_bot_rails` gem to the Gemfile.
4. Run `bundle install`.
5. Create a test file that uses `FactoryBot`.
6. Run the test with `rspec`.

## Expected Behavior

The test should run without errors.

## Actual Behavior

A syntax error occurs in `factory_bot` gem files, such as `evaluator.rb` and `definition_proxy.rb`, preventing the test from running. The error message points to lines of code using the `method_missing` and `sequence` methods.

## 1. File : `evaluator.rb`

### Correction:
Add the `*args` and `&block` parameters to the `method_missing` method definition

```ruby
def method_missing(method_name, *args, &block)
  if @instance.respond_to?(method_name)
    @instance.send(method_name, *args, &block)
  else
    SyntaxRunner.new.send(method_name, *args, &block) 
  end
end
```

## 2. File : `definition_proxy.rb`

### Correction:
The `method_missing` method definition is already correct. Change the  `sequence` method definition to:

```ruby
def sequence(name, *args, &block)
  sequence = Sequence.new(name, *args, &block)
  FactoryBot::Internal.register_inline_sequence(sequence)
  add_attribute(name) { increment_sequence(sequence) }
end
```

## 3. File : `default.rb`

### Correction:
Change the `sequence` method definition to::

```ruby
def sequence(name, *args, &block)
  register_sequence(Sequence.new(name, *args, &block))
end
```

The corrections involve adding the parameters `*args` and `&block` to the `method_missing` and `sequence` methods to ensure compatibility with Ruby 2.7.0 syntax.

## System Configuration

- **factory_bot_rails version:** 6.4.5
- **factory_bot version:** 6.4.5
- **rails version:** 6.0.0
- **ruby version:** 2.7.0
