### PR TITLE
Small update to "verbose linting" spec to allow for Ruby 3.4 backtrace changes

### DIFF
--- a/spec/acceptance/lint_spec.rb
+++ b/spec/acceptance/lint_spec.rb
@@ -211,7 +211,7 @@ describe "FactoryBot.lint" do
         FactoryBot.lint(verbose: true)
       }.to raise_error(
         FactoryBot::InvalidFactoryError,
-        %r{#{__FILE__}:\d*:in `save!'}
+        %r{#{__FILE__}:\d*:in ('InvalidThing#save!'|`save!')}
       )
     end
   end


### PR DESCRIPTION
Update for testing in Ruby 3.4

- file:   spec/acceptance/lint_spec.rb:188


THE PROBLEM THIS FIXES

Ruby 3.4 backtrace locations now include both the object and method names in the format:
 "<object_name>#<method_name>.

So a backtrace location with "...`save!`" in ruby 3.3, now becomes "... 'InvalidThing#save!'" in Ruby 3.4.


THE SOLUTION

The solution was to update the test regex to allow for either option:
  %r{#{__FILE__}:\d*:in ('InvalidThing#save!'|`save!')}