### PR TITLE
Add `factory_bot.before_run_factory` instrumentation event

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -2084,6 +2084,26 @@ config.after(:suite) do
 end
 ```
 
+You can also subscribe to `factory_bot.before_run_factory` to be notified
+before a factory is run. This is useful for building a factory call stack when
+debugging deeply nested associations:
+
+```ruby
+factory_call_stack = []
+
+ActiveSupport::Notifications.subscribe("factory_bot.before_run_factory") do |name, start, finish, id, payload|
+  factory_call_stack.push(payload[:name])
+end
+
+ActiveSupport::Notifications.subscribe("factory_bot.run_factory") do |name, start, finish, id, payload|
+  factory_call_stack.pop
+end
+```
+
+The payload for `factory_bot.before_run_factory` contains the same keys as
+`factory_bot.run_factory`: `:name`, `:strategy`, `:traits`, `:overrides`, and
+`:factory`.
+
 Another example could involve tracking the attributes and traits that factories are compiled with. If you're using RSpec, you could add `before(:suite)` and `after(:suite)` blocks that subscribe to `factory_bot.compile_factory` notifications:
 
 ```ruby

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # News
 
+## Unreleased
+
+* Feat: Added `factory_bot.before_run_factory` instrumentation event
+
 ## 6.5.6 (October 22, 2025)
 
 * Fix: Enforce association override precedence over trait foreign keys by @JinOketani in [#1768](https://github.com/thoughtbot/factory_bot/pull/1768)

--- a/docs/src/activesupport-instrumentation/summary.md
+++ b/docs/src/activesupport-instrumentation/summary.md
@@ -36,6 +36,26 @@ config.after(:suite) do
 end
 ```
 
+You can also subscribe to `factory_bot.before_run_factory` to be notified
+before a factory is run. This is useful for building a factory call stack when
+debugging deeply nested associations:
+
+```ruby
+factory_call_stack = []
+
+ActiveSupport::Notifications.subscribe("factory_bot.before_run_factory") do |name, start, finish, id, payload|
+  factory_call_stack.push(payload[:name])
+end
+
+ActiveSupport::Notifications.subscribe("factory_bot.run_factory") do |name, start, finish, id, payload|
+  factory_call_stack.pop
+end
+```
+
+The payload for `factory_bot.before_run_factory` contains the same keys as
+`factory_bot.run_factory`: `:name`, `:strategy`, `:traits`, `:overrides`, and
+`:factory`.
+
 Another example could involve tracking the attributes and traits that factories are compiled with. If you're using RSpec, you could add `before(:suite)` and `after(:suite)` blocks that subscribe to `factory_bot.compile_factory` notifications:
 
 ```ruby

--- a/lib/factory_bot/factory_runner.rb
+++ b/lib/factory_bot/factory_runner.rb
@@ -25,6 +25,8 @@ module FactoryBot
         factory: factory
       }
 
+      ActiveSupport::Notifications.instrument("factory_bot.before_run_factory", instrumentation_payload)
+
       ActiveSupport::Notifications.instrument("factory_bot.run_factory", instrumentation_payload) do
         factory.run(runner_strategy, @overrides, &block)
       end

--- a/spec/acceptance/activesupport_instrumentation_spec.rb
+++ b/spec/acceptance/activesupport_instrumentation_spec.rb
@@ -79,6 +79,93 @@ describe "using ActiveSupport::Instrumentation to track run_factory interaction"
   end
 end
 
+describe "using ActiveSupport::Instrumentation to track before_run_factory interaction" do
+  before do
+    define_model("User", email: :string)
+    define_model("Post", user_id: :integer) do
+      belongs_to :user
+    end
+
+    FactoryBot.define do
+      factory :user do
+        email { "john@example.com" }
+      end
+
+      factory :post do
+        trait :with_user do
+          user
+        end
+      end
+    end
+  end
+
+  it "builds the correct payload" do
+    tracked_payloads = []
+    callback = ->(_name, _start, _finish, _id, payload) { tracked_payloads << payload }
+
+    ActiveSupport::Notifications.subscribed(callback, "factory_bot.before_run_factory") do
+      FactoryBot.build(:user)
+      FactoryBot.create(:post, :with_user)
+    end
+
+    user_payload = tracked_payloads.detect { |p| p[:name] == :user }
+    expect(user_payload[:strategy]).to eq(:build)
+    expect(user_payload[:traits]).to eq([])
+    expect(user_payload[:overrides]).to eq({})
+    expect(user_payload[:factory]).to be_a(FactoryBot::Factory)
+
+    post_payload = tracked_payloads.detect { |p| p[:name] == :post }
+    expect(post_payload[:strategy]).to eq(:create)
+    expect(post_payload[:traits]).to eq([:with_user])
+    expect(post_payload[:factory]).to be_a(FactoryBot::Factory)
+  end
+
+  it "fires before run_factory completes" do
+    events = []
+
+    before_callback = ->(_name, _start, _finish, _id, payload) {
+      events << [:before, payload[:name]]
+    }
+    run_callback = ->(_name, _start, _finish, _id, payload) {
+      events << [:run, payload[:name]]
+    }
+
+    ActiveSupport::Notifications.subscribed(before_callback, "factory_bot.before_run_factory") do
+      ActiveSupport::Notifications.subscribed(run_callback, "factory_bot.run_factory") do
+        FactoryBot.build(:user)
+      end
+    end
+
+    expect(events).to eq([[:before, :user], [:run, :user]])
+  end
+
+  it "captures nested factory call stack" do
+    call_stack = []
+
+    before_callback = ->(_name, _start, _finish, _id, payload) {
+      call_stack.push(payload[:name])
+    }
+    run_callback = ->(_name, _start, _finish, _id, payload) {
+      call_stack.pop
+    }
+
+    stack_during_user_build = nil
+    user_before = ->(_name, _start, _finish, _id, payload) {
+      stack_during_user_build = call_stack.dup if payload[:name] == :user
+    }
+
+    ActiveSupport::Notifications.subscribed(before_callback, "factory_bot.before_run_factory") do
+      ActiveSupport::Notifications.subscribed(run_callback, "factory_bot.run_factory") do
+        ActiveSupport::Notifications.subscribed(user_before, "factory_bot.before_run_factory") do
+          FactoryBot.create(:post, :with_user)
+        end
+      end
+    end
+
+    expect(stack_during_user_build).to eq([:post, :user])
+  end
+end
+
 describe "using ActiveSupport::Instrumentation to track compile_factory interaction" do
   before do
     define_model("User", name: :string, email: :string)


### PR DESCRIPTION
## Summary

- Adds a new `factory_bot.before_run_factory` ActiveSupport::Notifications event that fires immediately before `run_factory`
- Enables subscribers to build a factory call stack at runtime for debugging deeply nested association errors
- Reuses the existing `instrumentation_payload` — no new payload construction needed

Closes #1673

## Motivation

When factories are deeply nested via associations, errors in `after` callbacks only surface the top-level factory in the stack trace. A `before_run_factory` event lets users push/pop a call stack to identify the exact factory chain that led to an error.

Existing alternatives don't work:
- **Global callbacks** can't access the factory name
- **`compile_factory`** only fires once per factory definition (cached)
- **Custom `start`/`finish` subscriber on `run_factory`** works but is an obscure pattern most users won't discover

## Changes

| File | Change |
|------|--------|
| `lib/factory_bot/factory_runner.rb` | Added one-line non-block `instrument` call before existing `run_factory` block |
| `spec/acceptance/activesupport_instrumentation_spec.rb` | Added 3 tests: payload correctness, firing order, nested call stack capture |
| `docs/src/activesupport-instrumentation/summary.md` | Documented new event with call-stack example |
| `GETTING_STARTED.md` | Mirrored documentation update |
| `NEWS.md` | Added changelog entry |

## Test plan

- [x] All 3 new tests pass (`bundle exec rspec spec/acceptance/activesupport_instrumentation_spec.rb`)
- [x] Full test suite passes (763 examples, 0 failures)
- [x] `bundle exec rake standard` — no formatting offenses