### PR TITLE
Cleanup Active Support core extensions

### DIFF
--- a/lib/factory_bot/evaluator.rb
+++ b/lib/factory_bot/evaluator.rb
@@ -1,4 +1,3 @@
-require "active_support/core_ext/hash/except"
 require "active_support/core_ext/class/attribute"
 
 module FactoryBot

--- a/lib/factory_bot/registry.rb
+++ b/lib/factory_bot/registry.rb
@@ -1,4 +1,4 @@
-require "active_support/core_ext/hash/indifferent_access"
+require "active_support/hash_with_indifferent_access"
 
 module FactoryBot
   class Registry


### PR DESCRIPTION
Reviewing the Active Support usage, I noticed two `require` calls that are unnecessary:

We don't use the `Hash#except!` method defined on `active_support/core_ext/hash/except.rb`, nor the `Hash#with_indifferent_access` defined on `active_support/hash_with_indifferent_access.rb`.

We _do_ use the `HashWithIndifferentAccess` class directly, so we're now requiring `"active_support/hash_with_indifferent_access"` instead.