### PR TITLE
FEATURE: Before(:all) and after(:all) callbacks added

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -81,6 +81,7 @@
   - [Multiple callbacks](callbacks/multiple-callbacks.md)
   - [Global callbacks](callbacks/global-callbacks.md)
   - [Symbol#to_proc](callbacks/symbol-to_proc.md)
+  - [Callback order](callbacks/callback_order.md)
 - [Modifying factories](modifying-factories/summary.md)
 - [Linting Factories](linting-factories/summary.md)
 - [Custom Construction](custom-construction/summary.md)

--- a/docs/src/callbacks/callback_order.md
+++ b/docs/src/callbacks/callback_order.md
@@ -1,0 +1,101 @@
+# Callback Order
+
+When a callback event like `after_build` or `before_all` is triggered, all callbacks for that event are excuted in the following order:
+
+1. Global callbacks.
+2. Inherited callbacks.
+3. Factory callbacks.
+4. Trait callbacks (in the order requested).
+
+## A simple factory example:
+
+```ruby
+FactoryBot.define do
+  before(:all) { puts "Global before(:all)" }
+  after(:all) { puts "Global after(:all)" }
+
+  factory :user do
+    before(:all) { puts "User before(:all)" }
+    after(:all) { puts "User after(:all)" }
+    after(:build) { puts "User after(:build)"
+    
+    trait :trait_a do
+      after(:build) { puts "Trait-A after(:build)" 
+    end
+    
+    trait :trait_b do 
+      after(:build) { puts "Trait-B after(:build)" }
+    end
+  end
+end
+
+build(:user, :trait_b, :trait_a) 
+
+# Result:
+#
+# 1. "Global before(:all)"
+# 2. "User before(:all)"
+# 3. "User after(:build)"
+# 4. "Trait-B after(:build)"
+# 5. "Trait-A after(:build)"
+# 6. "Global after(:all)"
+# 7. "User after(:all)"
+
+```
+
+
+## An inherited factory example:
+
+```ruby
+FactoryBot.define do
+  before(:all) { puts "Global before(:all)" }
+  after(:build) { puts "Global after(:build)" }
+  after(:all) { puts "Global after(:all)" }
+
+  factory :parent do
+    before(:all) { puts "Parent before(:all)" }
+    after(:all) { puts "Parent after(:all)" }
+    after(:build) { puts "Parent after(:build)" }
+    
+    trait :trait_a do 
+      after(:build) { puts "Trait-A after(:build)" }
+    end
+
+    factory :child do
+      before(:all) { puts "Child before(:all)" }
+      after(:build) { puts "Child after(:build)" }
+      after(:all) { puts "Child after(:all)" }
+
+      trait :trait_b do
+        after(:build) { puts "Trait-B after(:build)" }
+        after(:all) { puts "Trait-B after(:all)" }
+      end
+
+      trait :trait_c do
+        after(:build) { puts "Trait-C after(:build)" }
+        before(:all) { puts "Trait-C before(:all)" }
+      end
+    end
+  end
+end
+
+build(:child, :trait_c, :trait_a, :trait_b) 
+
+# Result:
+#
+# 1. "Global before(:all)"
+# 2. "Parent before(:all)"
+# 3. "Child before(:all)"
+# 4. "Trait-C before(:all)"
+# 5. "Global after(:build)"
+# 6. "Parent after(:build)"
+# 7. "Child after(:build)"
+# 8. "Trait-C after(:build)"
+# 9. "Trait-A after(:build)"
+# 10. "Trait-B after(:build)"
+# 11. "Global after(:all)"
+# 12. "Parent after(:all)"
+# 13. "Child after(:all)"
+# 14. "Trait-B after(:all)"
+
+```

--- a/docs/src/callbacks/summary.md
+++ b/docs/src/callbacks/summary.md
@@ -12,7 +12,7 @@ factory\_bot makes six callbacks available:
 |after(:stub)   |called after a factory is stubbed (via `FactoryBot.build_stubbed`)|
 
 
-## Examples:
+## Examples
 
 ### Calling an object's own method after building.
 

--- a/docs/src/callbacks/summary.md
+++ b/docs/src/callbacks/summary.md
@@ -1,19 +1,44 @@
 # Callbacks
 
-factory\_bot makes four callbacks available:
+factory\_bot makes six callbacks available:
 
-* after(:build)   - called after a factory is built   (via `FactoryBot.build`, `FactoryBot.create`)
-* before(:create) - called before a factory is saved  (via `FactoryBot.create`)
-* after(:create)  - called after a factory is saved   (via `FactoryBot.create`)
-* after(:stub)    - called after a factory is stubbed (via `FactoryBot.build_stubbed`)
+|Callback|Timing|
+|---|---|
+|before(:all)   |called before a factory begins generating the object.|
+|after(:all)    |called after a factory has generated the object.|
+|after(:build)  |called after a factory is built (via `FactoryBot.build`, `FactoryBot.create`)|
+|before(:create)|called before a factory is saved (via `FactoryBot.create`)|
+|after(:create) |called after a factory is saved (via `FactoryBot.create`)|
+|after(:stub)   |called after a factory is stubbed (via `FactoryBot.build_stubbed`)|
 
-Examples:
+
+## Examples:
+
+### Calling an object's own method after building.
 
 ```ruby
-# Define a factory that calls the generate_hashed_password method after the user factory is built
+## 
+# Define a factory that calls the generate_hashed_password method
+# after the user factory is built.
+#
+# Note that you'll have an instance of the object in the block
+#
 factory :user do
   after(:build) { |user, context| generate_hashed_password(user) }
 end
 ```
 
-Note that you'll have an instance of the object in the block.
+### Skipping an object's own :after_create callback
+
+```ruby
+##
+# Disable a model's own :after_create callback that sends an email 
+# on creation, then re-enable it afterwards
+#
+factory :user do
+  before(:all){ User.skip_callback(:create, :after, :send_welcome_email) }
+  after(:all){ User.set_callback(:create, :after, :send_welcome_email) }
+end
+```
+
+

--- a/docs/src/callbacks/summary.md
+++ b/docs/src/callbacks/summary.md
@@ -40,5 +40,3 @@ factory :user do
   after(:all){ User.set_callback(:create, :after, :send_welcome_email) }
 end
 ```
-
-

--- a/docs/src/callbacks/summary.md
+++ b/docs/src/callbacks/summary.md
@@ -2,14 +2,14 @@
 
 factory\_bot makes six callbacks available:
 
-|Callback|Timing|
-|---|---|
-|before(:all)   |called before a factory begins generating the object.|
-|after(:all)    |called after a factory has generated the object.|
-|after(:build)  |called after a factory is built (via `FactoryBot.build`, `FactoryBot.create`)|
-|before(:create)|called before a factory is saved (via `FactoryBot.create`)|
-|after(:create) |called after a factory is saved (via `FactoryBot.create`)|
-|after(:stub)   |called after a factory is stubbed (via `FactoryBot.build_stubbed`)|
+| Callback        | Timing                                                                                                                    |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| before(:all)    | called before a factory constructs an object (via `FactoryBot.build`, `FactoryBot.create`, or `FactoryBot.build_stubbed`) |
+| after(:build)   | called after a factory builds an object (via `FactoryBot.build` or `FactoryBot.create`)                                   |
+| before(:create) | called before a factory saves an object (via `FactoryBot.create`)                                                         |
+| after(:create)  | called after a factory saves an object (via `FactoryBot.create`)                                                          |
+| after(:stub)    | called after a factory stubs an object (via `FactoryBot.build_stubbed`)                                                   |
+| after(:all)     | called after a factory constructs an object (via `FactoryBot.build`, `FactoryBot.create`, or `FactoryBot.build_stubbed`)  |
 
 
 ## Examples

--- a/docs/src/callbacks/summary.md
+++ b/docs/src/callbacks/summary.md
@@ -14,7 +14,7 @@ factory\_bot makes six callbacks available:
 
 ## Examples
 
-### Calling an object's own method after building.
+### Calling an object's own method after building
 
 ```ruby
 ## 

--- a/docs/src/ref/hooks.md
+++ b/docs/src/ref/hooks.md
@@ -13,7 +13,7 @@ factory. Within a `FactoryBot.define` block, they are global to all factories.
 
 The `callback` method allows you to hook into any factory\_bot callback by
 name. The pre-defined names, as seen in the [build strategies] reference, are
-`before_all`, `after_all`, `after_build`, `before_create`, `after_create`, and `after_stub`.
+`before_all`, `after_build`, `before_create`, `after_create`, `after_stub`, and `after_all`.
 
 This method takes a splat of names, and a block. It invokes the block any time
 one of the names is activated. The block can be anything that responds to

--- a/docs/src/ref/hooks.md
+++ b/docs/src/ref/hooks.md
@@ -13,7 +13,7 @@ factory. Within a `FactoryBot.define` block, they are global to all factories.
 
 The `callback` method allows you to hook into any factory\_bot callback by
 name. The pre-defined names, as seen in the [build strategies] reference, are
-`after_build`, `before_create`, `after_create`, and `after_stub`.
+`before_all`, `after_all`, `after_build`, `before_create`, `after_create`, and `after_stub`.
 
 This method takes a splat of names, and a block. It invokes the block any time
 one of the names is activated. The block can be anything that responds to

--- a/lib/factory_bot/factory.rb
+++ b/lib/factory_bot/factory.rb
@@ -32,6 +32,7 @@ module FactoryBot
 
     def run(build_strategy, overrides, &block)
       block ||= ->(result) { result }
+
       compile
 
       strategy = StrategyCalculator.new(build_strategy).strategy.new
@@ -43,7 +44,11 @@ module FactoryBot
       evaluation =
         Evaluation.new(evaluator, attribute_assigner, compiled_to_create, observer)
 
-      strategy.result(evaluation).tap(&block)
+      evaluation.notify(:before_all, nil)
+      instance = strategy.result(evaluation).tap(&block)
+      evaluation.notify(:after_all, instance)
+
+      instance
     end
 
     def human_names

--- a/spec/factory_bot/definition_proxy_spec.rb
+++ b/spec/factory_bot/definition_proxy_spec.rb
@@ -145,6 +145,26 @@ describe FactoryBot::DefinitionProxy, "#association" do
 end
 
 describe FactoryBot::DefinitionProxy, "adding callbacks" do
+  it "adding a :before_all callback succeeds" do
+    definition = FactoryBot::Definition.new(:name)
+    proxy = FactoryBot::DefinitionProxy.new(definition)
+    callback = -> { "my awesome callback!" }
+
+    proxy.before(:all, &callback)
+
+    expect(definition).to have_callback(:before_all).with_block(callback)
+  end
+
+  it "adding an :after_all callback succeeds" do
+    definition = FactoryBot::Definition.new(:name)
+    proxy = FactoryBot::DefinitionProxy.new(definition)
+    callback = -> { "my awesome callback!" }
+
+    proxy.after(:all, &callback)
+
+    expect(definition).to have_callback(:after_all).with_block(callback)
+  end
+
   it "adding an :after_build callback succeeds" do
     definition = FactoryBot::Definition.new(:name)
     proxy = FactoryBot::DefinitionProxy.new(definition)

--- a/spec/support/containers/test_log.rb
+++ b/spec/support/containers/test_log.rb
@@ -1,0 +1,26 @@
+##
+# Designed for tests to log output for later evaluation
+#
+module TestLog
+  class << self
+    require "forwardable"
+    extend Forwardable
+
+    def_delegators :log_array, :<<, :[], :size, :first, :last
+    def_delegators :log_array, :map, :in?, :include?, :inspect
+
+    def all
+      Thread.current[:my_thread_safe_test_log] ||= []
+    end
+
+    def reset!
+      Thread.current[:my_thread_safe_test_log] = []
+    end
+
+    private
+
+    def log_array
+      Thread.current[:my_thread_safe_test_log] ||= []
+    end
+  end
+end

--- a/spec/support/containers/test_log.rb
+++ b/spec/support/containers/test_log.rb
@@ -1,9 +1,10 @@
+require "forwardable"
+
 ##
 # Designed for tests to log output for later evaluation
 #
 module TestLog
   class << self
-    require "forwardable"
     extend Forwardable
 
     def_delegators :log_array, :<<, :[], :size, :first, :last


### PR DESCRIPTION
Fixes: #1694 
Continues: #1695 

## SUMMARY

Continuing on from #1695 it was decided that `before(:all)` and `after(:all)` callbacks would provide a solution, without exposing context internals.

## FEATURE

Both callbacks are defined in the usual way, and operate through the normal callback process.

`before(:all)` callbacks are triggered before the factory is run. Calling it with `before(:all){ |instance, context| ... }` will provide the factory context, but both the `instance` and `context.object` will be nil.

`after(:all)` callbacks are triggered once the factory has completed it's strategy. In this case, the `instance` and `context.object` are populated as normal.

## CHANGES

The only code changes are two new lines to trigger the :before and :after callbacks in the `Factory#run` method, and a little restructuring to return the instance.

## DOCUMENTATION

I've updated the documentation for the two new callbacks, and I've also added a page describing how callbacks are ordered (which initially confused me!).

## TESTING

Additional tests have been included to test multiple scenarios.

Because `before(:all)` runs BEFORE the instance is generated, there was no easy way to track the callback.  I tried using a global `$callback_output = []` but Standard.rb complained.

The best solution was to add a new module `TestLog` which acts as an array, allowing callbacks to update it in order and the test to query the results.

I hate adding new objects, but was stuck for another solution.  I'm happy to change this if you have a better idea.
