### PR TITLE
chore: tag slow specs

### DIFF
--- a/spec/acceptance/activesupport_instrumentation_spec.rb
+++ b/spec/acceptance/activesupport_instrumentation_spec.rb
@@ -47,7 +47,7 @@ describe "using ActiveSupport::Instrumentation to track run_factory interaction"
     expect(time_to_execute).to be >= 0.1
   end
 
-  it "builds the correct payload" do
+  it "builds the correct payload", :slow do
     tracked_invocations = {}
 
     callback = ->(_name, _start, _finish, _id, payload) do

--- a/spec/acceptance/sequence_setting_spec.rb
+++ b/spec/acceptance/sequence_setting_spec.rb
@@ -306,7 +306,7 @@ describe "FactoryBot.set_sequence" do
           .to raise_error ArgumentError, /Value cannot be less than: 1000/
       end
 
-      it "raises an error for unmatched String values" do
+      it "raises an error for unmatched String values", :slow do
         FactoryBot.define do
           sequence(:char, "c")
         end
@@ -328,7 +328,7 @@ describe "FactoryBot.set_sequence" do
           .to raise_error ArgumentError, /Unable to find 'Jester' in the sequence/
       end
 
-      it "times out when value cannot be found within timeout period" do
+      it "times out when value cannot be found within timeout period", :slow do
         with_temporary_assignment(FactoryBot, :sequence_setting_timeout, 3) do
           FactoryBot.define do
             sequence(:test, "a")


### PR DESCRIPTION
marks the slowest specs with `:slow`

- use `bundle exec rspec --tag '~slow'` to skip slow tests
- use `bundle exec rspec --profile` to see slowest tests
- makes it possible to run the bulk of the test suite in roughly **1 second** as opposed to roughly **5 seconds**
- namely `./spec/acceptance/sequence_setting_spec.rb:309` alone was taking up 61% of the time to run the entire suite (3.12 seconds out of the 5.09 seconds). It seems like a useful test to retain, but is not critical to run while developing other features.