### PR TITLE
BUGFIX: Refactored sequences to ensure cloned traits use parent sequences.

### DIFF
--- a/lib/factory_bot/definition_proxy.rb
+++ b/lib/factory_bot/definition_proxy.rb
@@ -120,9 +120,16 @@ module FactoryBot
     #
     # Except that no globally available sequence will be defined.
     def sequence(name, ...)
-      sequence = Sequence.new(name, ...)
-      FactoryBot::Internal.register_inline_sequence(sequence)
-      add_attribute(name) { increment_sequence(sequence) }
+      new_sequence = Sequence.new(name, ...)
+      registered_sequence = __fetch_or_register_sequence(new_sequence)
+      # FactoryBot::Internal.register_inline_sequence(sequence)
+      add_attribute(name) { increment_sequence(registered_sequence) }
+
+      # unless sequence = FactoryBot::Internal.inline_sequences.select { |s| s.name == name }.first
+      #   sequence = Sequence.new(name, ...)
+      #   FactoryBot::Internal.register_inline_sequence(sequence)
+      # end
+      # add_attribute(name) { increment_sequence(sequence) }
     end
 
     # Adds an attribute that builds an association. The associated instance will
@@ -251,6 +258,20 @@ module FactoryBot
 
     def __valid_association_options?(options)
       options.respond_to?(:has_key?) && options.has_key?(:factory)
+    end
+
+    ##
+    # If the sequence has aready been registered by a parent, return that one,
+    # otherwise register and return the given sequence
+    #
+    def __fetch_or_register_sequence(sequence)
+      FactoryBot::Internal.inline_sequences
+        .each do |registered_sequence|
+        return registered_sequence if registered_sequence.matches?(sequence)
+      end
+
+      FactoryBot::Internal.register_inline_sequence(sequence)
+      sequence
     end
   end
 end

--- a/lib/factory_bot/sequence.rb
+++ b/lib/factory_bot/sequence.rb
@@ -38,6 +38,17 @@ module FactoryBot
       @value.rewind
     end
 
+    def matches?(test_sequence)
+      return false unless name == test_sequence.name
+      return false unless proc.source_location == test_sequence.proc.source_location
+
+      proc.parameters == test_sequence.proc.parameters
+    end
+
+    protected
+
+    attr_reader :proc
+
     private
 
     def value

--- a/spec/acceptance/sequence_context_spec.rb
+++ b/spec/acceptance/sequence_context_spec.rb
@@ -47,4 +47,107 @@ describe "sequences are evaluated in the correct context" do
     end
     expect(FactoryBot.build(:sequence_referencing_attribute_directly).id).to eq "aw yeah1"
   end
+
+  context "with inherited factories" do
+    it "uses the parent's sequenced attribute" do
+      FactoryBot.define do
+        factory :parent, class: User do
+          sequence(:id) { |n| "#{awesome}#{n}" }
+          factory :child, class: User
+        end
+      end
+
+      parents = FactoryBot.build_list(:parent, 3)
+      expect(parents[0].id).to eq "aw yeah1"
+      expect(parents[1].id).to eq "aw yeah2"
+      expect(parents[2].id).to eq "aw yeah3"
+
+      children = FactoryBot.build_list(:child, 3)
+      expect(children[0].id).to eq "aw yeah4"
+      expect(children[1].id).to eq "aw yeah5"
+      expect(children[2].id).to eq "aw yeah6"
+    end
+
+    it "invokes the parent's sequenced trait from a child's trait" do
+      FactoryBot.define do
+        factory :parent, class: User do
+          trait :with_sequenced_id do
+            sequence(:id) { |n| "#{awesome}#{n}" }
+          end
+
+          factory :child, class: User
+        end
+      end
+
+      parents = FactoryBot.build_list(:parent, 3, :with_sequenced_id)
+      expect(parents[0].id).to eq "aw yeah1"
+      expect(parents[1].id).to eq "aw yeah2"
+      expect(parents[2].id).to eq "aw yeah3"
+
+      children = FactoryBot.build_list(:child, 3, :with_sequenced_id)
+      expect(children[0].id).to eq "aw yeah4"
+      expect(children[1].id).to eq "aw yeah5"
+      expect(children[2].id).to eq "aw yeah6"
+    end
+
+    it "redefines a child's sequence" do
+      FactoryBot.define do
+        factory :parent, class: User do
+          sequence(:id) { |n| "#{awesome}#{n}" }
+
+          factory :child, class: User do
+            sequence(:id) { |n| "#{awesome}#{n}" }
+          end
+        end
+      end
+
+      parents = FactoryBot.build_list(:parent, 3)
+      expect(parents[0].id).to eq "aw yeah1"
+      expect(parents[1].id).to eq "aw yeah2"
+      expect(parents[2].id).to eq "aw yeah3"
+
+      children = FactoryBot.build_list(:child, 3)
+      expect(children[0].id).to eq "aw yeah1"
+      expect(children[1].id).to eq "aw yeah2"
+      expect(children[2].id).to eq "aw yeah3"
+    end
+
+    it "maintains context seperation" do
+      FactoryBot.define do
+        sequence(:id) { |n| "global_#{n}" }
+
+        factory :parent, class: User do
+          sequence(:id) { |n| "parent_#{n}" }
+
+          factory :child, class: User do
+            sequence(:id) { |n| "child_#{n}" }
+          end
+        end
+
+        factory :sibling, class: User do
+          sequence(:id) { |n| "sibling_#{n}" }
+        end
+      end
+
+      globals = [FactoryBot.generate(:id), FactoryBot.generate(:id), FactoryBot.generate(:id)]
+      expect(globals[0]).to eq "global_1"
+      expect(globals[1]).to eq "global_2"
+      expect(globals[2]).to eq "global_3"
+
+      parents = FactoryBot.build_list(:parent, 3)
+      expect(parents[0].id).to eq "parent_1"
+      expect(parents[1].id).to eq "parent_2"
+      expect(parents[2].id).to eq "parent_3"
+
+      children = FactoryBot.build_list(:child, 3)
+      expect(children[0].id).to eq "child_1"
+      expect(children[1].id).to eq "child_2"
+      expect(children[2].id).to eq "child_3"
+
+      siblings = FactoryBot.build_list(:sibling, 3)
+      expect(siblings[0].id).to eq "sibling_1"
+      expect(siblings[1].id).to eq "sibling_2"
+      expect(siblings[2].id).to eq "sibling_3"
+    end
+  end
 end


### PR DESCRIPTION
Fixes: #1738 

THE ISSUE
-----------

Child factories clone parent traits to ensure they are executes in the correct context. 
This means that they are also registering a new version of the parent's sequence.


THE SOLUTION
----------------

When registering a child sequence, check if it's already registered by the parent and, if so, use the parent's sequence.


CHANGES
----------

Update to ensure child factories do not register their own version of a paren't factory.

- added :matches?(<other_sequence>) to Sequence class
- updated DefinitionProxy to ensure registered sequences are unique

Added test  to ensure:
- parent direct sequences are used by child
- sequences within parent traits are used by child
- children can re-define a new sequence with the same name
- Global, factory & inherited factories with sequences of the same name, all maintain their own context.

