### PR TITLE
Add unit tests for FactoryBot::Enum

### DIFF
--- a/spec/factory_bot/enum_spec.rb
+++ b/spec/factory_bot/enum_spec.rb
@@ -1,0 +1,41 @@
+describe FactoryBot::Enum do
+  it "creates traits from explicit hash values" do
+    enum = FactoryBot::Enum.new(:status, {active: 0, inactive: 1})
+    traits = enum.build_traits(double("klass"))
+
+    expect(traits.length).to eq 2
+    expect(traits.map(&:name)).to match_array %w[active inactive]
+  end
+
+  it "creates traits from explicit array values" do
+    enum = FactoryBot::Enum.new(:status, %w[active inactive])
+    traits = enum.build_traits(double("klass"))
+
+    expect(traits.length).to eq 2
+    expect(traits.map(&:name)).to match_array %w[active inactive]
+  end
+
+  it "creates traits from class method when no values provided" do
+    enum = FactoryBot::Enum.new(:status)
+    klass = double("klass")
+    allow(klass).to receive(:statuses).and_return(active: 0, inactive: 1)
+    traits = enum.build_traits(klass)
+
+    expect(traits.length).to eq 2
+    expect(traits.map(&:name)).to match_array %w[active inactive]
+  end
+
+  it "returns Trait instances" do
+    enum = FactoryBot::Enum.new(:status, {active: 0})
+    traits = enum.build_traits(double("klass"))
+
+    expect(traits.first).to be_a FactoryBot::Trait
+  end
+
+  it "returns an empty array when there are no enum values" do
+    enum = FactoryBot::Enum.new(:status, {})
+    traits = enum.build_traits(double("klass"))
+
+    expect(traits).to be_empty
+  end
+end


### PR DESCRIPTION
## Summary
- Add unit tests for `FactoryBot::Enum` (`lib/factory_bot/enum.rb`)
- This file previously had no corresponding unit test file

## Test plan
- [x] `bundle exec rspec spec/factory_bot/enum_spec.rb` passes (5 examples, 0 failures)
- [x] `bundle exec standardrb` passes