### PR TITLE
 Expanded trait error message to include list of defined traits.

### DIFF
--- a/spec/acceptance/enum_traits_spec.rb
+++ b/spec/acceptance/enum_traits_spec.rb
@@ -132,7 +132,7 @@ describe "enum traits" do
 
         Task.statuses.each_key do |trait_name|
           expect { FactoryBot.build(:task, trait_name) }.to raise_error(
-            KeyError, "Trait not registered: \"#{trait_name}\""
+            KeyError, /Trait not registered: "#{trait_name}"/
           )
         end
 


### PR DESCRIPTION
## Summary

Fixes: #1727

Expands trait error messages to include a list of the factory's defined traits.

## Included

The message now includes: `Registered traits: [:trait_1, :trait_2, :trait_3]`

## Example

### Internal Definition Call
factory: :user
defined traits: :accessible_trait
error: internal reference to a missing trait :inaccessible_trait

Error Message: 
  `Trait not registered: "inaccessible_trait". Registered traits: [:accessible_trait]. Referenced within "user" definition`

### User Trait Specified
factory: :user
defined traits: :accessible_trait
error: user calls an non-existent trait with `build(:user, :missing_trait)`

Error Message: 
  `Trait not registered: "missing_trait". Registered traits: [:accessible_trait]`

## Note

When the error is because a missing trait was called from within a factory's definition, the message still includes the original:
`Referenced within "user" definition`


## Changes

- lib/factory_bot/definition.rb 
    - error-rescue moved from :base_traits to :trait_by_name to catch both definition and calling errors.

- spec/acceptance/enum_traits_spec.rb 
    - updated specs for new error message layout.

- spec/acceptance/traits_spec.rb updated specs for new error message layout. added new use-case tests with:
    - no registered traits
    - single registered trait
    - multiple registered traits
    - multiple registered traits through multiple inheritance

