### PR TITLE
Ensure linting transactions don't interfere with ActiveRecord lifecycle

### DIFF
--- a/lib/factory_bot/linter.rb
+++ b/lib/factory_bot/linter.rb
@@ -109,7 +109,7 @@ module FactoryBot
 
     def in_transaction
       if defined?(ActiveRecord::Base)
-        ActiveRecord::Base.transaction do
+        ActiveRecord::Base.transaction(joinable: false) do
           yield
           raise ActiveRecord::Rollback
         end

--- a/spec/acceptance/lint_spec.rb
+++ b/spec/acceptance/lint_spec.rb
@@ -44,6 +44,23 @@ describe "FactoryBot.lint" do
     expect { FactoryBot.lint }.to_not raise_error
   end
 
+  it "runs after_commit callbacks when linting in a ActiveRecord::Base transaction" do
+    define_model "ModelWithAfterCommitCallbacks" do
+      class_attribute :after_commit_callbacks_received
+
+      after_commit do
+        self.class.after_commit_callbacks_received = true
+      end
+    end
+
+    FactoryBot.define do
+      factory :model_with_after_commit_callbacks
+    end
+
+    FactoryBot.lint
+    expect(ModelWithAfterCommitCallbacks.after_commit_callbacks_received).to be true
+  end
+
   it "does not raise when all factories are valid" do
     define_model "User", name: :string do
       validates :name, presence: true


### PR DESCRIPTION
Our FactoryBot linting started failing for a factory despite evidence that the trait combination was producing a valid model in test. We eventually traced that down to the change made in #1726. Introducing a `ActiveRecord::Base.transaction` meant that the `after_commit` hooks of our model weren't running during linting.

This is because of the way `ActiveRecord::Base` handles transactions. When changes are inserted for an ActiveRecord within an `ActiveRecord::Base.transaction`, that transaction keeps a list of all the records it contains changes for. as part of the transaction committing, `*_commit` record callbacks are fired

`ActiveRecord::Base.transaction`s are `joinable` by default, which means that `ActiveRecord` can choose to join an existing transaction instead of inserting a new one. This means that `*_commit`s that would previously result from the object's lifecycle are not sent until the end of the linting transaction.

To reinstate the previous behaviour, this PR ensures that the linting transaction is not joinable and any `*_commit` callbacks are respected.