### PR TITLE
Limit `push` builds to the `main` branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,12 @@
 name: Build
 on:
-  - push
-  - pull_request
+  pull_request:
+  push:
+    branches: [ main ]
 
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }}
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
GitHub Actions has been running the lint twice in Pull Requests: once following the `on push` trigger, once following `on pull_request`. This duplication is currently avoided when running tests by an `if` rule, which skips if the event isn't a push or the Pull Request doesn't come from a fork.

<img width="1282" alt="image" src="https://github.com/user-attachments/assets/8b9f21f3-6ad2-49f1-a3de-5be084b2bef9" />

This commit removes the `if` rule, and limits the `push` builds to the `main` branch. That will ensure that merged Pull Requests will trigger a build, and that any Pull Request activity will also trigger a build. Being a global rule for the whole build, `standard` will not run twice anymore.