### PR TITLE
Fix definition_file_paths comment

### DIFF
--- a/lib/factory_bot/find_definitions.rb
+++ b/lib/factory_bot/find_definitions.rb
@@ -2,8 +2,9 @@ module FactoryBot
   class << self
     # An Array of strings specifying locations that should be searched for
     # factory definitions. By default, factory_bot will attempt to require
-    # "factories", "test/factories" and "spec/factories". Only the first
-    # existing file will be loaded.
+    # "factories.rb", "factories/**/*.rb",
+    # "test/factories.rb", "test/factories/**.rb",
+    # "spec/factories.rb", and "spec/factories/**.rb".
     attr_accessor :definition_file_paths
   end
 


### PR DESCRIPTION
The comment for `definition_file_paths` is incorrect; all matching factory paths will be loaded. This is also documented correctly at https://thoughtbot.github.io/factory_bot/ref/find_definitions.html