### PR TITLE
Add ruby-lsp extensions to `Useful Tools` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Useful Tools
 ------------
 
 * [FactoryTrace](https://github.com/djezzzl/factory_trace) - helps to find unused factories and traits.
+* [ruby-lsp-factory_bot](https://github.com/donny741/ruby-lsp-factory_bot) / [ruby-lsp-rails-factory-bot](https://github.com/johansenja/ruby-lsp-rails-factory-bot) - integration with [ruby-lsp](https://github.com/Shopify/ruby-lsp) to provide intellisense
 
 Contributing
 ------------


### PR DESCRIPTION
Full disclosure: one of these is my own gem :) but the other, I have no connexion with!

https://github.com/donny741/ruby-lsp-factory_bot
https://github.com/johansenja/ruby-lsp-rails-factory-bot