### PR TITLE
Fix RSpec deprecation for raise_error expectation

### DIFF
--- a/spec/factory_bot/definition_proxy_spec.rb
+++ b/spec/factory_bot/definition_proxy_spec.rb
@@ -81,7 +81,7 @@ describe FactoryBot::DefinitionProxy, "#method_missing" do
       proxy.author(factory: :user) { :this_should_raise_an_error }
     end
 
-    expect(invalid_call).to raise_error(
+    expect(&invalid_call).to raise_error(
       FactoryBot::AssociationDefinitionError,
       "Unexpected block passed to 'author' association in 'user' factory"
     )


### PR DESCRIPTION
## Summary
- Fix an RSpec deprecation warning in `definition_proxy_spec` by using explicit block expectation syntax.
- RSpec warns when a Proc is passed as an argument to `expect` with a block expectation matcher.
- This change updates the failing-style expectation to `expect(&invalid_call)`, matching the pattern already used elsewhere in the same file.

## Execution history
### Before
```
$ bundle exec rake
/Users/shingo.shimizu/.rbenv/versions/4.0.5/bin/ruby -I/Users/shingo.shimizu/.rbenv/versions/4.0.5/lib/ruby/gems/4.0.0/gems/rspec-core-3.13.5/lib:/Users/shingo.shimizu/.rbenv/versions/4.0.5/lib/ruby/gems/4.0.0/gems/rspec-support-3.13.6/lib /Users/shingo.shimizu/.rbenv/versions/4.0.5/lib/ruby/gems/4.0.0/gems/rspec-core-3.13.5/exe/rspec --pattern spec/\{\*_spec.rb,factory_bot/\*\*/\*_spec.rb\}

Randomized with seed 40578
.............................................................................................................................................................................................................................................................................................................................................

Deprecation Warnings:

The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to raise FactoryBot::AssociationDefinitionError with "Unexpected block passed to 'author' association in 'user' factory"`not `expect(value).to raise FactoryBot::AssociationDefinitionError with "Unexpected block passed to 'author' association in 'user' factory"`


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total

Finished in 0.32567 seconds (files took 0.2104 seconds to load)
333 examples, 0 failures

Randomized with seed 40578

Coverage report generated for RSpec to /Users/shingo.shimizu/oss-workspace/factory_bot/coverage.
Line Coverage: 84.24% (1133 / 1345)
/Users/shingo.shimizu/.rbenv/versions/4.0.5/bin/ruby -I/Users/shingo.shimizu/.rbenv/versions/4.0.5/lib/ruby/gems/4.0.0/gems/rspec-core-3.13.5/lib:/Users/shingo.shimizu/.rbenv/versions/4.0.5/lib/ruby/gems/4.0.0/gems/rspec-support-3.13.6/lib /Users/shingo.shimizu/.rbenv/versions/4.0.5/lib/ruby/gems/4.0.0/gems/rspec-core-3.13.5/exe/rspec --pattern spec/acceptance/\*\*/\*_spec.rb

Randomized with seed 47958
...............................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 4.84 seconds (files took 0.16943 seconds to load)
431 examples, 0 failures

Randomized with seed 47958

Coverage report generated for RSpec to /Users/shingo.shimizu/oss-workspace/factory_bot/coverage.
Line Coverage: 96.58% (1299 / 1345)
/Users/shingo.shimizu/.rbenv/versions/4.0.5/bin/ruby -S bundle exec cucumber --format progress
Using the default profile...
..................

4 scenarios (4 passed)
18 steps (18 passed)
0m0.013s
Coverage report generated for Cucumber Features, RSpec to /Users/shingo.shimizu/oss-workspace/factory_bot/coverage.
Line Coverage: 96.73% (1331 / 1376)
Inspecting 155 files
...........................................................................................................................................................

155 files inspected, no offenses detected
```

### After
```
$ bundle exec rake                      
/Users/shingo.shimizu/.rbenv/versions/4.0.5/bin/ruby -I/Users/shingo.shimizu/.rbenv/versions/4.0.5/lib/ruby/gems/4.0.0/gems/rspec-core-3.13.5/lib:/Users/shingo.shimizu/.rbenv/versions/4.0.5/lib/ruby/gems/4.0.0/gems/rspec-support-3.13.6/lib /Users/shingo.shimizu/.rbenv/versions/4.0.5/lib/ruby/gems/4.0.0/gems/rspec-core-3.13.5/exe/rspec --pattern spec/\{\*_spec.rb,factory_bot/\*\*/\*_spec.rb\}

Randomized with seed 14771
.............................................................................................................................................................................................................................................................................................................................................

Finished in 0.31618 seconds (files took 0.17185 seconds to load)
333 examples, 0 failures

Randomized with seed 14771

Coverage report generated for RSpec to /Users/shingo.shimizu/oss-workspace/factory_bot/coverage.
Line Coverage: 84.24% (1133 / 1345)
/Users/shingo.shimizu/.rbenv/versions/4.0.5/bin/ruby -I/Users/shingo.shimizu/.rbenv/versions/4.0.5/lib/ruby/gems/4.0.0/gems/rspec-core-3.13.5/lib:/Users/shingo.shimizu/.rbenv/versions/4.0.5/lib/ruby/gems/4.0.0/gems/rspec-support-3.13.6/lib /Users/shingo.shimizu/.rbenv/versions/4.0.5/lib/ruby/gems/4.0.0/gems/rspec-core-3.13.5/exe/rspec --pattern spec/acceptance/\*\*/\*_spec.rb

Randomized with seed 31410
...............................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 4.89 seconds (files took 0.15744 seconds to load)
431 examples, 0 failures

Randomized with seed 31410

Coverage report generated for RSpec to /Users/shingo.shimizu/oss-workspace/factory_bot/coverage.
Line Coverage: 96.58% (1299 / 1345)
/Users/shingo.shimizu/.rbenv/versions/4.0.5/bin/ruby -S bundle exec cucumber --format progress
Using the default profile...
..................

4 scenarios (4 passed)
18 steps (18 passed)
0m0.013s
Coverage report generated for Cucumber Features, RSpec to /Users/shingo.shimizu/oss-workspace/factory_bot/coverage.
Line Coverage: 96.73% (1331 / 1376)
Inspecting 155 files
...........................................................................................................................................................

155 files inspected, no offenses detected
```

## Changes

- Update `spec/factory_bot/definition_proxy_spec.rb` to use `expect(&invalid_call)` instead of `expect(invalid_call)` when asserting `FactoryBot::AssociationDefinitionError`

No production code changes.

## Test plan

- [x] `bundle exec rake` (431 examples, 0 failures)
- [x] No RSpec deprecation warning for implicit block expectation syntax