### PR TITLE
Execute `FactoryBot.lint!` in database transactions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # News
 
+## Unreleased
+
+  * Changed: execute linting tests within ActiveRecord transactions when available
+
 ## 6.5.0 (September 6, 2024)
 
   * fix: issue 1621 broken links in ref/factory.md by @elasticspoon in https://github.com/thoughtbot/factory_bot/pull/1623

--- a/spec/acceptance/lint_spec.rb
+++ b/spec/acceptance/lint_spec.rb
@@ -26,6 +26,24 @@ describe "FactoryBot.lint" do
     }.to raise_error FactoryBot::InvalidFactoryError, error_message
   end
 
+  it "executes linting in an ActiveRecord::Base transaction" do
+    define_model "User", name: :string do
+      validates :name, uniqueness: true
+    end
+
+    define_model "AlwaysValid"
+
+    FactoryBot.define do
+      factory :user do
+        factory :admin_user
+      end
+
+      factory :always_valid
+    end
+
+    expect { FactoryBot.lint }.to_not raise_error
+  end
+
   it "does not raise when all factories are valid" do
     define_model "User", name: :string do
       validates :name, presence: true


### PR DESCRIPTION
Prior to this change `FactoryBot.lint!` execution can trigger sequential `FactoryBot.create` calls made within the same test (either Minitest `test` or RSpec `it` blocks).

This can result in linting violations for records that have database-level uniqueness constraints.

This commit introduces the private `Linter#in_transaction` method to wrap the executing block within an [ActiveRecord::Base.transaction][] block that concludes with raising an [ActiveRecord::Rollback][] error.

After this change, executions no longer contest with database-level uniqueness constraints.

[ActiveRecord::Base.transaction]: https://edgeapi.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html#method-i-transaction
[ActiveRecord::Rollback]: https://edgeapi.rubyonrails.org/classes/ActiveRecord/Rollback.html