### PR TITLE
Expanded trait error message to include list of defined traits.

### DIFF
--- a/lib/factory_bot/definition.rb
+++ b/lib/factory_bot/definition.rb
@@ -136,13 +136,6 @@ module FactoryBot
       raise error_with_definition_name(error)
     end
 
-    def registered_trait_message(all_registered_traits)
-      if all_registered_traits.empty?
-        "No registered traits"
-      else
-        "Registered traits: #{all_registered_traits.map(&:to_sym).sort.inspect}"
-      end
-    end
 
     def all_registered_trait_names
       (defined_traits_names + Internal.traits.map(&:name)).uniq
@@ -163,6 +156,13 @@ module FactoryBot
       end
     end
 
+    def registered_trait_message(all_registered_traits)
+      if all_registered_traits.empty?
+        "No registered traits"
+      else
+        "Registered traits: #{all_registered_traits.map(&:to_sym).sort.inspect}"
+      end
+    end
     # detailed_message introduced in Ruby 3.2 for cleaner integration with
     # did_you_mean. See https://bugs.ruby-lang.org/issues/18564
     if KeyError.method_defined?(:detailed_message)

--- a/lib/factory_bot/definition.rb
+++ b/lib/factory_bot/definition.rb
@@ -127,20 +127,60 @@ module FactoryBot
     def base_traits
       @base_traits.map { |name| trait_by_name(name) }
     rescue KeyError => error
-      raise error_with_definition_name(error)
+      raise error_with_definition_name(error_with_registered_traits(error))
+    end
+
+    def additional_traits
+      @additional_traits.map { |name| trait_by_name(name) }
+    rescue KeyError => error
+      raise error_with_registered_traits(error)
+    end
+
+    def error_with_registered_traits(error)
+      message = error.message.rstrip
+      message += "." unless message.end_with?(".")
+      message += " Registered traits: #{all_registered_trait_names}"
+      new_error = error.class.new(message, **error_options(error))
+      new_error.set_backtrace(error.backtrace)
+      new_error
+    end
+
+    def all_registered_trait_names
+      (defined_traits_names + Internal.traits.map(&:name)).uniq.map(&:to_sym).sort.inspect
+    end
+
+    def error_options(error)
+      if error.respond_to?(:key) && error.respond_to?(:receiver)
+        receiver = error.receiver
+        if receiver.is_a?(Hash) || receiver.is_a?(ActiveSupport::HashWithIndifferentAccess)
+          receiver = receiver.dup
+          defined_traits_names.each do |trait_name|
+            receiver[trait_name] = nil unless receiver.key?(trait_name)
+          end
+        end
+        {key: error.key, receiver: receiver}
+      else
+        {}
+      end
     end
 
     # detailed_message introduced in Ruby 3.2 for cleaner integration with
     # did_you_mean. See https://bugs.ruby-lang.org/issues/18564
     if KeyError.method_defined?(:detailed_message)
       def error_with_definition_name(error)
-        message = error.message + " referenced within \"#{name}\" definition"
+        return error if error.message.include?("referenced within")
 
-        error.class.new(message, key: error.key, receiver: error.receiver)
+        message = error.message.rstrip
+        message += "." unless message.end_with?(".")
+        message += " Referenced within \"#{name}\" definition"
+
+        error.class.new(message, **error_options(error))
           .tap { |new_error| new_error.set_backtrace(error.backtrace) }
       end
     else
       def error_with_definition_name(error)
+        return error if error.message.include?("referenced within")
+
         message = error.message
         message.insert(
           message.index("\nDid you mean?") || message.length,
@@ -151,10 +191,6 @@ module FactoryBot
           new_error.set_backtrace(error.backtrace)
         end
       end
-    end
-
-    def additional_traits
-      @additional_traits.map { |name| trait_by_name(name) }
     end
 
     def trait_by_name(name)

--- a/lib/factory_bot/definition.rb
+++ b/lib/factory_bot/definition.rb
@@ -139,14 +139,22 @@ module FactoryBot
     def error_with_registered_traits(error)
       message = error.message.rstrip
       message += "." unless message.end_with?(".")
-      message += " Registered traits: #{all_registered_trait_names}"
+      message += " #{registered_trait_message(all_registered_trait_names)}."
       new_error = error.class.new(message, **error_options(error))
       new_error.set_backtrace(error.backtrace)
       new_error
     end
 
+    def registered_trait_message(all_registered_traits)
+      if all_registered_traits.empty?
+        "No registered traits"
+      else
+        "Registered traits: #{all_registered_traits.map(&:to_sym).sort.inspect}"
+      end
+    end
+
     def all_registered_trait_names
-      (defined_traits_names + Internal.traits.map(&:name)).uniq.map(&:to_sym).sort.inspect
+      (defined_traits_names + Internal.traits.map(&:name)).uniq
     end
 
     def error_options(error)

--- a/lib/factory_bot/definition.rb
+++ b/lib/factory_bot/definition.rb
@@ -56,8 +56,8 @@ module FactoryBot
         self.klass ||= klass
         defined_traits.each do |defined_trait|
           defined_trait.klass ||= klass
-          base_traits.each { |bt| bt.define_trait defined_trait }
-          additional_traits.each { |at| at.define_trait defined_trait }
+          base_trait_names.each { |bt| bt.define_trait defined_trait }
+          additional_trait_names.each { |at| at.define_trait defined_trait }
         end
 
         @compiled = true
@@ -124,25 +124,16 @@ module FactoryBot
 
     private
 
-    def base_traits
+    def base_trait_names
       @base_traits.map { |name| trait_by_name(name) }
     rescue KeyError => error
-      raise error_with_definition_name(error_with_registered_traits(error))
+      raise error_with_definition_name(error)
     end
 
-    def additional_traits
+    def additional_trait_names
       @additional_traits.map { |name| trait_by_name(name) }
     rescue KeyError => error
-      raise error_with_registered_traits(error)
-    end
-
-    def error_with_registered_traits(error)
-      message = error.message.rstrip
-      message += "." unless message.end_with?(".")
-      message += " #{registered_trait_message(all_registered_trait_names)}."
-      new_error = error.class.new(message, **error_options(error))
-      new_error.set_backtrace(error.backtrace)
-      new_error
+      raise error_with_definition_name(error)
     end
 
     def registered_trait_message(all_registered_traits)
@@ -176,20 +167,18 @@ module FactoryBot
     # did_you_mean. See https://bugs.ruby-lang.org/issues/18564
     if KeyError.method_defined?(:detailed_message)
       def error_with_definition_name(error)
-        return error if error.message.include?("referenced within")
-
         message = error.message.rstrip
         message += "." unless message.end_with?(".")
+        message += " #{registered_trait_message(all_registered_trait_names)}."
         message += " Referenced within \"#{name}\" definition"
 
         error.class.new(message, **error_options(error))
-          .tap { |new_error| new_error.set_backtrace(error.backtrace) }
+             .tap { |new_error| new_error.set_backtrace(error.backtrace) }
       end
     else
       def error_with_definition_name(error)
-        return error if error.message.include?("referenced within")
-
         message = error.message
+        message += " #{registered_trait_message(all_registered_trait_names)}."
         message.insert(
           message.index("\nDid you mean?") || message.length,
           " referenced within \"#{name}\" definition"
@@ -221,9 +210,9 @@ module FactoryBot
       compile
 
       [
-        base_traits.map(&method_name),
+        base_trait_names.map(&method_name),
         instance_exec(&block),
-        additional_traits.map(&method_name)
+        additional_trait_names.map(&method_name)
       ].flatten.compact
     end
 

--- a/spec/acceptance/enum_traits_spec.rb
+++ b/spec/acceptance/enum_traits_spec.rb
@@ -132,7 +132,7 @@ describe "enum traits" do
 
         Task.statuses.each_key do |trait_name|
           expect { FactoryBot.build(:task, trait_name) }.to raise_error(
-            KeyError, "Trait not registered: \"#{trait_name}\""
+            KeyError, "Trait not registered: \"#{trait_name}\". Registered traits: []"
           )
         end
 

--- a/spec/acceptance/enum_traits_spec.rb
+++ b/spec/acceptance/enum_traits_spec.rb
@@ -132,7 +132,7 @@ describe "enum traits" do
 
         Task.statuses.each_key do |trait_name|
           expect { FactoryBot.build(:task, trait_name) }.to raise_error(
-            KeyError, "Trait not registered: \"#{trait_name}\". Registered traits: []"
+            KeyError, "Trait not registered: \"#{trait_name}\". No registered traits."
           )
         end
 

--- a/spec/acceptance/enum_traits_spec.rb
+++ b/spec/acceptance/enum_traits_spec.rb
@@ -132,7 +132,7 @@ describe "enum traits" do
 
         Task.statuses.each_key do |trait_name|
           expect { FactoryBot.build(:task, trait_name) }.to raise_error(
-            KeyError, "Trait not registered: \"#{trait_name}\". No registered traits."
+            KeyError, "Trait not registered: \"#{trait_name}\". No registered traits. Referenced within \"task\" definition"
           )
         end
 

--- a/spec/acceptance/traits_spec.rb
+++ b/spec/acceptance/traits_spec.rb
@@ -335,7 +335,7 @@ describe "looking up traits that don't exist" do
 
       expect { FactoryBot.build(:user) }.to raise_error(
         KeyError,
-        'Trait not registered: "inaccessible_trait". Registered traits: []. Referenced within "user" definition'
+        'Trait not registered: "inaccessible_trait". No registered traits. Referenced within "user" definition'
       )
     end
 
@@ -414,7 +414,7 @@ describe "trait exception error messages" do
 
         expect { FactoryBot.build(:user, :missing_trait) }.to raise_error(
           KeyError,
-          "Trait not registered: \"missing_trait\". Registered traits: [:trait_1]"
+          "Trait not registered: \"missing_trait\". Registered traits: [:trait_1]."
         )
       end
     end
@@ -430,7 +430,7 @@ describe "trait exception error messages" do
 
         expect { FactoryBot.build(:user) }.to raise_error(
           KeyError,
-          /Registered traits: \[\]/
+          /No registered traits/
         )
       end
 
@@ -441,7 +441,7 @@ describe "trait exception error messages" do
 
         expect { FactoryBot.build(:user, :missing_trait) }.to raise_error(
           KeyError,
-          "Trait not registered: \"missing_trait\". Registered traits: []"
+          "Trait not registered: \"missing_trait\". No registered traits."
         )
       end
     end
@@ -484,7 +484,7 @@ describe "trait exception error messages" do
 
         expected_message = [
           "Trait not registered: \"missing_trait\".",
-          "Registered traits: [:trait_1, :trait_2, :trait_3, :trait_4]"
+          "Registered traits: [:trait_1, :trait_2, :trait_3, :trait_4]."
         ].join(" ")
 
         expect { FactoryBot.build(:user, :missing_trait) }.to raise_error(
@@ -562,7 +562,7 @@ describe "trait exception error messages" do
         expected_message = [
           "Trait not registered: \"missing_trait\".",
           "Registered traits: [:admin_trait_1, :admin_trait_2,",
-          ":dev_trait_1, :dev_trait_2, :user_trait_1, :user_trait_2]"
+          ":dev_trait_1, :dev_trait_2, :user_trait_1, :user_trait_2]."
         ].join(" ")
 
         expect { FactoryBot.build(:dev, :missing_trait) }.to raise_error(

--- a/spec/acceptance/traits_spec.rb
+++ b/spec/acceptance/traits_spec.rb
@@ -400,9 +400,9 @@ describe "trait exception error messages" do
         ].join(" ")
 
         expect { FactoryBot.build(:user) }.to raise_error(
-                                                KeyError,
-                                                expected_message
-                                              )
+          KeyError,
+          expected_message
+        )
       end
 
       it "when a missing trait is called by the user" do
@@ -413,9 +413,9 @@ describe "trait exception error messages" do
         end
 
         expect { FactoryBot.build(:user, :missing_trait) }.to raise_error(
-                                                                KeyError,
-                                                                "Trait not registered: \"missing_trait\". Registered traits: [:trait_1]"
-                                                              )
+          KeyError,
+          "Trait not registered: \"missing_trait\". Registered traits: [:trait_1]"
+        )
       end
     end
   end
@@ -429,9 +429,9 @@ describe "trait exception error messages" do
         end
 
         expect { FactoryBot.build(:user) }.to raise_error(
-                                                KeyError,
-                                                /Registered traits: \[\]/
-                                              )
+          KeyError,
+          /Registered traits: \[\]/
+        )
       end
 
       it "when a missing trait is called by the user" do
@@ -440,9 +440,9 @@ describe "trait exception error messages" do
         end
 
         expect { FactoryBot.build(:user, :missing_trait) }.to raise_error(
-                                                                KeyError,
-                                                                "Trait not registered: \"missing_trait\". Registered traits: []"
-                                                              )
+          KeyError,
+          "Trait not registered: \"missing_trait\". Registered traits: []"
+        )
       end
     end
   end
@@ -467,9 +467,9 @@ describe "trait exception error messages" do
         ].join(" ")
 
         expect { FactoryBot.build(:user) }.to raise_error(
-                                                KeyError,
-                                                expected_message
-                                              )
+          KeyError,
+          expected_message
+        )
       end
 
       it "when a missing trait is called by the user" do
@@ -488,9 +488,9 @@ describe "trait exception error messages" do
         ].join(" ")
 
         expect { FactoryBot.build(:user, :missing_trait) }.to raise_error(
-                                                                KeyError,
-                                                                expected_message
-                                                              )
+          KeyError,
+          expected_message
+        )
       end
 
       it "when a missing trait is similar to the existing traits" do
@@ -536,9 +536,9 @@ describe "trait exception error messages" do
         ].join(" ")
 
         expect { FactoryBot.build(:dev) }.to raise_error(
-                                               KeyError,
-                                               expected_message
-                                             )
+          KeyError,
+          expected_message
+        )
       end
 
       it "when a missing trait is called by the user" do
@@ -566,9 +566,9 @@ describe "trait exception error messages" do
         ].join(" ")
 
         expect { FactoryBot.build(:dev, :missing_trait) }.to raise_error(
-                                                               KeyError,
-                                                               expected_message
-                                                             )
+          KeyError,
+          expected_message
+        )
       end
     end
   end

--- a/spec/acceptance/traits_spec.rb
+++ b/spec/acceptance/traits_spec.rb
@@ -334,9 +334,9 @@ describe "looking up traits that don't exist" do
       end
 
       expect { FactoryBot.build(:user) }.to raise_error(
-                                              KeyError,
-                                              'Trait not registered: "inaccessible_trait". Registered traits: []. Referenced within "user" definition'
-                                            )
+        KeyError,
+        'Trait not registered: "inaccessible_trait". Registered traits: []. Referenced within "user" definition'
+      )
     end
 
     it "maintains 'Did you mean?' suggestions at the end of the error message" do
@@ -371,9 +371,9 @@ describe "looking up traits that don't exist" do
       end
 
       expect { FactoryBot.build(:user, :admin) }.to raise_error(
-                                                      KeyError,
-                                                      'Trait not registered: "inaccessible_trait". Registered traits: [:admin]. Referenced within "admin" definition'
-                                                    )
+        KeyError,
+        'Trait not registered: "inaccessible_trait". Registered traits: [:admin]. Referenced within "admin" definition'
+      )
     end
   end
 end

--- a/spec/acceptance/traits_spec.rb
+++ b/spec/acceptance/traits_spec.rb
@@ -414,7 +414,7 @@ describe "trait exception error messages" do
 
         expect { FactoryBot.build(:user, :missing_trait) }.to raise_error(
           KeyError,
-          "Trait not registered: \"missing_trait\". Registered traits: [:trait_1]."
+          "Trait not registered: \"missing_trait\". Registered traits: [:trait_1]. Referenced within \"user\" definition"
         )
       end
     end
@@ -441,7 +441,7 @@ describe "trait exception error messages" do
 
         expect { FactoryBot.build(:user, :missing_trait) }.to raise_error(
           KeyError,
-          "Trait not registered: \"missing_trait\". No registered traits."
+          "Trait not registered: \"missing_trait\". No registered traits. Referenced within \"user\" definition"
         )
       end
     end
@@ -484,7 +484,8 @@ describe "trait exception error messages" do
 
         expected_message = [
           "Trait not registered: \"missing_trait\".",
-          "Registered traits: [:trait_1, :trait_2, :trait_3, :trait_4]."
+          "Registered traits: [:trait_1, :trait_2, :trait_3, :trait_4].",
+          "Referenced within \"user\" definition"
         ].join(" ")
 
         expect { FactoryBot.build(:user, :missing_trait) }.to raise_error(
@@ -514,9 +515,9 @@ describe "trait exception error messages" do
 
         expected_message = [
           "Trait not registered: \"missing_trait_1\".",
-          "Registered traits: [:trait_1, :trait_2]."
+          "Registered traits: [:trait_1, :trait_2].",
+          "Referenced within \"user\" definition"
         ].join(" ")
-
         expect { FactoryBot.build(:user, :missing_trait_1, :bs_trait) }.to raise_error(KeyError, expected_message)
       end
     end
@@ -578,7 +579,8 @@ describe "trait exception error messages" do
         expected_message = [
           "Trait not registered: \"missing_trait\".",
           "Registered traits: [:admin_trait_1, :admin_trait_2,",
-          ":dev_trait_1, :dev_trait_2, :user_trait_1, :user_trait_2]."
+          ":dev_trait_1, :dev_trait_2, :user_trait_1, :user_trait_2].",
+          "Referenced within \"dev\" definition"
         ].join(" ")
 
         expect { FactoryBot.build(:dev, :missing_trait) }.to raise_error(

--- a/spec/acceptance/traits_spec.rb
+++ b/spec/acceptance/traits_spec.rb
@@ -503,6 +503,22 @@ describe "trait exception error messages" do
 
         expect { FactoryBot.build(:user, :traiz_1) }.to raise_did_you_mean_error
       end
+
+      it "errors on the first trait that is missing and reports back" do
+        FactoryBot.define do
+          factory :user do
+            trait :trait_1
+            trait :trait_2
+          end
+        end
+
+        expected_message = [
+          "Trait not registered: \"missing_trait_1\".",
+          "Registered traits: [:trait_1, :trait_2]."
+        ].join(" ")
+
+        expect { FactoryBot.build(:user, :missing_trait_1, :bs_trait) }.to raise_error(KeyError, expected_message)
+      end
     end
   end
 

--- a/spec/acceptance/traits_spec.rb
+++ b/spec/acceptance/traits_spec.rb
@@ -334,9 +334,9 @@ describe "looking up traits that don't exist" do
       end
 
       expect { FactoryBot.build(:user) }.to raise_error(
-        KeyError,
-        'Trait not registered: "inaccessible_trait" referenced within "user" definition'
-      )
+                                              KeyError,
+                                              'Trait not registered: "inaccessible_trait". Registered traits: []. Referenced within "user" definition'
+                                            )
     end
 
     it "maintains 'Did you mean?' suggestions at the end of the error message" do
@@ -371,9 +371,205 @@ describe "looking up traits that don't exist" do
       end
 
       expect { FactoryBot.build(:user, :admin) }.to raise_error(
-        KeyError,
-        'Trait not registered: "inaccessible_trait" referenced within "admin" definition'
-      )
+                                                      KeyError,
+                                                      'Trait not registered: "inaccessible_trait". Registered traits: [:admin]. Referenced within "admin" definition'
+                                                    )
+    end
+  end
+end
+
+describe "trait exception error messages" do
+  before do
+    define_model("User", name: :string)
+  end
+  context "with a single defined trait" do
+    context "includes a list if the single trait" do
+      it "when the factory references a missing trait internally" do
+        FactoryBot.define do
+          factory :user do
+            trait :trait_1
+
+            inaccessible_trait
+          end
+        end
+
+        expected_message = [
+          "Trait not registered: \"inaccessible_trait\".",
+          "Registered traits: [:trait_1].",
+          "Referenced within \"user\" definition"
+        ].join(" ")
+
+        expect { FactoryBot.build(:user) }.to raise_error(
+                                                KeyError,
+                                                expected_message
+                                              )
+      end
+
+      it "when a missing trait is called by the user" do
+        FactoryBot.define do
+          factory :user do
+            trait :trait_1
+          end
+        end
+
+        expect { FactoryBot.build(:user, :missing_trait) }.to raise_error(
+                                                                KeyError,
+                                                                "Trait not registered: \"missing_trait\". Registered traits: [:trait_1]"
+                                                              )
+      end
+    end
+  end
+  context "when no defined traits" do
+    context "includes an empty list" do
+      it "when the factory references a missing trait internally" do
+        FactoryBot.define do
+          factory :user do
+            inaccessible_trait
+          end
+        end
+
+        expect { FactoryBot.build(:user) }.to raise_error(
+                                                KeyError,
+                                                /Registered traits: \[\]/
+                                              )
+      end
+
+      it "when a missing trait is called by the user" do
+        FactoryBot.define do
+          factory :user
+        end
+
+        expect { FactoryBot.build(:user, :missing_trait) }.to raise_error(
+                                                                KeyError,
+                                                                "Trait not registered: \"missing_trait\". Registered traits: []"
+                                                              )
+      end
+    end
+  end
+  context "with multiple defined traits" do
+    context "includes a list of all traits" do
+      it "when the factory references a missing trait internally" do
+        FactoryBot.define do
+          factory :user do
+            trait :trait_1
+            trait :trait_2
+            trait :trait_3
+            trait :trait_4
+
+            inaccessible_trait
+          end
+        end
+
+        expected_message = [
+          "Trait not registered: \"inaccessible_trait\".",
+          "Registered traits: [:trait_1, :trait_2, :trait_3, :trait_4].",
+          "Referenced within \"user\" definition"
+        ].join(" ")
+
+        expect { FactoryBot.build(:user) }.to raise_error(
+                                                KeyError,
+                                                expected_message
+                                              )
+      end
+
+      it "when a missing trait is called by the user" do
+        FactoryBot.define do
+          factory :user do
+            trait :trait_1
+            trait :trait_2
+            trait :trait_3
+            trait :trait_4
+          end
+        end
+
+        expected_message = [
+          "Trait not registered: \"missing_trait\".",
+          "Registered traits: [:trait_1, :trait_2, :trait_3, :trait_4]"
+        ].join(" ")
+
+        expect { FactoryBot.build(:user, :missing_trait) }.to raise_error(
+                                                                KeyError,
+                                                                expected_message
+                                                              )
+      end
+
+      it "when a missing trait is similar to the existing traits" do
+        FactoryBot.define do
+          factory :user do
+            trait :trait_1
+            trait :trait_2
+          end
+        end
+
+        expect { FactoryBot.build(:user, :traiz_1) }.to raise_did_you_mean_error
+      end
+    end
+  end
+
+  context "with both defined and inherited traits" do
+    context "includes a list of all traits" do
+      it "when the factory references a missing trait internally" do
+        FactoryBot.define do
+          factory :user do
+            trait :user_trait_1
+            trait :user_trait_2
+
+            factory :admin do
+              trait :admin_trait_1
+              trait :admin_trait_2
+
+              factory :dev do
+                trait :dev_trait_1
+                trait :dev_trait_2
+
+                inaccessible_trait
+              end
+            end
+          end
+        end
+
+        expected_message = [
+          "Trait not registered: \"inaccessible_trait\".",
+          "Registered traits: [:admin_trait_1, :admin_trait_2,",
+          ":dev_trait_1, :dev_trait_2, :user_trait_1, :user_trait_2].",
+          "Referenced within \"dev\" definition"
+        ].join(" ")
+
+        expect { FactoryBot.build(:dev) }.to raise_error(
+                                               KeyError,
+                                               expected_message
+                                             )
+      end
+
+      it "when a missing trait is called by the user" do
+        FactoryBot.define do
+          factory :user do
+            trait :user_trait_1
+            trait :user_trait_2
+
+            factory :admin do
+              trait :admin_trait_1
+              trait :admin_trait_2
+
+              factory :dev do
+                trait :dev_trait_1
+                trait :dev_trait_2
+              end
+            end
+          end
+        end
+
+        expected_message = [
+          "Trait not registered: \"missing_trait\".",
+          "Registered traits: [:admin_trait_1, :admin_trait_2,",
+          ":dev_trait_1, :dev_trait_2, :user_trait_1, :user_trait_2]"
+        ].join(" ")
+
+        expect { FactoryBot.build(:dev, :missing_trait) }.to raise_error(
+                                                               KeyError,
+                                                               expected_message
+                                                             )
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes: https://github.com/thoughtbot/factory_bot/issues/1727, building off of https://github.com/thoughtbot/factory_bot/pull/1732, but preserving DidYouMean behavior in traits as well.

Expands trait error messages to include a list of the factory's defined traits.

Included
The message now includes: Registered traits: [:trait_1, :trait_2, :trait_3]

Example
Internal Definition Call
factory: :user
defined traits: :accessible_trait
error: internal reference to a missing trait :inaccessible_trait

Error Message:
Trait not registered: "inaccessible_trait". Registered traits: [:accessible_trait]. Referenced within "user" definition

User Trait Specified
factory: :user
defined traits: :accessible_trait
error: user calls an non-existent trait with build(:user, :missing_trait)

Error Message:
Trait not registered: "missing_trait". Registered traits: [:accessible_trait]

Note
When the error is because a missing trait was called from within a factory's definition, the message still includes the original:
Referenced within "user" definition

Changes
lib/factory_bot/definition.rb

error-rescue moved from :base_traits to :trait_by_name to catch both definition and calling errors.
spec/acceptance/enum_traits_spec.rb

updated specs for new error message layout.
spec/acceptance/traits_spec.rb updated specs for new error message layout. added new use-case tests with:

no registered traits
single registered trait
multiple registered traits
multiple registered traits through multiple inheritance
trait DidYouMean tests 