### PR TITLE
Issue 1825 - Refactor internal references to ignored (attributes) to transient attributes

### DIFF
--- a/lib/factory_bot/attribute_assigner.rb
+++ b/lib/factory_bot/attribute_assigner.rb
@@ -78,7 +78,7 @@ module FactoryBot
         assignment_candidates = non_ignored_attribute_names + override_names
         # then remove any transient attributes (potentially reintroduced by the overrides),
         # and remove ignorable aliased attributes from the candidate list
-        assignment_candidates - ignored_attribute_names - attribute_names_overriden_by_alias
+        assignment_candidates - transient_attribute_names - attribute_names_overriden_by_alias
       end
     end
 
@@ -86,8 +86,8 @@ module FactoryBot
       @attribute_list.non_ignored.names
     end
 
-    def ignored_attribute_names
-      @attribute_list.ignored.names
+    def transient_attribute_names
+      @attribute_list.transient.names
     end
 
     def association_names

--- a/lib/factory_bot/attribute_assigner.rb
+++ b/lib/factory_bot/attribute_assigner.rb
@@ -75,15 +75,15 @@ module FactoryBot
     def attribute_names_to_assign
       @attribute_names_to_assign ||= begin
         # start a list of candidates containing non-transient attributes and overrides
-        assignment_candidates = non_ignored_attribute_names + override_names
+        assignment_candidates = non_transient_attribute_names + override_names
         # then remove any transient attributes (potentially reintroduced by the overrides),
         # and remove ignorable aliased attributes from the candidate list
         assignment_candidates - transient_attribute_names - attribute_names_overriden_by_alias
       end
     end
 
-    def non_ignored_attribute_names
-      @attribute_list.non_ignored.names
+    def non_transient_attribute_names
+      @attribute_list.non_transient.names
     end
 
     def transient_attribute_names
@@ -109,7 +109,7 @@ module FactoryBot
     # Builds a list of attribute names which are slated to be interrupted by an override.
     def attribute_names_overriden_by_alias
       @attribute_list
-        .non_ignored
+        .non_transient
         .flat_map { |attribute|
           override_names.map do |override|
             attribute.name if ignorable_alias?(attribute, override)

--- a/lib/factory_bot/attribute_list.rb
+++ b/lib/factory_bot/attribute_list.rb
@@ -27,7 +27,7 @@ module FactoryBot
       AttributeList.new(@name, select(&:association?))
     end
 
-    def ignored
+    def transient
       AttributeList.new(@name, select(&:ignored))
     end
 

--- a/lib/factory_bot/attribute_list.rb
+++ b/lib/factory_bot/attribute_list.rb
@@ -31,7 +31,7 @@ module FactoryBot
       AttributeList.new(@name, select(&:ignored))
     end
 
-    def non_ignored
+    def non_transient
       AttributeList.new(@name, reject(&:ignored))
     end
 

--- a/spec/acceptance/initialize_with_spec.rb
+++ b/spec/acceptance/initialize_with_spec.rb
@@ -180,12 +180,12 @@ end
 describe "initialize_with has access to all attributes for construction" do
   it "assigns attributes correctly" do
     define_class("User") do
-      attr_reader :name, :email, :ignored
+      attr_reader :name, :email, :transient_text
 
       def initialize(attributes = {})
         @name = attributes[:name]
         @email = attributes[:email]
-        @ignored = attributes[:ignored]
+        @transient_text = attributes[:transient_text]
       end
     end
 
@@ -194,7 +194,7 @@ describe "initialize_with has access to all attributes for construction" do
 
       factory :user do
         transient do
-          ignored { "of course!" }
+          transient_text { "of course!" }
         end
 
         email
@@ -208,7 +208,7 @@ describe "initialize_with has access to all attributes for construction" do
     user_with_attributes = FactoryBot.build(:user)
     expect(user_with_attributes.email).to eq "person1@example.com"
     expect(user_with_attributes.name).to eq "person1"
-    expect(user_with_attributes.ignored).to be_nil
+    expect(user_with_attributes.transient_text).to be_nil
   end
 end
 

--- a/spec/factory_bot/attribute_list_spec.rb
+++ b/spec/factory_bot/attribute_list_spec.rb
@@ -94,7 +94,7 @@ end
 describe FactoryBot::AttributeList, "filter based on ignored attributes" do
   include AttributeList
 
-  def build_ignored_attribute(name)
+  def build_transient_attribute(name)
     FactoryBot::Attribute::Dynamic.new(name, true, -> { "value" })
   end
 
@@ -102,18 +102,18 @@ describe FactoryBot::AttributeList, "filter based on ignored attributes" do
     FactoryBot::Attribute::Dynamic.new(name, false, -> { "value" })
   end
 
-  it "filters #ignored attributes" do
+  it "filters #transient attributes" do
     list = build_attribute_list(
-      build_ignored_attribute(:comments_count),
+      build_transient_attribute(:comments_count),
       build_non_ignored_attribute(:email)
     )
 
-    expect(list.ignored.names).to eq [:comments_count]
+    expect(list.transient.names).to eq [:comments_count]
   end
 
   it "filters #non_ignored attributes" do
     list = build_attribute_list(
-      build_ignored_attribute(:comments_count),
+      build_transient_attribute(:comments_count),
       build_non_ignored_attribute(:email)
     )
 
@@ -124,7 +124,7 @@ end
 describe FactoryBot::AttributeList, "generating names" do
   include AttributeList
 
-  def build_ignored_attribute(name)
+  def build_transient_attribute(name)
     FactoryBot::Attribute::Dynamic.new(name, true, -> { "value" })
   end
 
@@ -138,7 +138,7 @@ describe FactoryBot::AttributeList, "generating names" do
 
   it "knows all its #names" do
     list = build_attribute_list(
-      build_ignored_attribute(:comments_count),
+      build_transient_attribute(:comments_count),
       build_non_ignored_attribute(:last_name),
       build_association(:avatar)
     )
@@ -146,19 +146,19 @@ describe FactoryBot::AttributeList, "generating names" do
     expect(list.names).to eq [:comments_count, :last_name, :avatar]
   end
 
-  it "knows all its #names for #ignored attributes" do
+  it "knows all its #names for #transient attributes" do
     list = build_attribute_list(
-      build_ignored_attribute(:posts_count),
+      build_transient_attribute(:posts_count),
       build_non_ignored_attribute(:last_name),
       build_association(:avatar)
     )
 
-    expect(list.ignored.names).to eq [:posts_count]
+    expect(list.transient.names).to eq [:posts_count]
   end
 
   it "knows all its #names for #non_ignored attributes" do
     list = build_attribute_list(
-      build_ignored_attribute(:posts_count),
+      build_transient_attribute(:posts_count),
       build_non_ignored_attribute(:last_name),
       build_association(:avatar)
     )
@@ -168,7 +168,7 @@ describe FactoryBot::AttributeList, "generating names" do
 
   it "knows all its #names for #associations" do
     list = build_attribute_list(
-      build_ignored_attribute(:posts_count),
+      build_transient_attribute(:posts_count),
       build_non_ignored_attribute(:last_name),
       build_association(:avatar)
     )

--- a/spec/factory_bot/attribute_list_spec.rb
+++ b/spec/factory_bot/attribute_list_spec.rb
@@ -91,7 +91,7 @@ describe FactoryBot::AttributeList, "#associations" do
   end
 end
 
-describe FactoryBot::AttributeList, "filter based on ignored attributes" do
+describe FactoryBot::AttributeList, "filter based on transient attributes" do
   include AttributeList
 
   def build_transient_attribute(name)

--- a/spec/factory_bot/attribute_list_spec.rb
+++ b/spec/factory_bot/attribute_list_spec.rb
@@ -98,26 +98,26 @@ describe FactoryBot::AttributeList, "filter based on ignored attributes" do
     FactoryBot::Attribute::Dynamic.new(name, true, -> { "value" })
   end
 
-  def build_non_ignored_attribute(name)
+  def build_non_transient_attribute(name)
     FactoryBot::Attribute::Dynamic.new(name, false, -> { "value" })
   end
 
   it "filters #transient attributes" do
     list = build_attribute_list(
       build_transient_attribute(:comments_count),
-      build_non_ignored_attribute(:email)
+      build_non_transient_attribute(:email)
     )
 
     expect(list.transient.names).to eq [:comments_count]
   end
 
-  it "filters #non_ignored attributes" do
+  it "filters #non_transient attributes" do
     list = build_attribute_list(
       build_transient_attribute(:comments_count),
-      build_non_ignored_attribute(:email)
+      build_non_transient_attribute(:email)
     )
 
-    expect(list.non_ignored.names).to eq [:email]
+    expect(list.non_transient.names).to eq [:email]
   end
 end
 
@@ -128,7 +128,7 @@ describe FactoryBot::AttributeList, "generating names" do
     FactoryBot::Attribute::Dynamic.new(name, true, -> { "value" })
   end
 
-  def build_non_ignored_attribute(name)
+  def build_non_transient_attribute(name)
     FactoryBot::Attribute::Dynamic.new(name, false, -> { "value" })
   end
 
@@ -139,7 +139,7 @@ describe FactoryBot::AttributeList, "generating names" do
   it "knows all its #names" do
     list = build_attribute_list(
       build_transient_attribute(:comments_count),
-      build_non_ignored_attribute(:last_name),
+      build_non_transient_attribute(:last_name),
       build_association(:avatar)
     )
 
@@ -149,27 +149,27 @@ describe FactoryBot::AttributeList, "generating names" do
   it "knows all its #names for #transient attributes" do
     list = build_attribute_list(
       build_transient_attribute(:posts_count),
-      build_non_ignored_attribute(:last_name),
+      build_non_transient_attribute(:last_name),
       build_association(:avatar)
     )
 
     expect(list.transient.names).to eq [:posts_count]
   end
 
-  it "knows all its #names for #non_ignored attributes" do
+  it "knows all its #names for #non_transient attributes" do
     list = build_attribute_list(
       build_transient_attribute(:posts_count),
-      build_non_ignored_attribute(:last_name),
+      build_non_transient_attribute(:last_name),
       build_association(:avatar)
     )
 
-    expect(list.non_ignored.names).to eq [:last_name, :avatar]
+    expect(list.non_transient.names).to eq [:last_name, :avatar]
   end
 
   it "knows all its #names for #associations" do
     list = build_attribute_list(
       build_transient_attribute(:posts_count),
-      build_non_ignored_attribute(:last_name),
+      build_non_transient_attribute(:last_name),
       build_association(:avatar)
     )
 

--- a/spec/factory_bot/declaration/dynamic_spec.rb
+++ b/spec/factory_bot/declaration/dynamic_spec.rb
@@ -29,7 +29,7 @@ describe FactoryBot::Declaration::Dynamic do
       end
     end
 
-    context "when one is ignored and the other isn't" do
+    context "when one is transient and the other isn't" do
       it "the objects are NOT equal" do
         block = -> {}
         declaration = described_class.new(:name, false, block)

--- a/spec/factory_bot/declaration/implicit_spec.rb
+++ b/spec/factory_bot/declaration/implicit_spec.rb
@@ -68,7 +68,7 @@ describe FactoryBot::Declaration::Implicit do
       end
     end
 
-    context "when one is ignored and the other isn't" do
+    context "when one is transient and the other isn't" do
       it "the objects are NOT equal" do
         declaration = described_class.new(:name, :factory, false)
         other_declaration = described_class.new(:name, :factory, true)

--- a/spec/factory_bot/definition_proxy_spec.rb
+++ b/spec/factory_bot/definition_proxy_spec.rb
@@ -15,13 +15,13 @@ describe FactoryBot::DefinitionProxy, "#add_attribute" do
     attribute_value = -> { "dynamic attribute" }
     proxy.add_attribute(:attribute_name, &attribute_value)
     expect(definition).to have_dynamic_declaration(:attribute_name)
-      .ignored
+      .transient
       .with_value(attribute_value)
   end
 end
 
 describe FactoryBot::DefinitionProxy, "#transient" do
-  it "makes all attributes added ignored" do
+  it "makes all attributes added transient" do
     definition = FactoryBot::Definition.new(:name)
     proxy = FactoryBot::DefinitionProxy.new(definition)
     attribute_value = -> { "dynamic_attribute" }
@@ -30,7 +30,7 @@ describe FactoryBot::DefinitionProxy, "#transient" do
     end
 
     expect(definition).to have_dynamic_declaration(:attribute_name)
-      .ignored
+      .transient
       .with_value(attribute_value)
   end
 end

--- a/spec/support/matchers/declaration.rb
+++ b/spec/support/matchers/declaration.rb
@@ -25,8 +25,8 @@ module DeclarationMatchers
       self
     end
 
-    def ignored
-      @ignored = true
+    def transient
+      @transient = true
       self
     end
 
@@ -56,8 +56,8 @@ module DeclarationMatchers
 
     def expected_declaration
       case @declaration_type
-      when :dynamic then FactoryBot::Declaration::Dynamic.new(@name, ignored?, @value)
-      when :implicit then FactoryBot::Declaration::Implicit.new(@name, @factory, ignored?)
+      when :dynamic then FactoryBot::Declaration::Dynamic.new(@name, transient?, @value)
+      when :implicit then FactoryBot::Declaration::Implicit.new(@name, @factory, transient?)
       when :association
         if @options
           FactoryBot::Declaration::Association.new(@name, options)
@@ -67,8 +67,8 @@ module DeclarationMatchers
       end
     end
 
-    def ignored?
-      !!@ignored
+    def transient?
+      !!@transient
     end
 
     def options


### PR DESCRIPTION
Rename attribute_list.ignored to attribute_list.transient
Rename attribute_list.non_ignored to attribute_list.non_transient
Update DeclarationMatcher to use transient instead of ignored
#1825 