### PR TITLE
fix(gemspec): add ostruct as a development dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
     minitest (5.25.4)
     multi_test (1.1.0)
     mutex_m (0.3.0)
+    ostruct (0.6.3)
     parallel (1.26.3)
     parser (3.3.7.0)
       ast (~> 2.4.1)
@@ -168,6 +169,7 @@ DEPENDENCIES
   cucumber
   factory_bot!
   mutex_m
+  ostruct
   rake
   rspec
   rspec-its

--- a/factory_bot.gemspec
+++ b/factory_bot.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("aruba")
   s.add_development_dependency("cucumber")
   s.add_development_dependency("mutex_m")
+  s.add_development_dependency("ostruct")
   s.add_development_dependency("rake")
   s.add_development_dependency("rspec")
   s.add_development_dependency("rspec-its")


### PR DESCRIPTION
```
❯ RUBYOPT=-W:deprecated bundle exec rspec
/Users/ydah/factory_bot/spec/acceptance/sequence_spec.rb:3: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.

Randomized with seed 22961
..............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 5.84 seconds (files took 1.97 seconds to load)
750 examples, 0 failures
```