### PR TITLE
Allow the initial value of a sequence to be lazy loaded

### DIFF
--- a/docs/src/sequences/initial-value.md
+++ b/docs/src/sequences/initial-value.md
@@ -8,3 +8,11 @@ factory :user do
   sequence(:email, 1000) { |n| "person#{n}@example.com" }
 end
 ```
+
+The initial value can also be lazily set by passing a Proc as the value. This Proc will be called the first time the `sequence.next` is called.
+
+```ruby
+factory :user do
+  sequence(:email, proc { Person.count + 1 }) { |n| "person#{n}@example.com" }
+end
+```

--- a/lib/factory_bot/sequence.rb
+++ b/lib/factory_bot/sequence.rb
@@ -150,25 +150,32 @@ module FactoryBot
     end
 
     class EnumeratorAdapter
-      def initialize(value)
-        @first_value = value
-        @value = value
+      def initialize(initial_value)
+        if initial_value.is_a?(Proc)
+          @first_value = nil
+          @loaded = false
+        else
+          @first_value = initial_value
+          @loaded = true
+        end
+
+        @value = initial_value
       end
 
       def peek
-        @value
+        value
       end
 
       def next
-        @value = @value.next
+        @value = value.next
       end
 
       def rewind
-        @value = @first_value
+        @value = first_value
       end
 
       def set_value(new_value)
-        if new_value >= @first_value
+        if new_value >= first_value
           @value = new_value
         else
           fail ArgumentError, "Value cannot be less than: #{@first_value}"
@@ -176,7 +183,31 @@ module FactoryBot
       end
 
       def integer_value?
-        @first_value.is_a?(Integer)
+        first_value.is_a?(Integer)
+      end
+
+      private
+
+      def first_value
+        load_initial_value unless loaded?
+
+        @first_value
+      end
+
+      def value
+        load_initial_value unless loaded?
+
+        @value
+      end
+
+      def load_initial_value
+        @value = @value.call
+        @first_value = @value
+        @loaded = true
+      end
+
+      def loaded?
+        @loaded
       end
     end
   end

--- a/lib/factory_bot/sequence.rb
+++ b/lib/factory_bot/sequence.rb
@@ -151,15 +151,7 @@ module FactoryBot
 
     class EnumeratorAdapter
       def initialize(initial_value)
-        if initial_value.is_a?(Proc)
-          @first_value = nil
-          @loaded = false
-        else
-          @first_value = initial_value
-          @loaded = true
-        end
-
-        @value = initial_value
+        @initial_value = initial_value
       end
 
       def peek
@@ -189,25 +181,16 @@ module FactoryBot
       private
 
       def first_value
-        load_initial_value unless loaded?
-
-        @first_value
+        @first_value ||= initial_value
       end
 
       def value
-        load_initial_value unless loaded?
-
-        @value
+        @value ||= initial_value
       end
 
-      def load_initial_value
-        @value = @value.call
+      def initial_value
+        @value = @initial_value.respond_to?(:call) ? @initial_value.call : @initial_value
         @first_value = @value
-        @loaded = true
-      end
-
-      def loaded?
-        @loaded
       end
     end
   end

--- a/spec/acceptance/sequence_setting_spec.rb
+++ b/spec/acceptance/sequence_setting_spec.rb
@@ -72,6 +72,16 @@ describe "FactoryBot.set_sequence" do
         expect(generate_list(:jet_pilot, :dob, 3).last).to eq Date.parse("2025-05-03")
       end
 
+      it "works with lazy Integer sequences" do
+        FactoryBot.define do
+          sequence(:email, proc { 42 }) { |n| "somebody#{n}@example.com" }
+        end
+
+        expect(generate_list(:email, 3).last).to eq "somebody44@example.com"
+        FactoryBot.set_sequence(:email, 54321)
+        expect(generate_list(:email, 3).last).to eq "somebody54323@example.com"
+      end
+
       it "does not collide with other factory or global sequences" do
         define_class("User") { attr_accessor :email }
         define_class("Admin") { attr_accessor :email }

--- a/spec/acceptance/sequence_spec.rb
+++ b/spec/acceptance/sequence_spec.rb
@@ -86,7 +86,7 @@ describe "sequences" do
       expect(generate(:commenter, :length)).to eq "user-called-z"
     end
 
-    it "generates sequences after lazy loading an initial value" do
+    it "generates sequences after lazy loading an initial value from a proc" do
       loaded = false
 
       FactoryBot.define do
@@ -105,6 +105,39 @@ describe "sequences" do
 
       expect(first_value).to eq "d"
       expect(another_value).to eq "e"
+    end
+
+    it "generates sequences after lazy loading an initial value from an object responding to call" do
+      define_class("HasCallMethod") do
+        def initialise
+          @called = false
+        end
+
+        def called?
+          @called
+        end
+
+        def call
+          @called = true
+          "ABC"
+        end
+      end
+
+      has_call_method_instance = HasCallMethod.new
+
+      FactoryBot.define do
+        sequence :letters, has_call_method_instance
+      end
+
+      expect(has_call_method_instance).not_to be_called
+
+      first_value = generate(:letters)
+      another_value = generate(:letters)
+
+      expect(has_call_method_instance).to be_called
+
+      expect(first_value).to eq "ABC"
+      expect(another_value).to eq "ABD"
     end
 
     it "generates few values of the sequence" do

--- a/spec/acceptance/sequence_spec.rb
+++ b/spec/acceptance/sequence_spec.rb
@@ -86,6 +86,27 @@ describe "sequences" do
       expect(generate(:commenter, :length)).to eq "user-called-z"
     end
 
+    it "generates sequences after lazy loading an initial value" do
+      loaded = false
+
+      FactoryBot.define do
+        sequence :count, proc {
+          loaded = true
+          "d"
+        }
+      end
+
+      expect(loaded).to be false
+
+      first_value = generate(:count)
+      another_value = generate(:count)
+
+      expect(loaded).to be true
+
+      expect(first_value).to eq "d"
+      expect(another_value).to eq "e"
+    end
+
     it "generates few values of the sequence" do
       define_class("User") { attr_accessor :email }
 

--- a/spec/factory_bot/sequence_spec.rb
+++ b/spec/factory_bot/sequence_spec.rb
@@ -162,7 +162,7 @@ describe FactoryBot::Sequence do
     it_behaves_like "a sequence", first_value: "=J", second_value: "=K"
   end
 
-  describe "a sequence with lazy initial value without a block" do
+  describe "a sequence with a lazy initial value without a block" do
     subject do
       FactoryBot::Sequence.new(:test, proc { 3 })
     end


### PR DESCRIPTION
## Allow the initial value of a sequence to be evaluated on first use

Note: This is a re-implementation of the changes in https://github.com/thoughtbot/factory_bot/pull/1674 to remove the need to use a `lazy` kwarg.

In order to be able to use factory_bot to generate seeds for a database where the database might not have the schema set up yet or might have data already populated, it is useful to be able to defer assigning the initial value to a sequence until it is needed. 
Currently, factory_bot needs the initial value of the sequence to be defined when the factory file is loaded.

This lazy loading behaviour has been very handy for use when we need to create objects that have unique sequential id in formats specific to third party systems. We can use these factories in our development and CI environments without having to think about which values have already been used.

I found https://github.com/thoughtbot/factory_bot/pull/1434 and thought it was worth submitting this PR.

This PR adds the ability to pass a proc as the initial value of a sequence method. The supplied proc will be called the first time as sequence is used via `next`, to set the initial value.
After the initial `next` call, these sequences behave exactly the same as any other factory_bot sequence.

Rewinding a lazy sequence uses the originally calculated value, it does not re-call the lazy Proc object. I'm not sure if it would make more sense to re-evaluate the proc on a rewind call?

Example usage:

```ruby
FactoryBot.define do
  sequence(:email, proc {  User.count + 1 }) { "user#{_1}@example.com" }
end

generate(:email) # user42@example.com if you already have 41 users
```