### PR TITLE
Limit `push` builds to the `main` branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,8 @@
 name: Build
 on:
-  - push
-  - pull_request
+  pull_request:
+  push:
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
GitHub Actions has been running the tests and lint twice in Pull Requests: once following the `on push` rule, once following `on pull_request`.

<img width="1275" alt="image" src="https://github.com/user-attachments/assets/90351c48-4e1b-4bdc-b4c0-228499799a2c" />

This commit limits the `push` rule to the `main` branch.