### PR TITLE
Add irb as a development dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,12 +69,20 @@ GEM
       cucumber-messages (> 19, < 28)
     cucumber-messages (27.2.0)
     cucumber-tag-expressions (6.1.2)
+    date (3.5.1)
     diff-lcs (1.6.2)
     docile (1.4.1)
     drb (2.2.3)
+    erb (6.0.7)
     ffi (1.17.2)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    io-console (0.8.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.15.1)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
@@ -92,11 +100,23 @@ GEM
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
+    pp (0.6.4)
+      prettyprint
+    prettyprint (0.2.0)
     prism (1.5.2)
+    psych (5.4.0)
+      date
+      stringio
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.3.0)
+    rdoc (7.2.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
     regexp_parser (2.11.3)
+    reline (0.6.3)
+      io-console (~> 0.5)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -153,11 +173,13 @@ GEM
     standard-performance (1.8.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.25.0)
+    stringio (3.2.0)
     sys-uname (1.4.1)
       ffi (~> 1.1)
       memoist3 (~> 1.0.0)
     thor (1.4.0)
     timeout (0.4.3)
+    tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
@@ -175,6 +197,7 @@ DEPENDENCIES
   appraisal
   aruba
   factory_bot!
+  irb
   mutex_m
   ostruct
   rake

--- a/factory_bot.gemspec
+++ b/factory_bot.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("activerecord")
   s.add_development_dependency("appraisal")
   s.add_development_dependency("aruba")
+  s.add_development_dependency("irb")
   s.add_development_dependency("mutex_m")
   s.add_development_dependency("ostruct")
   s.add_development_dependency("rake")


### PR DESCRIPTION
## Summary
- Add `irb` as a development dependency so `bin/console` works on Ruby 4.0+.
- Since Ruby 4.0, `irb` is no longer part of the default gems. `bin/console` requires `irb` after `bundler/setup`, so without declaring it in the gemspec, starting the developer console fails with: bin/console:
  -  `warning: irb used to be loaded from the standard library, but is not part of the default gems since Ruby 4.0.0. You can add irb to your Gemfile or gemspec to fix this error. ... cannot load such file -- irb (LoadError)`

## Execution history
### Before
```
$ bin/setup 

bundle install
+ bundle install
Bundle complete! 14 Gemfile dependencies, 72 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```

```
$ bin/console
bin/console:12: warning: irb used to be loaded from the standard library, but is not part of the default gems since Ruby 4.0.0.
You can add irb to your Gemfile or gemspec to fix this error.
/Users/shingo.shimizu/.rbenv/versions/4.0.5/lib/ruby/4.0.0/bundled_gems.rb:60:in 'Kernel.require': cannot load such file -- irb (LoadError)
Did you mean?  erb
        from /Users/shingo.shimizu/.rbenv/versions/4.0.5/lib/ruby/4.0.0/bundled_gems.rb:60:in 'block (2 levels) in Kernel#replace_require'
        from bin/console:12:in '<main>'
```

### After
```
$ bin/setup

bundle install
+ bundle install
Bundle complete! 15 Gemfile dependencies, 83 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```

```
$ bin/console
irb(main):001> 
```

## Changes
- Add `s.add_development_dependency("irb")` to `factory_bot.gemspec` (alphabetically with other development dependencies)
- Update `Gemfile.lock` accordingly

## Test plan
- [x] `bundle exec rake` (unit + acceptance + cucumber + standard)
- [x] `bin/console` starts successfully on Ruby 4.0.5 (2026-05-20 revision 64336ffd0e)