### PR TITLE
Add gem release workflow with GitHub release notes from changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - lib/factory_bot/version.rb
+
+jobs:
+  release:
+    name: Release gem
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # create git tag
+      id-token: write  # OIDC token for RubyGems trusted publishing
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+      - uses: rubygems/release-gem@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           VERSION=$(ruby -e "require_relative 'lib/factory_bot/version'; puts FactoryBot::VERSION")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          NOTES=$(awk "BEGIN{p=0} /^## $VERSION/{p=1; next} p && /^## /{exit} p{print}" NEWS.md)
+          NOTES=$(awk -v version="$VERSION" 'BEGIN{p=0} $0 == "## " version {p=1; next} p && /^## /{exit} p{print}' NEWS.md)
           DELIM=$(uuidgen)
           echo "notes<<$DELIM" >> "$GITHUB_OUTPUT"
           echo "$NOTES" >> "$GITHUB_OUTPUT"
@@ -40,5 +40,6 @@ jobs:
           ${{ steps.release_notes.outputs.notes }}
           EOF
           gh release create "v${{ steps.release_notes.outputs.version }}" \
+            --target "${{ github.sha }}" \
             --title "v${{ steps.release_notes.outputs.version }}" \
             --notes-file "$NOTES_FILE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          NOTES_FILE="$(mktemp)"
+          cat > "$NOTES_FILE" <<'EOF'
+          ${{ steps.release_notes.outputs.notes }}
+          EOF
           gh release create "v${{ steps.release_notes.outputs.version }}" \
             --title "v${{ steps.release_notes.outputs.version }}" \
-            --notes "${{ steps.release_notes.outputs.notes }}"
+            --notes-file "$NOTES_FILE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,10 @@ jobs:
           VERSION=$(ruby -e "require_relative 'lib/factory_bot/version'; puts FactoryBot::VERSION")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           NOTES=$(awk "BEGIN{p=0} /^## $VERSION/{p=1; next} p && /^## /{exit} p{print}" NEWS.md)
-          echo "notes<<EOF" >> "$GITHUB_OUTPUT"
+          DELIM=$(uuidgen)
+          echo "notes<<$DELIM" >> "$GITHUB_OUTPUT"
           echo "$NOTES" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "$DELIM" >> "$GITHUB_OUTPUT"
       - uses: rubygems/release-gem@v1
       - name: Create GitHub release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Release gem
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # create git tag
+      contents: write  # create git tag + GitHub release
       id-token: write  # OIDC token for RubyGems trusted publishing
     steps:
       - uses: actions/checkout@v6
@@ -20,4 +20,20 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.3"
+      - name: Extract release notes from NEWS.md
+        id: release_notes
+        run: |
+          VERSION=$(ruby -e "require_relative 'lib/factory_bot/version'; puts FactoryBot::VERSION")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          NOTES=$(awk "BEGIN{p=0} /^## $VERSION/{p=1; next} p && /^## /{exit} p{print}" NEWS.md)
+          echo "notes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$NOTES" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - uses: rubygems/release-gem@v1
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ steps.release_notes.outputs.version }}" \
+            --title "v${{ steps.release_notes.outputs.version }}" \
+            --notes "${{ steps.release_notes.outputs.notes }}"

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -1,0 +1,21 @@
+name: Validate changelog
+
+on:
+  pull_request:
+    paths:
+      - lib/factory_bot/version.rb
+
+jobs:
+  validate:
+    name: Check NEWS.md has release section
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check NEWS.md contains version section
+        run: |
+          VERSION=$(ruby -e "require_relative 'lib/factory_bot/version'; puts FactoryBot::VERSION")
+          if ! grep -q "^## $VERSION" NEWS.md; then
+            echo "ERROR: NEWS.md is missing a section for version $VERSION"
+            echo "Add a '## $VERSION (date)' entry to NEWS.md before bumping the version."
+            exit 1
+          fi

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -11,10 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
       - name: Check NEWS.md contains version section
         run: |
           VERSION=$(ruby -e "require_relative 'lib/factory_bot/version'; puts FactoryBot::VERSION")
-          if ! grep -q "^## $VERSION" NEWS.md; then
+          if ! grep -Fq "## $VERSION" NEWS.md; then
             echo "ERROR: NEWS.md is missing a section for version $VERSION"
             echo "Add a '## $VERSION (date)' entry to NEWS.md before bumping the version."
             exit 1


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that triggers when `lib/factory_bot/version.rb` changes on `main` and publishes the gem to RubyGems.org
- Uses RubyGems trusted publishing (OIDC) so no API key needs to be stored as a secret — compatible with the `rubygems_mfa_required` restriction in the gemspec
- After the gem is pushed, creates a GitHub Release populated with the relevant section extracted from `NEWS.md`
- Adds a PR check that fails if `version.rb` is bumped without a corresponding section in `NEWS.md`

## What a reviewer should know

- [x] **One-time setup required on RubyGems.org:** a gem owner needs to configure a trusted publisher for this repo under the `factory_bot` gem settings (GitHub → `thoughtbot/factory_bot`, workflow `release.yml`).

- [x] **Changelog extraction:** the `awk` script pulls the bullet points between the matching version header and the next `## ` header in `NEWS.md`. The `## Unreleased` entries should be moved under the new version header before bumping `version.rb`. A new `validate-changelog` workflow enforces this on PRs.