### PR TITLE
Add unit tests for Decorator, InvocationTracker, and NewConstructor

### DIFF
--- a/spec/factory_bot/decorator/invocation_tracker_spec.rb
+++ b/spec/factory_bot/decorator/invocation_tracker_spec.rb
@@ -1,0 +1,43 @@
+describe FactoryBot::Decorator::InvocationTracker do
+  it "tracks method names that are called" do
+    component = double("component", foo: nil, bar: nil)
+    tracker = FactoryBot::Decorator::InvocationTracker.new(component)
+
+    tracker.foo
+    tracker.bar
+
+    expect(tracker.__invoked_methods__).to eq [:foo, :bar]
+  end
+
+  it "forwards method calls to the component" do
+    component = double("component", foo: "result")
+    tracker = FactoryBot::Decorator::InvocationTracker.new(component)
+
+    expect(tracker.foo).to eq "result"
+  end
+
+  it "forwards arguments to the component" do
+    component = double("component")
+    allow(component).to receive(:foo).with(1, "two").and_return("result")
+    tracker = FactoryBot::Decorator::InvocationTracker.new(component)
+
+    expect(tracker.foo(1, "two")).to eq "result"
+  end
+
+  it "returns unique method names" do
+    component = double("component", foo: nil)
+    tracker = FactoryBot::Decorator::InvocationTracker.new(component)
+
+    tracker.foo
+    tracker.foo
+
+    expect(tracker.__invoked_methods__).to eq [:foo]
+  end
+
+  it "returns an empty array when no methods have been called" do
+    component = double("component")
+    tracker = FactoryBot::Decorator::InvocationTracker.new(component)
+
+    expect(tracker.__invoked_methods__).to eq []
+  end
+end

--- a/spec/factory_bot/decorator/new_constructor_spec.rb
+++ b/spec/factory_bot/decorator/new_constructor_spec.rb
@@ -1,0 +1,29 @@
+describe FactoryBot::Decorator::NewConstructor do
+  it "delegates new to the build class" do
+    component = double("component")
+    build_class = double("build_class")
+    instance = double("instance")
+    allow(build_class).to receive(:new).and_return(instance)
+    decorator = FactoryBot::Decorator::NewConstructor.new(component, build_class)
+
+    expect(decorator.new).to eq instance
+  end
+
+  it "passes arguments to the build class" do
+    component = double("component")
+    build_class = double("build_class")
+    instance = double("instance")
+    allow(build_class).to receive(:new).with("arg1", "arg2").and_return(instance)
+    decorator = FactoryBot::Decorator::NewConstructor.new(component, build_class)
+
+    expect(decorator.new("arg1", "arg2")).to eq instance
+  end
+
+  it "forwards other methods to the component" do
+    component = double("component", foo: "bar")
+    build_class = double("build_class")
+    decorator = FactoryBot::Decorator::NewConstructor.new(component, build_class)
+
+    expect(decorator.foo).to eq "bar"
+  end
+end

--- a/spec/factory_bot/decorator_spec.rb
+++ b/spec/factory_bot/decorator_spec.rb
@@ -1,0 +1,49 @@
+describe FactoryBot::Decorator do
+  it "forwards method calls to the component" do
+    component = double("component", foo: "bar")
+    decorator = FactoryBot::Decorator.new(component)
+
+    expect(decorator.foo).to eq "bar"
+  end
+
+  it "forwards method calls with arguments" do
+    component = double("component")
+    allow(component).to receive(:foo).with(1, 2).and_return("result")
+    decorator = FactoryBot::Decorator.new(component)
+
+    expect(decorator.foo(1, 2)).to eq "result"
+  end
+
+  it "forwards method calls with blocks" do
+    component = Object.new
+    def component.foo(&block) = block.call
+    decorator = FactoryBot::Decorator.new(component)
+
+    expect(decorator.foo { "yielded" }).to eq "yielded"
+  end
+
+  it "delegates send to __send__" do
+    component = double("component", foo: "bar")
+    decorator = FactoryBot::Decorator.new(component)
+
+    expect(decorator.send(:foo)).to eq "bar"
+  end
+
+  it "returns true from respond_to? when the component responds to the method" do
+    component = double("component", foo: "bar")
+    decorator = FactoryBot::Decorator.new(component)
+
+    expect(decorator.respond_to?(:foo)).to be true
+  end
+
+  it "returns false from respond_to? when the component does not respond" do
+    component = double("component")
+    decorator = FactoryBot::Decorator.new(component)
+
+    expect(decorator.respond_to?(:nonexistent)).to be false
+  end
+
+  it "resolves constants from Object" do
+    expect(FactoryBot::Decorator::String).to eq ::String
+  end
+end


### PR DESCRIPTION
## Summary
- Add unit tests for `FactoryBot::Decorator`, `FactoryBot::Decorator::InvocationTracker`, and `FactoryBot::Decorator::NewConstructor`
- These tightly coupled classes previously had no corresponding unit test files
- Batched into one PR since InvocationTracker and NewConstructor both inherit from Decorator

## Test plan
- [x] `bundle exec rspec spec/factory_bot/decorator_spec.rb spec/factory_bot/decorator/invocation_tracker_spec.rb spec/factory_bot/decorator/new_constructor_spec.rb` passes (15 examples, 0 failures)
- [x] `bundle exec standardrb` passes