### PR TITLE
Include Gemfile.lock in release preparation commit

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -51,7 +51,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add lib/factory_bot/version.rb NEWS.md
+          git add lib/factory_bot/version.rb Gemfile.lock NEWS.md
           git commit -m "Release v$NEW_VERSION"
           git push origin "$BRANCH"
           gh pr create \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    factory_bot (6.5.6)
+    factory_bot (6.6.0)
       activesupport (>= 6.1.0)
 
 GEM
@@ -43,7 +43,7 @@ GEM
     builder (3.3.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
-    contracts (0.17.2)
+    contracts (0.17.3)
     cucumber (10.1.1)
       base64 (~> 0.2)
       builder (~> 3.2)
@@ -82,7 +82,9 @@ GEM
     memoist3 (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
-    minitest (5.26.0)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
     multi_test (1.1.0)
     mutex_m (0.3.0)
     ostruct (0.6.3)
@@ -160,7 +162,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
-    unicode-emoji (4.1.0)
+    unicode-emoji (4.2.0)
     uri (1.0.4)
     yard (0.9.37)
 


### PR DESCRIPTION
## Summary

The `bundle install` step in the prepare-release workflow updates `Gemfile.lock` to reflect the new gem version, but it wasn't being staged before the release commit. This left `Gemfile.lock` dirty, causing the release workflow to fail with:

> There are files that need to be committed first.

This PR fixes that by adding `Gemfile.lock` to the `git add` in the "Push branch and open draft PR" step, and commits the currently stale `Gemfile.lock` (which still referenced `6.5.6`).