### PR TITLE
Developer Console Feature

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,0 +1,14 @@
+def reload!
+  # Undefine FactoryBot so we can reload Constants and fresh code
+  Object.send(:remove_const, :FactoryBot) if Object.const_defined?(:FactoryBot)
+
+  # Remove all files from the 'loaded' register
+  $LOADED_FEATURES.grep(/factory_bot/).each do |path|
+    $LOADED_FEATURES.delete(path)
+  end
+
+  # re-load it again
+  require "factory_bot"
+  puts "\nfactory_bot reloaded!\n\n"
+  true
+end

--- a/.irbrc
+++ b/.irbrc
@@ -1,5 +1,5 @@
 def reload!
-  # Undefine FactoryBot so we can reload Constants and fresh code
+  # Undefine FactoryBot so we can reload constants and fresh code
   Object.send(:remove_const, :FactoryBot) if Object.const_defined?(:FactoryBot)
 
   # Remove all files from the 'loaded' register

--- a/.irbrc
+++ b/.irbrc
@@ -3,9 +3,7 @@ def reload!
   Object.send(:remove_const, :FactoryBot) if Object.const_defined?(:FactoryBot)
 
   # Remove all files from the 'loaded' register
-  $LOADED_FEATURES.grep(/factory_bot/).each do |path|
-    $LOADED_FEATURES.delete(path)
-  end
+  $LOADED_FEATURES.delete_if { |path| path.match?(/factory_bot/) }
 
   # re-load it again
   require "factory_bot"

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+lib = File.expand_path("../lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require "bundler/setup"
+require "factory_bot"
+
+# Add any other fixtures and/or initialization code here.
+
+require "irb"
+require "irb/completion"
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+


### PR DESCRIPTION
Developer helper to quickly open an IRB console with the gem code already loaded: `bin/console`

It also has a built-in `reload!` method that will reload  a fresh copy of the files.

There is no change to any gem code.

- the `reload!` method is define in `.irb`
- the console is configured and launched from `bin/console`
- `.setup` ensures the shell environment:
  -  fails early
  - only uses "\n\t" as line breaks
  - prints the result of each command to the console, for easier debugging.

---

It's easier to debug using an IDE with an integrated debugger, but sometimes you just want to play with the code 🚀
