### PR TITLE
refactor: make EvaluatorClassDefiner functional

### DIFF
--- a/lib/factory_bot/evaluator_class_definer.rb
+++ b/lib/factory_bot/evaluator_class_definer.rb
@@ -1,19 +1,13 @@
 module FactoryBot
   # @api private
-  class EvaluatorClassDefiner
-    def initialize(attributes, parent_class)
-      @parent_class = parent_class
-      @attributes = attributes
-
-      attributes.each do |attribute|
-        evaluator_class.define_attribute(attribute.name, &attribute.to_proc)
-      end
-    end
-
-    def evaluator_class
-      @evaluator_class ||= Class.new(@parent_class).tap do |klass|
+  module EvaluatorClassDefiner
+    def self.define_evaluator_class(attributes, parent_class)
+      Class.new(parent_class).tap do |klass|
         klass.attribute_lists ||= []
-        klass.attribute_lists += [@attributes]
+        klass.attribute_lists += [attributes]
+        attributes.each do |attribute|
+          klass.define_attribute(attribute.name, &attribute.to_proc)
+        end
       end
     end
   end

--- a/lib/factory_bot/factory.rb
+++ b/lib/factory_bot/factory.rb
@@ -111,7 +111,7 @@ module FactoryBot
     end
 
     def evaluator_class
-      @evaluator_class ||= EvaluatorClassDefiner.new(attributes, parent.evaluator_class).evaluator_class
+      @evaluator_class ||= EvaluatorClassDefiner.define_evaluator_class(attributes, parent.evaluator_class)
     end
 
     def attributes

--- a/spec/factory_bot/evaluator_class_definer_spec.rb
+++ b/spec/factory_bot/evaluator_class_definer_spec.rb
@@ -60,11 +60,10 @@ describe FactoryBot::EvaluatorClassDefiner do
   end
 
   def define_evaluator_class(arguments = {})
-    evaluator_class_definer = FactoryBot::EvaluatorClassDefiner.new(
+    FactoryBot::EvaluatorClassDefiner.define_evaluator_class(
       arguments[:attributes] || [],
       arguments[:parent_class] || FactoryBot::Evaluator
     )
-    evaluator_class_definer.evaluator_class
   end
 
   def stub_attribute(name = :attribute, &value)


### PR DESCRIPTION
The work performed in `FactoryBot::EvaluatorClassDefiner` can be done without creating an instance of the class. The code is rewritten in a more functional manner with a module.