### PR TITLE
Remove CodeClimate badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # factory_bot 
 
-[![Build Status][ci-image]][ci] [![Code Climate][grade-image]][grade] [![Gem Version][version-image]][version]
+[![Build Status][ci-image]][ci] [![Gem Version][version-image]][version]
 
 factory_bot is a fixtures replacement with a straightforward definition syntax, support for multiple build strategies (saved instances, unsaved instances, attribute hashes, and stubbed objects), and support for multiple factories for the same class (user, admin_user, and so on), including factory inheritance.
 
@@ -93,8 +93,6 @@ We are [available for hire][hire].
 
 [ci-image]: https://github.com/thoughtbot/factory_bot/actions/workflows/build.yml/badge.svg?branch=main
 [ci]: https://github.com/thoughtbot/factory_bot/actions?query=workflow%3ABuild+branch%3Amain
-[grade-image]: https://codeclimate.com/github/thoughtbot/factory_bot/badges/gpa.svg
-[grade]: https://codeclimate.com/github/thoughtbot/factory_bot
 [version-image]: https://badge.fury.io/rb/factory_bot.svg
 [version]: https://badge.fury.io/rb/factory_bot
 [hound-badge-image]: https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg


### PR DESCRIPTION
## Summary
- Removes the CodeClimate badge from the README badge row
- Removes the associated `[grade-image]` and `[grade]` reference link definitions

Closes #1792