### PR TITLE
Update link to FactoryGirl upgrade guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you want to use factory_bot with Rails, see
 
 Interested in the history of the project name? You can find the history [here](https://github.com/thoughtbot/factory_bot/blob/main/NAME.md)
 
-Transitioning from factory\_girl? Check out the [upgrade guide](https://github.com/thoughtbot/factory_bot/blob/4-9-0-stable/UPGRADE_FROM_FACTORY_GIRL.md).
+Transitioning from factory\_girl? Check out the [upgrade guide](https://github.com/thoughtbot/factory_bot/blob/v4.9.0/UPGRADE_FROM_FACTORY_GIRL.md).
 
 ## Documentation
 


### PR DESCRIPTION
I noticed that the README currently has a broken link to the upgrade guide from FactoryGirl due to a change in how Github generates tag links.

This PR fixes that link in the README.