### PR TITLE
Add unit tests for FactoryBot::DefinitionHierarchy

### DIFF
--- a/spec/factory_bot/definition_hierarchy_spec.rb
+++ b/spec/factory_bot/definition_hierarchy_spec.rb
@@ -1,0 +1,47 @@
+describe FactoryBot::DefinitionHierarchy do
+  it "defines a to_create method when the definition has one" do
+    definition = double("definition",
+      to_create: -> { "custom create" },
+      constructor: nil,
+      callbacks: [])
+    hierarchy_class = Class.new(FactoryBot::DefinitionHierarchy)
+    hierarchy_class.build_from_definition(definition)
+
+    expect(hierarchy_class.new.to_create).to eq definition.to_create
+  end
+
+  it "defines a constructor method when the definition has one" do
+    constructor_block = -> { "custom constructor" }
+    definition = double("definition",
+      to_create: nil,
+      constructor: constructor_block,
+      callbacks: [])
+    hierarchy_class = Class.new(FactoryBot::DefinitionHierarchy)
+    hierarchy_class.build_from_definition(definition)
+
+    expect(hierarchy_class.new.constructor).to eq constructor_block
+  end
+
+  it "adds callbacks when the definition has them" do
+    callback = double("callback")
+    definition = double("definition",
+      to_create: nil,
+      constructor: nil,
+      callbacks: [callback])
+    hierarchy_class = Class.new(FactoryBot::DefinitionHierarchy)
+    hierarchy_class.build_from_definition(definition)
+
+    expect(hierarchy_class.new.callbacks).to include(callback)
+  end
+
+  it "falls back to Internal defaults when the definition has no values" do
+    definition = double("definition",
+      to_create: nil,
+      constructor: nil,
+      callbacks: [])
+    hierarchy_class = Class.new(FactoryBot::DefinitionHierarchy)
+    hierarchy_class.build_from_definition(definition)
+
+    expect(hierarchy_class.new.callbacks).to eq FactoryBot::Internal.callbacks
+  end
+end


### PR DESCRIPTION
## Summary
- Add unit tests for `FactoryBot::DefinitionHierarchy` (`lib/factory_bot/definition_hierarchy.rb`)
- This file previously had no corresponding unit test file

## Test plan
- [x] `bundle exec rspec spec/factory_bot/definition_hierarchy_spec.rb` passes (4 examples, 0 failures)
- [x] `bundle exec standardrb` passes