### PR TITLE
Add debug gem and mark slow specs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,12 +69,22 @@ GEM
       cucumber-messages (> 19, < 27)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.1)
+    date (3.4.1)
+    debug (1.11.0)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     diff-lcs (1.5.1)
     docile (1.4.1)
     drb (2.2.1)
+    erb (5.0.2)
     ffi (1.17.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    io-console (0.8.1)
+    irb (1.15.2)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.9.1)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
@@ -88,10 +98,21 @@ GEM
     parser (3.3.7.0)
       ast (~> 2.4.1)
       racc
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
+    psych (5.2.6)
+      date
+      stringio
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
+    rdoc (6.14.2)
+      erb
+      psych (>= 4.0.0)
     regexp_parser (2.10.0)
+    reline (0.6.2)
+      io-console (~> 0.5)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -145,6 +166,7 @@ GEM
     standard-performance (1.6.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.23.0)
+    stringio (3.1.7)
     sys-uname (1.3.1)
       ffi (~> 1.1)
     thor (1.3.2)
@@ -166,6 +188,7 @@ DEPENDENCIES
   appraisal
   aruba
   cucumber
+  debug
   factory_bot!
   mutex_m
   rake

--- a/factory_bot.gemspec
+++ b/factory_bot.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("appraisal")
   s.add_development_dependency("aruba")
   s.add_development_dependency("cucumber")
+  s.add_development_dependency("debug")
   s.add_development_dependency("mutex_m")
   s.add_development_dependency("rake")
   s.add_development_dependency("rspec")

--- a/factory_bot.gemspec
+++ b/factory_bot.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("appraisal")
   s.add_development_dependency("aruba")
   s.add_development_dependency("cucumber")
-  s.add_development_dependency("debug")
+  s.add_development_dependency("debug") if RUBY_ENGINE == "ruby"
   s.add_development_dependency("mutex_m")
   s.add_development_dependency("rake")
   s.add_development_dependency("rspec")

--- a/spec/acceptance/activesupport_instrumentation_spec.rb
+++ b/spec/acceptance/activesupport_instrumentation_spec.rb
@@ -47,7 +47,7 @@ describe "using ActiveSupport::Instrumentation to track run_factory interaction"
     expect(time_to_execute).to be >= 0.1
   end
 
-  it "builds the correct payload" do
+  it "builds the correct payload", :slow do
     tracked_invocations = {}
 
     callback = ->(_name, _start, _finish, _id, payload) do

--- a/spec/acceptance/sequence_setting_spec.rb
+++ b/spec/acceptance/sequence_setting_spec.rb
@@ -306,7 +306,7 @@ describe "FactoryBot.set_sequence" do
           .to raise_error ArgumentError, /Value cannot be less than: 1000/
       end
 
-      it "raises an error for unmatched String values" do
+      it "raises an error for unmatched String values", :slow do
         FactoryBot.define do
           sequence(:char, "c")
         end
@@ -328,7 +328,7 @@ describe "FactoryBot.set_sequence" do
           .to raise_error ArgumentError, /Unable to find 'Jester' in the sequence/
       end
 
-      it "times out when value cannot be found within timeout period" do
+      it "times out when value cannot be found within timeout period", :slow do
         with_temporary_assignment(FactoryBot, :sequence_setting_timeout, 3) do
           FactoryBot.define do
             sequence(:test, "a")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # Set timeout when setting sequences
+require "debug"
 require "rspec"
 require "rspec/its"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 # Set timeout when setting sequences
-require "debug"
+require "debug" if RUBY_ENGINE == "ruby"
 require "rspec"
 require "rspec/its"
 


### PR DESCRIPTION
- adds the `debug` gem 
  - to make it easier to set breakpoints via an invocation of `debugger`
- marks the slowest specs with `:slow`
  - use `bundle exec rspec --tag '~slow'` to skip slow tests
  - use `bundle exec rspec --profile` to see slowest tests
  - this makes it possible to run the bulk of the test suite in roughly **1 second** as opposed to roughly **5 seconds**
  - namely `./spec/acceptance/sequence_setting_spec.rb:309` alone was taking up 61% of the time to run the entire suite (3.12 seconds out of the 5.09 seconds). It seems like a useful test to retain, but is not critical to run while developing other features.