### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -364,7 +364,7 @@ Aliases
 -------
 
 factory\_bot allows you to define aliases to existing factories to make them
-easier to re-use. This could come in handy when, for example, your Post object
+easier to reuse. This could come in handy when, for example, your Post object
 has an author attribute that actually refers to an instance of a User class.
 While normally factory\_bot can infer the factory name from the association name,
 in this case it will look for an author factory in vain. So, alias your user

--- a/docs/src/aliases/summary.md
+++ b/docs/src/aliases/summary.md
@@ -1,7 +1,7 @@
 # Aliases
 
 factory\_bot allows you to define aliases to existing factories to make them
-easier to re-use. This could come in handy when, for example, your Post object
+easier to reuse. This could come in handy when, for example, your Post object
 has an author attribute that actually refers to an instance of a User class.
 While normally factory\_bot can infer the factory name from the association name,
 in this case it will look for an author factory in vain. So, alias your user

--- a/lib/factory_bot/attribute_assigner.rb
+++ b/lib/factory_bot/attribute_assigner.rb
@@ -120,7 +120,7 @@ module FactoryBot
 
     # Is the attribute an ignorable alias of the override?
     # An attribute is ignorable when it is an alias of the override AND it is
-    # either interrupting an assocciation OR is not the name of another attribute
+    # either interrupting an association OR is not the name of another attribute
     #
     # @note An "alias" is currently an overloaded term for two distinct cases:
     #   (1) attributes which are aliases and reference the same value


### PR DESCRIPTION
Fix minor typos found by codespell in comments and documentation strings.

- `assocciation` → `association` in `lib/factory_bot/attribute_assigner.rb` (comment on line 123)
- `re-use` → `reuse` in `GETTING_STARTED.md` (line 367) and `docs/src/aliases/summary.md` (line 4)

Changes found by running:
\`\`\`
codespell --skip=".git,*.lock,*.json,*.svg,*.png,Gemfile.lock,CHANGELOG*,vendor" -q 3 .
\`\`\`