### PR TITLE
refactor: StrategySyntaxMethodRegistrar doesn't need to be a class

### DIFF
--- a/lib/factory_bot/internal/strategies.rb
+++ b/lib/factory_bot/internal/strategies.rb
@@ -9,11 +9,6 @@ module FactoryBot
         @strategies&.reset
       end
 
-      def self.register_strategy(strategy_name, strategy_class)
-        strategies.register(strategy_name, strategy_class)
-        StrategySyntaxMethodRegistrar.new(strategy_name).define_strategy_methods
-      end
-
       def self.strategy_by_name(name)
         strategies.find(name)
       end
@@ -24,6 +19,11 @@ module FactoryBot
         register_strategy(:attributes_for, FactoryBot::Strategy::AttributesFor)
         register_strategy(:build_stubbed, FactoryBot::Strategy::Stub)
         register_strategy(:null, FactoryBot::Strategy::Null)
+      end
+
+      def self.register_strategy(strategy_name, strategy_class)
+        strategies.register(strategy_name, strategy_class)
+        StrategySyntaxMethodRegistrar.define_strategy_methods(strategy_name)
       end
     end
   end

--- a/lib/factory_bot/strategy_syntax_method_registrar.rb
+++ b/lib/factory_bot/strategy_syntax_method_registrar.rb
@@ -1,37 +1,20 @@
 module FactoryBot
   # @api private
-  class StrategySyntaxMethodRegistrar
-    def initialize(strategy_name)
-      @strategy_name = strategy_name
+  module StrategySyntaxMethodRegistrar
+    def self.define_strategy_methods(strategy_name)
+      define_singular_strategy_method(strategy_name)
+      define_list_strategy_method(strategy_name)
+      define_pair_strategy_method(strategy_name)
     end
 
-    def define_strategy_methods
-      define_singular_strategy_method
-      define_list_strategy_method
-      define_pair_strategy_method
-    end
-
-    def self.with_index(block, index)
-      if block&.arity == 2
-        ->(instance) { block.call(instance, index) }
-      else
-        block
-      end
-    end
-
-    private
-
-    def define_singular_strategy_method
-      strategy_name = @strategy_name
-
+    def self.define_singular_strategy_method(strategy_name)
       define_syntax_method(strategy_name) do |name, *traits_and_overrides, &block|
         FactoryRunner.new(name, strategy_name, traits_and_overrides).run(&block)
       end
     end
+    private_class_method :define_singular_strategy_method
 
-    def define_list_strategy_method
-      strategy_name = @strategy_name
-
+    def self.define_list_strategy_method(strategy_name)
       define_syntax_method("#{strategy_name}_list") do |name, amount, *traits_and_overrides, &block|
         unless amount.respond_to?(:times)
           raise ArgumentError, "count missing for #{strategy_name}_list"
@@ -43,22 +26,31 @@ module FactoryBot
         end
       end
     end
+    private_class_method :define_list_strategy_method
 
-    def define_pair_strategy_method
-      strategy_name = @strategy_name
-
+    def self.define_pair_strategy_method(strategy_name)
       define_syntax_method("#{strategy_name}_pair") do |name, *traits_and_overrides, &block|
         Array.new(2) { send(strategy_name, name, *traits_and_overrides, &block) }
       end
     end
+    private_class_method :define_pair_strategy_method
 
-    def define_syntax_method(name, &block)
+    def self.define_syntax_method(name, &block)
       FactoryBot::Syntax::Methods.module_exec do
         if method_defined?(name) || private_method_defined?(name)
           undef_method(name)
         end
 
         define_method(name, &block)
+      end
+    end
+    private_class_method :define_syntax_method
+
+    def self.with_index(block, index)
+      if block&.arity == 2
+        ->(instance) { block.call(instance, index) }
+      else
+        block
       end
     end
   end


### PR DESCRIPTION
**NOTE** — this is dependent on the `refactor-internal-module` branch #1772

The `StrategySyntaxMethodRegistrar` doesn't need to  be instantiated (and doesn't need to be a class) to perform the behavior it implements. This refactors it into a more functional module.