### PR TITLE
fix: revert removal of mutex_m

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
     mini_portile2 (2.8.8)
     minitest (5.26.0)
     multi_test (1.1.0)
+    mutex_m (0.3.0)
     ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.9.0)
@@ -172,6 +173,7 @@ DEPENDENCIES
   appraisal
   aruba
   factory_bot!
+  mutex_m
   ostruct
   rake
   rspec

--- a/factory_bot.gemspec
+++ b/factory_bot.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("activerecord")
   s.add_development_dependency("appraisal")
   s.add_development_dependency("aruba")
+  s.add_development_dependency("mutex_m")
   s.add_development_dependency("ostruct")
   s.add_development_dependency("rake")
   s.add_development_dependency("rspec")


### PR DESCRIPTION
including `mutex_m` as a dependency is sometimes necessary

<img width="670" height="186" alt="Screenshot 2025-10-15 at 8 06 52 PM" src="https://github.com/user-attachments/assets/03ec95c7-85ab-4975-aa96-d0f84427849f" />

```
>> BUNDLE_GEMFILE=/Users/valerie/dev/thoughtbot/factory_bot/gemfiles/6.1.gemfile bundle exec rspec
/Users/valerie/.asdf/installs/ruby/3.4.6/lib/ruby/gems/3.4.0/gems/activesupport-6.1.7.10/lib/active_support/notifications/fanout.rb:3: warning: mutex_m was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.

An error occurred while loading spec_helper. - Did you mean?
                    rspec ./spec/spec_helper.rb

Failure/Error: require "active_support/deprecation"

LoadError:
  cannot load such file -- mutex_m
# ./lib/factory_bot.rb:5:in '<top (required)>'
# ./spec/spec_helper.rb:7:in '<top (required)>'
No examples found.


Finished in 0.00002 seconds (files took 0.09563 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
```