### PR TITLE
Add unit tests for FactoryBot::Declaration

### DIFF
--- a/spec/factory_bot/declaration_spec.rb
+++ b/spec/factory_bot/declaration_spec.rb
@@ -1,0 +1,25 @@
+describe FactoryBot::Declaration do
+  it "returns the name given during initialization" do
+    declaration = FactoryBot::Declaration.new(:username)
+
+    expect(declaration.name).to eq :username
+  end
+
+  it "delegates to_attributes to the build method" do
+    declaration = FactoryBot::Declaration.new(:username)
+
+    expect { declaration.to_attributes }.to raise_error(NameError)
+  end
+
+  it "defaults ignored to false" do
+    declaration = FactoryBot::Declaration.new(:username)
+
+    expect(declaration.send(:ignored)).to be false
+  end
+
+  it "allows ignored to be set to true" do
+    declaration = FactoryBot::Declaration.new(:username, true)
+
+    expect(declaration.send(:ignored)).to be true
+  end
+end


### PR DESCRIPTION
## Summary
- Add unit tests for `FactoryBot::Declaration` (`lib/factory_bot/declaration.rb`)
- This base class previously had no corresponding unit test file

## Test plan
- [x] `bundle exec rspec spec/factory_bot/declaration_spec.rb` passes (4 examples, 0 failures)
- [x] `bundle exec standardrb` passes